### PR TITLE
feat(api): shared candidate runner — parallel fits, canonical-hash dedup, journal + resume [closes #1178]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,14 @@ section of the SDLC for the versioning policy).
   or failed the gate — appears in `candidates.csv` with its reason rather than being dropped.
   The thread budget splits across both levels of parallelism via `PoolPlan` (#1115) instead of
   nesting Rayon pools, and a `CancelFlag` stops a search between candidates and returns the
-  partial results. This is the orchestration layer the covariate, structural, variability and
+  partial results — into `candidates.partial.csv`, so cancelling a resumed run never overwrites
+  the complete table of the run it resumed. The cache directory is claimed for the length of a
+  run (`search.lock`) because two runs sharing one would silently destroy each other's journal,
+  and a directory that cannot be written costs the resume and the report rather than the fits:
+  those failures come back on `RunReport::warnings` with the results intact. A candidate whose
+  fit *errored* is refitted on the next resume instead of being remembered as permanently
+  unfittable, since a transient resource limit and a broken model are the same string from
+  there. This is the orchestration layer the covariate, structural, variability and
   residual-error searches of #1175 are built on.
 - **BIC variants and a `Strictness` gate for candidate ranking (#1177, part of #1175).**
   `ferx_core::bic(&result, BicType::{Mixed, Iiv, Random, Fixed})` computes the four
@@ -225,7 +232,9 @@ section of the SDLC for the versioning policy).
   `P = TVP * exp(ETA_P)` form and is a hard error naming the parameter on anything else, never
   a silent wrong edit. `ModelText::canonical_hash` gives a candidate a stable identity — equal
   across comment and whitespace changes, different for every semantic one — for use as a fit
-  cache key. This is the prerequisite for the model-search tooling in #1175.
+  cache key; a `#` or `//` inside a quoted value is content, not a comment, so two candidates
+  differing only in a quoted path (`"s3://bucket/a.csv"` vs `.../b.csv`) are two candidates.
+  This is the prerequisite for the model-search tooling in #1175.
 - **A cancellable bootstrap (#1161).** `BootstrapOptions::cancel` takes a `CancelFlag`; setting
   it from another thread stops a long `ferx_tools::bootstrap` run at the next replicate boundary
   and returns the new `BootstrapError::Cancelled`, so a caller reports an abort as an abort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,11 +65,14 @@ section of the SDLC for the versioning policy).
   the complete table of the run it resumed. The cache directory is claimed for the length of a
   run (`search.lock`) because two runs sharing one would silently destroy each other's journal,
   and a directory that cannot be written costs the resume and the report rather than the fits:
-  those failures come back on `RunReport::warnings` with the results intact. A candidate whose
-  fit *errored* is refitted on the next resume instead of being remembered as permanently
-  unfittable, since a transient resource limit and a broken model are the same string from
-  there. This is the orchestration layer the covariate, structural, variability and
-  residual-error searches of #1175 are built on.
+  those failures come back on `RunReport::warnings` with the results intact. A lock whose owner
+  was hard-killed is taken over automatically, so resuming after a kill — the case the journal
+  exists for — never needs a file deleted by hand. A candidate that produced no fit carries a
+  `CandidateError` saying whether the failure was the *model* (it does not compile: remembered,
+  and reported without refitting) or the *run* (a fit pool that could not be built: refitted on
+  the next resume), so one bad minute cannot permanently mark a fittable model as unfittable.
+  This is the orchestration layer the covariate, structural, variability and residual-error
+  searches of #1175 are built on.
 - **BIC variants and a `Strictness` gate for candidate ranking (#1177, part of #1175).**
   `ferx_core::bic(&result, BicType::{Mixed, Iiv, Random, Fixed})` computes the four
   conventions of `pharmpy.modeling.calculate_bic` from a finished `FitResult` — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,19 @@ section of the SDLC for the versioning policy).
   of one-cycle integrations back.
 
 ### Added
+- **A shared candidate runner for model-space search (#1178, part of #1175).**
+  `ferx_tools::search::Runner` fits a list of candidate models in parallel and returns each
+  one scored: the ranking criterion (`ofv`, `aic`, or any of the four BIC variants), the
+  `Strictness` verdict with the reasons for every gate it failed, and the fit itself.
+  Candidates are identified by the canonical hash of their model text, so a model reached
+  twice by two different edit paths is fitted **once**; with a cache directory each outcome is
+  journalled as it finishes, so an interrupted overnight search resumes and refits only what
+  is missing, and every candidate — including the ones that failed to compile, failed to fit
+  or failed the gate — appears in `candidates.csv` with its reason rather than being dropped.
+  The thread budget splits across both levels of parallelism via `PoolPlan` (#1115) instead of
+  nesting Rayon pools, and a `CancelFlag` stops a search between candidates and returns the
+  partial results. This is the orchestration layer the covariate, structural, variability and
+  residual-error searches of #1175 are built on.
 - **BIC variants and a `Strictness` gate for candidate ranking (#1177, part of #1175).**
   `ferx_core::bic(&result, BicType::{Mixed, Iiv, Random, Fixed})` computes the four
   conventions of `pharmpy.modeling.calculate_bic` from a finished `FitResult` — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,14 @@ section of the SDLC for the versioning policy).
   marked fixed, which is what it meant at the time.
 
 ### Fixed
+- **Numbers written to JSON now reload as themselves, bit for bit (#1178).** `serde_json`
+  parses floats with a fast algorithm accurate only to within 1 ULP unless its
+  `float_roundtrip` feature is enabled, which it now is across `ferx-core`, `ferx-tools` and
+  the CLI. Anything that writes a number and reads it back — a `.fitrx` bundle, a search
+  journal, a cached fit — could otherwise return an estimate one bit from the one that was
+  computed, and do it invisibly, since every printed form rounds long before that digit. The
+  case that caught it was a resumed candidate search reporting a criterion of
+  `-200.28784144636057` for a fit that scored `-200.28784144636055`.
 - **`n_parameters`, AIC and BIC no longer count the structural zeros of a mixed
   `block_omega` + diagonal `omega` as estimated parameters (#1177).** The cross-block
   Cholesky entries of such an Ω are pinned, never searched, and the covariance step already

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ version = "0.3.1"
 dependencies = [
  "csv",
  "ferx-core",
+ "libc",
  "nalgebra",
  "rand 0.10.2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,11 @@ slow-tests = []
 nalgebra = "0.35"
 csv = "1.3"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# `float_roundtrip`: without it `serde_json` parses floats to within 1 ULP
+# rather than exactly, so a `.fitrx` bundle — or any JSON a checkpoint or cache
+# reads back — can return an estimate one bit from the one that was written.
+# Every consumer here is numeric output that is meant to reload as itself.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 rayon = "1.10"
 rand = "0.10"

--- a/crates/ferx-cli/Cargo.toml
+++ b/crates/ferx-cli/Cargo.toml
@@ -28,7 +28,9 @@ path = "src/main.rs"
 ferx-core = { path = "../..", version = "0.3.1", default-features = false }
 ferx-tools = { path = "../ferx-tools", version = "0.3.1" }
 indicatif = "0.18.4"
-serde_json = "1"
+# Matches the root package and `ferx-tools`: see the note there — floats must
+# reload as themselves, not to within 1 ULP.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ferx-tools/Cargo.toml
+++ b/crates/ferx-tools/Cargo.toml
@@ -28,6 +28,14 @@ rayon = "1.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+# `search.lock` staleness only: `kill(pid, 0)` is how a search directory whose
+# owner was hard-killed is taken over instead of needing a manual delete —
+# resuming after a kill is the case the journal exists for. Already in the
+# workspace lockfile (via `tempfile` and `rand`), so this adds no crate to the
+# build; non-unix targets compile a `cfg` fallback and never take a lock over.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 # Heavy convergence tests (5–60 min wall). Default `cargo test` ignores them;
 # a nightly/manual job opts in with --features slow-tests.

--- a/crates/ferx-tools/Cargo.toml
+++ b/crates/ferx-tools/Cargo.toml
@@ -26,7 +26,14 @@ rayon = "1.10"
 # (#1143). Both are already in the workspace's lockfile via `ferx-core`, so this
 # adds no crate to the build.
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+# `float_roundtrip` is load-bearing, not tidiness. Without it `serde_json`
+# parses floats with a fast algorithm accurate only to within 1 ULP, so a
+# journalled criterion or OFV can come back one bit different from the one the
+# interrupted run computed — and a resumed run whose whole promise is "the same
+# numbers" would report a different score, invisibly, since the CSV prints six
+# decimals. Caught by `search_runner_end_to_end`: -200.28784144636055 read back
+# as -200.28784144636057.
+serde_json = { version = "1", features = ["float_roundtrip"] }
 
 # `search.lock` staleness only: `kill(pid, 0)` is how a search directory whose
 # owner was hard-killed is taken over instead of needing a manual delete —

--- a/crates/ferx-tools/src/lib.rs
+++ b/crates/ferx-tools/src/lib.rs
@@ -54,3 +54,4 @@ mod tests {
 
 pub mod bootstrap;
 pub mod gam;
+pub mod search;

--- a/crates/ferx-tools/src/search/candidate.rs
+++ b/crates/ferx-tools/src/search/candidate.rs
@@ -246,6 +246,63 @@ impl Default for RunOptions {
     }
 }
 
+/// Why a candidate produced no fit, and whether a later run should try again.
+///
+/// The flag is not cosmetic: a journalled outcome is what every subsequent
+/// `resume: true` run believes without rechecking, and the two failures that
+/// arrive here are not the same statement. A model that does not compile will
+/// not compile on the next machine either — remembering that saves the parse
+/// and, more importantly, keeps the candidate in the report. A fit that died
+/// because `install_on_fit_pool` could not build a pool (`api/pool.rs`) says
+/// nothing about the model at all, and writing *that* down as final would let
+/// one bad minute mark a fittable model dead for the rest of the search's life.
+///
+/// From inside the runner the two are one `String`, which is why the
+/// classification is made where the failure is raised rather than recovered
+/// from the message afterwards.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CandidateError {
+    /// What went wrong, as shown in the report.
+    pub message: String,
+    /// `true` when the failure describes the run rather than the candidate, so
+    /// a resumed run should fit it again instead of trusting the row.
+    pub retryable: bool,
+}
+
+impl CandidateError {
+    /// A failure that is a property of the candidate itself — a model that does
+    /// not compile, or does not bind against this run's data. Deterministic, so
+    /// a resume reuses it.
+    pub fn model(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retryable: false,
+        }
+    }
+
+    /// A failure raised by the run rather than by the candidate. A resume
+    /// refits it.
+    ///
+    /// This is the default for anything `fit()` itself returns. Note that the
+    /// *expected* bad outcome of a search candidate — a fit that finishes but
+    /// does not converge — is not an error at all: it comes back `Ok` and is
+    /// judged by [`check_strictness`](ferx_core::check_strictness), so it is
+    /// journalled and reused like any other result. An `Err` out of `fit()` is
+    /// the pathological case, and refitting it is cheap because it is rare.
+    pub fn environment(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            retryable: true,
+        }
+    }
+}
+
+impl std::fmt::Display for CandidateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 /// One candidate's outcome.
 ///
 /// A candidate that failed its strictness gate, failed to compile or failed to
@@ -291,8 +348,9 @@ pub struct CandidateResult {
     pub criterion: f64,
     /// Wall-clock seconds the fit took; `0.0` for a reused or duplicate result.
     pub seconds: f64,
-    /// Why there is no fit, when that is the reason.
-    pub error: Option<String>,
+    /// Why there is no fit, when that is the reason — and whether a resumed run
+    /// will take the candidate's word for it. See [`CandidateError`].
+    pub error: Option<CandidateError>,
     /// Set when this candidate rendered to the same canonical text as an
     /// earlier one in the same run: the named id is the one that was fitted,
     /// and this result carries its criterion and verdict.

--- a/crates/ferx-tools/src/search/candidate.rs
+++ b/crates/ferx-tools/src/search/candidate.rs
@@ -1,0 +1,301 @@
+//! What a search hands the runner, and what it gets back (#1178).
+//!
+//! A [`Candidate`] is a rendered model plus its provenance: the id the search
+//! knows it by, the parent it was derived from, and the [`FeatureVector`]
+//! describing *what makes it different* — the row a report shows next to its
+//! criterion. A [`CandidateResult`] is the same identity carried back with the
+//! fit, the [`StrictnessVerdict`] and the ranking criterion attached.
+
+use std::collections::BTreeMap;
+
+use ferx_core::{bic, BicType, FitResult, StrictnessVerdict};
+use serde::{Deserialize, Serialize};
+
+use ferx_core::edit::ModelText;
+
+/// The search-space coordinates of one candidate: `ABSORPTION = FO`,
+/// `CL-WT = pow`, `PERIPHERALS = 1`, …
+///
+/// The runner never interprets these — it stores them, journals them and puts
+/// them in the per-candidate table. They exist so a report can say *which*
+/// model won rather than only which id, and so a resumed run's table still
+/// describes its rows. Ordering is by key (a `BTreeMap`), so two vectors with
+/// the same entries render identically whatever order they were built in.
+///
+/// It is deliberately **not** the candidate's identity: two different feature
+/// vectors can render to the same model text, and it is the canonical hash of
+/// that text that decides whether a fit is reused (see
+/// [`ModelText::canonical_hash`]).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct FeatureVector {
+    entries: BTreeMap<String, String>,
+}
+
+impl FeatureVector {
+    /// An empty vector — a base model with nothing to say about itself.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder form of [`set`](Self::set), for `FeatureVector::new().with(…).with(…)`.
+    pub fn with(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.set(key, value);
+        self
+    }
+
+    /// Set one feature, returning the value it replaced.
+    pub fn set(&mut self, key: impl Into<String>, value: impl Into<String>) -> Option<String> {
+        self.entries.insert(key.into(), value.into())
+    }
+
+    /// The value of one feature, if present.
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.entries.get(key).map(String::as_str)
+    }
+
+    /// Every `(key, value)` in key order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.entries.iter().map(|(k, v)| (k.as_str(), v.as_str()))
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// The one-cell rendering for the per-candidate table: `k=v` pairs joined
+    /// by `;`, in key order.
+    ///
+    /// Display only — the journal round-trips the vector through serde, which
+    /// has no separator to collide with, so nothing has to parse this back.
+    pub fn render(&self) -> String {
+        self.iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(";")
+    }
+}
+
+impl<K: Into<String>, V: Into<String>> FromIterator<(K, V)> for FeatureVector {
+    fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+        Self {
+            entries: iter
+                .into_iter()
+                .map(|(k, v)| (k.into(), v.into()))
+                .collect(),
+        }
+    }
+}
+
+/// One model a search wants fitted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    /// How the search refers to this candidate. Must be unique within one
+    /// [`run`](super::Runner::run) — the results are keyed by it and the table
+    /// is written under it.
+    pub id: String,
+    /// The candidate's model source, as produced by the `ferx-core::edit`
+    /// layer.
+    pub model: ModelText,
+    /// The candidate this one was derived from, for a step-history report.
+    /// `None` for the base model or for an exhaustively enumerated candidate.
+    pub parent: Option<String>,
+    /// What distinguishes it — see [`FeatureVector`].
+    pub features: FeatureVector,
+}
+
+impl Candidate {
+    /// A candidate with no parent and no features.
+    pub fn new(id: impl Into<String>, model: ModelText) -> Self {
+        Self {
+            id: id.into(),
+            model,
+            parent: None,
+            features: FeatureVector::new(),
+        }
+    }
+
+    /// Builder: record the candidate this one was derived from.
+    pub fn parent(mut self, parent: impl Into<String>) -> Self {
+        self.parent = Some(parent.into());
+        self
+    }
+
+    /// Builder: attach the search-space coordinates.
+    pub fn features(mut self, features: FeatureVector) -> Self {
+        self.features = features;
+        self
+    }
+
+    /// The candidate's identity: hex [`ModelText::canonical_hash`].
+    ///
+    /// This — not the id, not the features — is the dedup and cache key, so a
+    /// model reached twice by two different step orders is fitted once.
+    pub fn hash(&self) -> String {
+        hex(&self.model.canonical_hash())
+    }
+}
+
+/// Lower-case hex of a 32-byte digest.
+pub(crate) fn hex(bytes: &[u8; 32]) -> String {
+    use std::fmt::Write as _;
+    bytes.iter().fold(String::with_capacity(64), |mut s, b| {
+        let _ = write!(s, "{b:02x}");
+        s
+    })
+}
+
+/// What a candidate is ranked on.
+///
+/// The BIC variants are `ferx_core::bic`, i.e. Pharmpy's four
+/// `calculate_bic` conventions; see [`BicType`]. Every variant is
+/// **lower-is-better**, which is what lets a search compare them without
+/// knowing which one it was configured with.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Criterion {
+    /// The objective function value itself. Only comparable between nested
+    /// models with the same parameter count, so a search using it supplies its
+    /// own likelihood-ratio cutoff.
+    Ofv,
+    /// `FitResult::aic`.
+    Aic,
+    /// `ferx_core::bic(result, kind)`.
+    Bic(BicType),
+}
+
+impl Default for Criterion {
+    /// The mixed BIC — Pharmpy's default and the one its structural and IIV
+    /// searches rank on.
+    fn default() -> Self {
+        Criterion::Bic(BicType::Mixed)
+    }
+}
+
+impl Criterion {
+    /// Evaluate the criterion on a finished fit.
+    pub fn of(&self, result: &FitResult) -> f64 {
+        match self {
+            Criterion::Ofv => result.ofv,
+            Criterion::Aic => result.aic,
+            Criterion::Bic(kind) => bic(result, *kind),
+        }
+    }
+
+    /// A short stable label for the table header and the run manifest.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Criterion::Ofv => "ofv",
+            Criterion::Aic => "aic",
+            Criterion::Bic(BicType::Mixed) => "bic_mixed",
+            Criterion::Bic(BicType::Iiv) => "bic_iiv",
+            Criterion::Bic(BicType::Random) => "bic_random",
+            Criterion::Bic(BicType::Fixed) => "bic_fixed",
+        }
+    }
+}
+
+/// How the candidates in one [`run`](super::Runner::run) are fitted and judged.
+#[derive(Debug, Clone)]
+pub struct RunOptions {
+    /// What [`CandidateResult::criterion`] holds.
+    pub criterion: Criterion,
+    /// The gate a fit must pass before its criterion is trusted. A candidate
+    /// that fails is **kept**, with its reasons — see
+    /// [`CandidateResult::verdict`].
+    pub strictness: ferx_core::Strictness,
+    /// `FitOptions::n_starts` for every candidate — the *retries* of the epic's
+    /// search configuration, applied before the strictness gate. Clamped to at
+    /// least 1.
+    ///
+    /// The default is 3, not 1: under automation an init stall (#751) or an
+    /// inner-EBE mode (#864, #891) is a model-selection error, not a slow fit.
+    pub n_starts: usize,
+    /// Reuse the candidates already in the cache directory's journal instead of
+    /// refitting them. Ignored when the runner has no cache directory.
+    pub resume: bool,
+    /// Fit settings for every candidate, replacing the ones in its own
+    /// `[fit_options]` block.
+    ///
+    /// `None` — the default — lets each candidate carry its own settings, which
+    /// is what a search over models edited from one base file wants: the base
+    /// file's estimation method, tolerances and covariance step come along with
+    /// the edit. `Some` is for a caller that needs one configuration across a
+    /// space whose members disagree, or a cheaper one than the base file's.
+    ///
+    /// Either way the runner still applies its own overrides on top —
+    /// [`quiet`](ferx_core::FitOptions::quiet), the [`PoolPlan`](ferx_core::PoolPlan)
+    /// thread pin, `n_starts` and the cancellation flag — so those four are not
+    /// settable here.
+    pub fit_options: Option<ferx_core::FitOptions>,
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self {
+            criterion: Criterion::default(),
+            strictness: ferx_core::Strictness::default(),
+            n_starts: 3,
+            resume: false,
+            fit_options: None,
+        }
+    }
+}
+
+/// One candidate's outcome.
+///
+/// A candidate that failed its strictness gate, failed to compile or failed to
+/// fit is still here, with the reason — nothing is dropped silently, because a
+/// candidate missing from a search report is indistinguishable from one that
+/// was never generated.
+#[derive(Debug, Clone)]
+pub struct CandidateResult {
+    /// The [`Candidate::id`] this result belongs to.
+    pub id: String,
+    /// Hex canonical hash — the cache key the fit was stored under.
+    pub hash: String,
+    /// [`Candidate::parent`], carried through.
+    pub parent: Option<String>,
+    /// [`Candidate::features`], carried through.
+    pub features: FeatureVector,
+    /// The fit, when this run performed it.
+    ///
+    /// `None` in three cases, told apart by the other fields: the fit failed
+    /// (`error` is set), the candidate duplicated one that *was* fitted
+    /// (`duplicate_of` is set), or the outcome was read back from a journal
+    /// whose cached fit is absent or unreadable (`reused`).
+    pub fit: Option<FitResult>,
+    /// Every gate the fit failed, and every gate that could not be evaluated.
+    /// A compile or fit failure yields a verdict with one failure naming it.
+    pub verdict: StrictnessVerdict,
+    /// [`RunOptions::criterion`] evaluated on the fit; `NaN` when there is no
+    /// fit to evaluate it on.
+    pub criterion: f64,
+    /// Wall-clock seconds the fit took; `0.0` for a reused or duplicate result.
+    pub seconds: f64,
+    /// Why there is no fit, when that is the reason.
+    pub error: Option<String>,
+    /// Set when this candidate rendered to the same canonical text as an
+    /// earlier one in the same run: the named id is the one that was fitted,
+    /// and this result carries its criterion and verdict.
+    pub duplicate_of: Option<String>,
+    /// Set when the outcome came from the journal rather than from a fit in
+    /// this run.
+    pub reused: bool,
+}
+
+impl CandidateResult {
+    /// `true` when the fit exists and passed every enabled gate — the
+    /// precondition for ranking on [`criterion`](Self::criterion).
+    pub fn eligible(&self) -> bool {
+        self.error.is_none() && self.verdict.passed && self.criterion.is_finite()
+    }
+}
+
+#[cfg(test)]
+#[path = "candidate_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/search/candidate.rs
+++ b/crates/ferx-tools/src/search/candidate.rs
@@ -269,6 +269,20 @@ pub struct CandidateResult {
     /// (`duplicate_of` is set), or the outcome was read back from a journal
     /// whose cached fit is absent or unreadable (`reused`).
     pub fit: Option<FitResult>,
+    /// The objective function value, mirroring [`FitResult::ofv`] whenever
+    /// [`fit`](Self::fit) is present.
+    ///
+    /// Kept beside the fit rather than read out of it because the fit is the
+    /// part a resume can lose: `fits/<hash>.json` is a cache, and a candidate
+    /// whose cached fit is missing or corrupt still has its OFV in the journal
+    /// row. Reading the table's `ofv` column off `fit` alone would blank it for
+    /// exactly the degraded resume the journal is designed to survive.
+    /// `None` when there is no fit at all.
+    pub ofv: Option<f64>,
+    /// Whether the fit converged, mirroring [`FitResult::converged`] — and kept
+    /// beside it for the same reason as [`ofv`](Self::ofv). `None` when there
+    /// is no fit at all, which is not the same statement as `Some(false)`.
+    pub converged: Option<bool>,
     /// Every gate the fit failed, and every gate that could not be evaluated.
     /// A compile or fit failure yields a verdict with one failure naming it.
     pub verdict: StrictnessVerdict,

--- a/crates/ferx-tools/src/search/candidate_tests.rs
+++ b/crates/ferx-tools/src/search/candidate_tests.rs
@@ -131,6 +131,25 @@ fn criterion_labels_are_distinct_and_serde_round_trips() {
     assert_eq!(Criterion::default(), Criterion::Bic(BicType::Mixed));
 }
 
+#[test]
+fn two_candidates_differing_only_inside_a_quoted_path_are_not_one_candidate() {
+    // The hash is the dedup key *and* the fit-cache key, so a collision here is
+    // not a wasted fit — it is candidate B reported with candidate A's
+    // criterion and verdict under `duplicate_of`. A comment stripper that cut
+    // at the first `//` regardless of quoting ended both of these at
+    // `path = "s3:`.
+    let a = Candidate::new("a", model_text("[data]\n  path = \"s3://bucket/a.csv\"\n"));
+    let b = Candidate::new("b", model_text("[data]\n  path = \"s3://bucket/b.csv\"\n"));
+    assert_ne!(a.hash(), b.hash(), "{}", a.model.canonical_form());
+    // The spelling that *is* one candidate still is, so the fix did not simply
+    // stop canonicalising.
+    let reflowed = Candidate::new(
+        "a2",
+        model_text("[data]\npath=\"s3://bucket/a.csv\"  # x\n"),
+    );
+    assert_eq!(a.hash(), reflowed.hash());
+}
+
 // ── eligibility ──────────────────────────────────────────────────────────────
 
 fn result_with(criterion: f64, passed: bool, error: Option<&str>) -> CandidateResult {
@@ -140,6 +159,8 @@ fn result_with(criterion: f64, passed: bool, error: Option<&str>) -> CandidateRe
         parent: None,
         features: FeatureVector::new(),
         fit: None,
+        ofv: None,
+        converged: None,
         verdict: StrictnessVerdict {
             passed,
             failures: vec![],

--- a/crates/ferx-tools/src/search/candidate_tests.rs
+++ b/crates/ferx-tools/src/search/candidate_tests.rs
@@ -168,7 +168,7 @@ fn result_with(criterion: f64, passed: bool, error: Option<&str>) -> CandidateRe
         },
         criterion,
         seconds: 0.0,
-        error: error.map(str::to_string),
+        error: error.map(CandidateError::model),
         duplicate_of: None,
         reused: false,
     }

--- a/crates/ferx-tools/src/search/candidate_tests.rs
+++ b/crates/ferx-tools/src/search/candidate_tests.rs
@@ -1,0 +1,163 @@
+//! Candidate identity, feature vectors and ranking criteria (#1178).
+
+use ferx_core::{bic, BicType, StrictnessVerdict};
+
+use super::*;
+use crate::search::test_support::{converged_fit, model_text, same_model_two_ways};
+
+// ── FeatureVector ────────────────────────────────────────────────────────────
+
+#[test]
+fn features_render_in_key_order_whatever_order_they_were_set_in() {
+    let a = FeatureVector::new()
+        .with("PERIPHERALS", "1")
+        .with("ABSORPTION", "FO");
+    let b = FeatureVector::new()
+        .with("ABSORPTION", "FO")
+        .with("PERIPHERALS", "1");
+    assert_eq!(a.render(), "ABSORPTION=FO;PERIPHERALS=1");
+    assert_eq!(a, b, "insertion order leaked into the value");
+}
+
+#[test]
+fn setting_a_feature_twice_replaces_it() {
+    let mut features = FeatureVector::new().with("CL-WT", "lin");
+    assert_eq!(features.set("CL-WT", "pow"), Some("lin".to_string()));
+    assert_eq!(features.get("CL-WT"), Some("pow"));
+    assert_eq!(features.len(), 1);
+    assert!(!features.is_empty());
+    assert!(FeatureVector::new().is_empty());
+    assert_eq!(FeatureVector::new().render(), "");
+}
+
+#[test]
+fn features_round_trip_through_serde() {
+    // The journal stores them, so a resumed run's table must describe its rows
+    // the same way the interrupted run's did.
+    let features: FeatureVector = [("CL-WT", "pow"), ("V-SEX", "cat")].into_iter().collect();
+    let json = serde_json::to_string(&features).expect("serialize");
+    assert_eq!(json, r#"{"CL-WT":"pow","V-SEX":"cat"}"#);
+    let back: FeatureVector = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, features);
+    assert_eq!(
+        back.iter().collect::<Vec<_>>(),
+        vec![("CL-WT", "pow"), ("V-SEX", "cat")]
+    );
+}
+
+// ── identity ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_hash_ignores_comments_and_whitespace_but_not_tokens() {
+    let (a, b) = same_model_two_ways();
+    let plain = Candidate::new("a", a);
+    let decorated = Candidate::new("b", b);
+    assert_eq!(plain.hash(), decorated.hash());
+    assert_eq!(plain.hash().len(), 64, "not a hex sha-256");
+    assert!(plain.hash().chars().all(|c| c.is_ascii_hexdigit()));
+
+    let edited = Candidate::new(
+        "c",
+        model_text("[parameters]\ntheta CL = 2\ntheta V = 10\n"),
+    );
+    assert_ne!(
+        plain.hash(),
+        edited.hash(),
+        "a changed initial estimate left the identity unchanged"
+    );
+}
+
+#[test]
+fn the_builders_carry_provenance() {
+    let candidate = Candidate::new("step2", model_text("[parameters]\ntheta CL = 1\n"))
+        .parent("step1")
+        .features(FeatureVector::new().with("CL-WT", "pow"));
+    assert_eq!(candidate.id, "step2");
+    assert_eq!(candidate.parent.as_deref(), Some("step1"));
+    assert_eq!(candidate.features.get("CL-WT"), Some("pow"));
+
+    let bare = Candidate::new("base", model_text("[parameters]\ntheta CL = 1\n"));
+    assert!(bare.parent.is_none());
+    assert!(bare.features.is_empty());
+}
+
+// ── Criterion ────────────────────────────────────────────────────────────────
+
+#[test]
+fn each_criterion_reads_the_field_it_names() {
+    let fit = converged_fit(123.0);
+    assert_eq!(Criterion::Ofv.of(&fit), fit.ofv);
+    assert_eq!(Criterion::Aic.of(&fit), fit.aic);
+    for kind in [
+        BicType::Mixed,
+        BicType::Iiv,
+        BicType::Random,
+        BicType::Fixed,
+    ] {
+        assert_eq!(Criterion::Bic(kind).of(&fit), bic(&fit, kind));
+    }
+    // The variants are genuinely different numbers on this fit, so a criterion
+    // that silently fell back to another one would show here.
+    assert_ne!(Criterion::Ofv.of(&fit), Criterion::Aic.of(&fit));
+    assert_ne!(
+        Criterion::Bic(BicType::Mixed).of(&fit),
+        Criterion::Bic(BicType::Fixed).of(&fit)
+    );
+}
+
+#[test]
+fn criterion_labels_are_distinct_and_serde_round_trips() {
+    let all = [
+        Criterion::Ofv,
+        Criterion::Aic,
+        Criterion::Bic(BicType::Mixed),
+        Criterion::Bic(BicType::Iiv),
+        Criterion::Bic(BicType::Random),
+        Criterion::Bic(BicType::Fixed),
+    ];
+    let labels: std::collections::HashSet<&str> = all.iter().map(|c| c.label()).collect();
+    assert_eq!(
+        labels.len(),
+        all.len(),
+        "two criteria share a label, so the manifest cannot tell them apart"
+    );
+    for criterion in all {
+        let json = serde_json::to_string(&criterion).expect("serialize");
+        assert_eq!(
+            serde_json::from_str::<Criterion>(&json).expect("deserialize"),
+            criterion
+        );
+    }
+    assert_eq!(Criterion::default(), Criterion::Bic(BicType::Mixed));
+}
+
+// ── eligibility ──────────────────────────────────────────────────────────────
+
+fn result_with(criterion: f64, passed: bool, error: Option<&str>) -> CandidateResult {
+    CandidateResult {
+        id: "c".into(),
+        hash: "0".repeat(64),
+        parent: None,
+        features: FeatureVector::new(),
+        fit: None,
+        verdict: StrictnessVerdict {
+            passed,
+            failures: vec![],
+            skipped: vec![],
+        },
+        criterion,
+        seconds: 0.0,
+        error: error.map(str::to_string),
+        duplicate_of: None,
+        reused: false,
+    }
+}
+
+#[test]
+fn only_a_passing_finite_error_free_result_is_eligible() {
+    assert!(result_with(10.0, true, None).eligible());
+    assert!(!result_with(10.0, false, None).eligible());
+    assert!(!result_with(f64::NAN, true, None).eligible());
+    assert!(!result_with(f64::INFINITY, true, None).eligible());
+    assert!(!result_with(10.0, true, Some("no fit")).eligible());
+}

--- a/crates/ferx-tools/src/search/journal.rs
+++ b/crates/ferx-tools/src/search/journal.rs
@@ -64,9 +64,22 @@ pub struct CandidateRecord {
     pub skipped: Vec<String>,
     pub seconds: f64,
     pub error: Option<String>,
+    /// Whether `error` describes the run rather than the candidate, in which
+    /// case a resumed run refits instead of trusting this row — see
+    /// [`CandidateError`](super::CandidateError).
+    ///
+    /// Defaults to `true` so a row written before the field existed is refitted
+    /// rather than believed. That is the safe direction: a needless refit costs
+    /// time, and a wrongly trusted failure costs the candidate.
+    #[serde(default = "retryable_by_default")]
+    pub retryable: bool,
     /// Whether a `fits/<hash>.json` was written for this row. `false` for a
     /// failed fit; `true` does not promise the file is still readable.
     pub has_fit: bool,
+}
+
+fn retryable_by_default() -> bool {
+    true
 }
 
 pub fn journal_path(dir: &Path) -> PathBuf {
@@ -115,39 +128,52 @@ fn part_path(path: &Path) -> PathBuf {
 /// into an unlinked inode and every row it produces from then on is gone, with
 /// nothing on disk to say so. A lock file turns that into a message.
 ///
-/// It is deliberately a plain `O_EXCL` file rather than an OS advisory lock: no
-/// new dependency, and the failure mode is one a user can see and fix. The cost
-/// is that a hard kill leaves the file behind, so the error says how to clear
-/// it.
+/// It is deliberately a plain `O_EXCL` file rather than an OS advisory lock, so
+/// that it needs no new dependency and leaves something a user can see. The
+/// price of that choice is a *stale* lock: a hard kill releases no file, and
+/// resuming after a hard kill is the whole point of the journal — a lock that
+/// had to be deleted by hand would break the flagship case. So the holder's pid
+/// is written into the file and a lock whose owner is gone is taken over
+/// automatically.
+///
+/// The one thing it will not do is take a lock from a *live* pid, so the
+/// failure direction is "refused a run that could have proceeded", never "two
+/// runs in one directory". A recycled pid therefore reads as live and refuses;
+/// the message says which file to delete.
 pub struct DirLock {
     path: PathBuf,
 }
 
 impl DirLock {
-    /// Claim `dir`, or explain who holds it.
+    /// Claim `dir`, taking over a lock whose owner is no longer running.
     pub fn acquire(dir: &Path) -> Result<DirLock, String> {
         std::fs::create_dir_all(dir)
             .map_err(|e| format!("cannot create search directory `{}`: {e}", dir.display()))?;
         let path = lock_path(dir);
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
-            Ok(mut file) => {
-                // Best-effort: the lock is the file's existence, not its
-                // contents, so a failed write costs a better error message and
-                // nothing else.
-                let _ = writeln!(file, "pid {}", std::process::id());
-                Ok(DirLock { path })
-            }
+        match Self::claim(&path) {
+            Ok(lock) => Ok(lock),
+            // Taken. If the holder is gone this is the debris of a hard kill,
+            // and one retry is enough: losing the race to a third process just
+            // means that process holds a lock we then report honestly.
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                let owner = std::fs::read_to_string(&path)
-                    .ok()
-                    .map(|text| text.trim().to_string())
-                    .filter(|text| !text.is_empty())
-                    .unwrap_or_else(|| "owner unknown".to_string());
+                let owner = std::fs::read_to_string(&path).unwrap_or_default();
+                if !owner_is_running(&owner) {
+                    let _ = std::fs::remove_file(&path);
+                    if let Ok(lock) = Self::claim(&path) {
+                        return Ok(lock);
+                    }
+                }
+                let owner = owner.trim();
+                let owner = if owner.is_empty() {
+                    "owner unknown"
+                } else {
+                    owner
+                };
                 Err(format!(
                     "the search directory `{}` is already in use ({owner}): two runs sharing one \
-                     directory overwrite each other's journal, so the second one's fits would be \
-                     lost. Point this run at a different directory — or, if no such process is \
-                     running (a hard kill leaves the lock behind), delete `{}` and retry.",
+                     directory overwrite each other's journal, so one run's fits would be lost. \
+                     Point this run at a different directory — or, if that process is not \
+                     actually running, delete `{}` and retry.",
                     dir.display(),
                     path.display()
                 ))
@@ -155,6 +181,50 @@ impl DirLock {
             Err(e) => Err(format!("cannot create `{}`: {e}", path.display())),
         }
     }
+
+    fn claim(path: &Path) -> Result<DirLock, std::io::Error> {
+        let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+        // Best-effort: the lock is the file's existence, not its contents, so a
+        // failed write costs the takeover check and nothing else — and an
+        // unreadable owner reads as "still running", which refuses rather than
+        // steals.
+        let _ = writeln!(file, "pid {}", std::process::id());
+        Ok(DirLock {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+/// Whether the process named in a lock file is still alive.
+///
+/// Unparseable contents count as running: the takeover is the only path that
+/// deletes another run's lock, so everything it cannot positively establish has
+/// to fall on the refusing side.
+fn owner_is_running(contents: &str) -> bool {
+    let Some(pid) = contents
+        .trim()
+        .strip_prefix("pid ")
+        .and_then(|rest| rest.trim().parse::<u32>().ok())
+    else {
+        return true;
+    };
+    process_is_running(pid)
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: u32) -> bool {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything. `ESRCH` — and only `ESRCH` — means there is no such process;
+    // `EPERM` means one exists that we may not signal, which is still alive.
+    let alive = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    alive == 0 || std::io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: u32) -> bool {
+    // No dependency-free liveness check, so a lock is never taken over and the
+    // error tells the user which file to delete.
+    true
 }
 
 impl Drop for DirLock {

--- a/crates/ferx-tools/src/search/journal.rs
+++ b/crates/ferx-tools/src/search/journal.rs
@@ -37,7 +37,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use ferx_core::{FitResult, Population, Strictness};
+use ferx_core::{FitOptions, FitResult, Population, Strictness};
 use serde::{Deserialize, Serialize};
 
 use super::candidate::FeatureVector;
@@ -253,10 +253,19 @@ pub struct SearchManifest {
     pub strictness: Strictness,
     pub n_subjects: usize,
     pub n_observations: usize,
-    /// SHA-256 over the subject ids, their observation counts and the DV column
-    /// name — enough to catch "resumed against a different dataset" without
-    /// hashing a file the runner never sees (it is handed a `Population`).
+    /// SHA-256 over the dataset's contents: every field of every subject, with
+    /// covariate maps written in key order so the digest is stable across runs.
     pub data_fingerprint: String,
+    /// SHA-256 over [`RunOptions::fit_options`], when the caller supplied them.
+    ///
+    /// A candidate's identity is the hash of its *model text*, which carries the
+    /// `[fit_options]` block — so with `fit_options: None` the fit settings are
+    /// already part of the cache key. An override is not: it lives outside
+    /// `ModelText`, so resuming a run under a different method, iteration cap,
+    /// optimizer, tolerance, seed or covariance setting would reuse scores the
+    /// override never produced. `None` here records "no override", which is
+    /// itself incompatible with a run that had one.
+    pub fit_options_fingerprint: Option<String>,
 }
 
 impl SearchManifest {
@@ -268,6 +277,7 @@ impl SearchManifest {
             n_subjects: data.subjects.len(),
             n_observations: data.subjects.iter().map(|s| s.observations.len()).sum(),
             data_fingerprint: data_fingerprint(data),
+            fit_options_fingerprint: options.fit_options.as_ref().map(fit_options_fingerprint),
         }
     }
 
@@ -314,6 +324,17 @@ impl SearchManifest {
                 format!("{:?}", self.strictness),
             );
         }
+        if disk.fit_options_fingerprint != self.fit_options_fingerprint {
+            let describe = |f: &Option<String>| match f {
+                Some(hash) => hash.clone(),
+                None => "the candidates' own `[fit_options]`".to_string(),
+            };
+            return refuse(
+                "the fit settings",
+                describe(&disk.fit_options_fingerprint),
+                describe(&self.fit_options_fingerprint),
+            );
+        }
         if disk.data_fingerprint != self.data_fingerprint
             || disk.n_subjects != self.n_subjects
             || disk.n_observations != self.n_observations
@@ -334,19 +355,134 @@ impl SearchManifest {
     }
 }
 
-/// SHA-256 of the dataset's identity — subject ids, per-subject observation
-/// counts, and the DV column.
+/// SHA-256 over the fit settings that can change a candidate's *result*.
+///
+/// Taken off the `Debug` rendering of the options as the runner will actually
+/// apply them — `quiet()` included — with the four knobs the runner overrides
+/// per candidate normalised away, since they are properties of *this* run's
+/// scheduling rather than of the numbers it produces:
+///
+/// * `threads` — the [`PoolPlan`](ferx_core::PoolPlan) share, and pinned per run;
+/// * `cancel` — the run's own flag;
+/// * `n_starts` — recorded separately as [`SearchManifest::n_starts`];
+/// * `user_set_keys` — bookkeeping for the "key not consumed by this method"
+///   warning, and order-dependent on how the caller happened to build the
+///   options, so including it would refuse resumes that are in fact identical.
+///
+/// `FitOptions` implements neither `Hash` nor `Serialize`, and its `Debug` holds
+/// no maps, so its rendering is both complete and deterministic — a field added
+/// to it lands in this digest automatically.
+fn fit_options_fingerprint(options: &FitOptions) -> String {
+    let mut normalised = options.clone().quiet();
+    normalised.threads = None;
+    normalised.cancel = None;
+    normalised.n_starts = 1;
+    normalised.user_set_keys.clear();
+    ferx_core::io::hash::sha256_bytes(format!("{normalised:?}").as_bytes())
+}
+
+/// SHA-256 over the dataset's **contents**, not its shape.
+///
+/// The first version hashed subject ids, per-subject observation counts and the
+/// DV column, and that is a silent wrong-result path: change a DV value, an
+/// observation time, a dose, a censoring flag or a covariate while keeping the
+/// ids and the counts, and the fingerprint does not move. A resume then finds
+/// every candidate hash in the journal, fits nothing, and returns criteria
+/// computed from the *previous* dataset. Nothing downstream could detect it.
+///
+/// So every field of every subject is hashed. Two properties make that
+/// trustworthy rather than approximately trustworthy:
+///
+/// * **The subject is destructured exhaustively, with no `..`.** A field added
+///   to `ferx_core::Subject` stops this file compiling, which forces whoever
+///   adds it to decide whether it belongs in the fingerprint. A `..` here would
+///   silently un-hash it, which is exactly the failure this function exists to
+///   prevent.
+/// * **Every map is written in key order.** `HashMap`'s iteration order varies
+///   per process, so hashing its `Debug` directly would produce a different
+///   digest on every run and refuse every resume.
+///
+/// `Population::warnings` and `exclusions` are deliberately excluded: they
+/// describe what the *reader* did on the way to this population, not what the
+/// fit sees, and `exclusions` has already been applied to `subjects`.
 fn data_fingerprint(data: &Population) -> String {
+    use std::fmt::Write as _;
+
     let mut buf = String::new();
-    buf.push_str(&data.dv_column);
-    buf.push('\n');
+    let _ = writeln!(buf, "dv={}", data.dv_column);
+    let _ = writeln!(buf, "covariate_names={:?}", data.covariate_names);
+    let _ = writeln!(buf, "input_columns={:?}", data.input_columns);
+
     for subject in &data.subjects {
-        buf.push_str(&subject.id);
-        buf.push(':');
-        buf.push_str(&subject.observations.len().to_string());
+        // No `..`: see the note above — a new `Subject` field must fail to
+        // compile here rather than quietly leave the fingerprint blind to it.
+        let ferx_core::Subject {
+            id,
+            doses,
+            obs_times,
+            obs_raw_times,
+            observations,
+            obs_cmts,
+            covariates,
+            dose_covariates,
+            obs_covariates,
+            pk_only_times,
+            pk_only_covariates,
+            reset_times,
+            reset_covariates,
+            cens,
+            occasions,
+            obs_l2,
+            dose_occasions,
+            reset_occasions,
+            fremtype,
+            obs_records,
+        } = subject;
+
+        let _ = writeln!(buf, "id={id}");
+        let _ = writeln!(buf, "doses={doses:?}");
+        let _ = writeln!(buf, "obs_times={obs_times:?}");
+        let _ = writeln!(buf, "obs_raw_times={obs_raw_times:?}");
+        let _ = writeln!(buf, "observations={observations:?}");
+        let _ = writeln!(buf, "obs_cmts={obs_cmts:?}");
+        let _ = writeln!(buf, "pk_only_times={pk_only_times:?}");
+        let _ = writeln!(buf, "reset_times={reset_times:?}");
+        let _ = writeln!(buf, "cens={cens:?}");
+        let _ = writeln!(buf, "occasions={occasions:?}");
+        let _ = writeln!(buf, "obs_l2={obs_l2:?}");
+        let _ = writeln!(buf, "dose_occasions={dose_occasions:?}");
+        let _ = writeln!(buf, "reset_occasions={reset_occasions:?}");
+        let _ = writeln!(buf, "fremtype={fremtype:?}");
+        let _ = writeln!(buf, "obs_records={obs_records:?}");
+
+        write_covariates(&mut buf, "covariates", std::slice::from_ref(covariates));
+        write_covariates(&mut buf, "dose_covariates", dose_covariates);
+        write_covariates(&mut buf, "obs_covariates", obs_covariates);
+        write_covariates(&mut buf, "pk_only_covariates", pk_only_covariates);
+        write_covariates(&mut buf, "reset_covariates", reset_covariates);
+    }
+
+    ferx_core::io::hash::sha256_bytes(buf.as_bytes())
+}
+
+/// Append covariate snapshots in **key order**, so the digest does not depend on
+/// `HashMap`'s per-process iteration order.
+fn write_covariates(
+    buf: &mut String,
+    label: &str,
+    maps: &[std::collections::HashMap<String, f64>],
+) {
+    use std::fmt::Write as _;
+
+    for (i, map) in maps.iter().enumerate() {
+        let mut entries: Vec<(&String, &f64)> = map.iter().collect();
+        entries.sort_by(|a, b| a.0.cmp(b.0));
+        let _ = write!(buf, "{label}[{i}]=");
+        for (name, value) in entries {
+            let _ = write!(buf, "{name}:{value:?};");
+        }
         buf.push('\n');
     }
-    ferx_core::io::hash::sha256_bytes(buf.as_bytes())
 }
 
 #[cfg(test)]

--- a/crates/ferx-tools/src/search/journal.rs
+++ b/crates/ferx-tools/src/search/journal.rs
@@ -35,6 +35,7 @@
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use ferx_core::{FitOptions, FitResult, Population, Strictness};
@@ -84,12 +85,82 @@ pub fn fit_path(dir: &Path, hash: &str) -> PathBuf {
     fits_dir(dir).join(format!("{hash}.json"))
 }
 
+pub fn lock_path(dir: &Path) -> PathBuf {
+    dir.join("search.lock")
+}
+
 /// The temp sibling a file is rewritten through, in the same directory so the
 /// `rename` that swaps it in is atomic.
+///
+/// The name carries this process's id and a per-call counter, because a
+/// *fixed* `.part` name is shared state between processes: two runs pointed at
+/// one cache directory would `write` the same temp file concurrently and then
+/// rename it twice, publishing a byte-mix of two fits under a hash that names
+/// neither. [`DirLock`] is what normally keeps them apart; this is the second
+/// lock on that door, since a `.part` collision fails silently.
 fn part_path(path: &Path) -> PathBuf {
+    static NONCE: AtomicU64 = AtomicU64::new(0);
+    let n = NONCE.fetch_add(1, Ordering::Relaxed);
     let mut name = path.file_name().unwrap_or_default().to_os_string();
-    name.push(".part");
+    name.push(format!(".{}.{n}.part", std::process::id()));
     path.with_file_name(name)
+}
+
+/// An exclusive claim on a search directory, held for the length of one run and
+/// released when it is dropped.
+///
+/// Two runs sharing a cache directory do not merely interleave — they lose
+/// data silently. `Journal::create` *renames* a fresh file over
+/// `search_journal.jsonl`, so the run that was already appending keeps writing
+/// into an unlinked inode and every row it produces from then on is gone, with
+/// nothing on disk to say so. A lock file turns that into a message.
+///
+/// It is deliberately a plain `O_EXCL` file rather than an OS advisory lock: no
+/// new dependency, and the failure mode is one a user can see and fix. The cost
+/// is that a hard kill leaves the file behind, so the error says how to clear
+/// it.
+pub struct DirLock {
+    path: PathBuf,
+}
+
+impl DirLock {
+    /// Claim `dir`, or explain who holds it.
+    pub fn acquire(dir: &Path) -> Result<DirLock, String> {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("cannot create search directory `{}`: {e}", dir.display()))?;
+        let path = lock_path(dir);
+        match OpenOptions::new().write(true).create_new(true).open(&path) {
+            Ok(mut file) => {
+                // Best-effort: the lock is the file's existence, not its
+                // contents, so a failed write costs a better error message and
+                // nothing else.
+                let _ = writeln!(file, "pid {}", std::process::id());
+                Ok(DirLock { path })
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                let owner = std::fs::read_to_string(&path)
+                    .ok()
+                    .map(|text| text.trim().to_string())
+                    .filter(|text| !text.is_empty())
+                    .unwrap_or_else(|| "owner unknown".to_string());
+                Err(format!(
+                    "the search directory `{}` is already in use ({owner}): two runs sharing one \
+                     directory overwrite each other's journal, so the second one's fits would be \
+                     lost. Point this run at a different directory — or, if no such process is \
+                     running (a hard kill leaves the lock behind), delete `{}` and retry.",
+                    dir.display(),
+                    path.display()
+                ))
+            }
+            Err(e) => Err(format!("cannot create `{}`: {e}", path.display())),
+        }
+    }
+}
+
+impl Drop for DirLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
 }
 
 /// Every well-formed record in `path`, in file order.

--- a/crates/ferx-tools/src/search/journal.rs
+++ b/crates/ferx-tools/src/search/journal.rs
@@ -1,0 +1,354 @@
+//! The candidate journal — what makes an interrupted search resumable (#1178).
+//!
+//! A model-space search is hours of `fit()` calls, and a search that has to
+//! start over from candidate 1 after a kill is a search nobody runs overnight.
+//! So the runner writes each candidate's outcome **as it finishes**, and a
+//! resumed run reads that file and refits only what is missing. This is the
+//! `bootstrap/` journal (#1143) with two shape changes:
+//!
+//! * **The key is the canonical hash, not an index.** A bootstrap replicate is
+//!   identified by `(seed, index)`; a candidate is identified by the model text
+//!   it renders to, so a candidate the search reaches by a different step order
+//!   — or under a different id — hits the same journal row. That is dedup and
+//!   resume off one key.
+//! * **The row is JSON, one object per line.** A candidate's outcome is a
+//!   verdict with a variable-length list of reasons, which is not a CSV row.
+//!   The `candidates.csv` beside it is the human-readable *table*, rewritten in
+//!   candidate order once the run finishes; this file is the log.
+//!
+//! Three properties carried over from #1143 unchanged:
+//!
+//! * **Every line is flushed.** A lost tail row is a lost fit, and the flush
+//!   costs microseconds against a fit measured in seconds.
+//! * **A truncated final line is dropped, not fatal.** A hard kill lands
+//!   mid-write; [`read_records`] parses what it can and ignores the rest, and
+//!   [`Journal::create`] then *rewrites* the file from what it read rather than
+//!   appending onto the fragment.
+//! * **The rewrite goes through a `.part` sibling** renamed into place, so the
+//!   interrupted run's journal is never the only copy of its own recovery data.
+//!
+//! The fits themselves live beside the journal as `fits/<hash>.json`. They are
+//! a *cache*: a missing or unreadable one costs the reused candidate its
+//! `FitResult`, never its journalled criterion and verdict, so a corrupt fit
+//! file degrades a resume instead of failing it.
+
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use ferx_core::{FitResult, Population, Strictness};
+use serde::{Deserialize, Serialize};
+
+use super::candidate::FeatureVector;
+use super::RunOptions;
+
+/// One finished candidate, as stored in the journal.
+///
+/// `criterion` and `ofv` are `Option<f64>` rather than `f64` because JSON has
+/// no `NaN`: `serde_json` writes a non-finite float as `null` and then refuses
+/// to read it back as an `f64`, so a failed candidate's row would be a row that
+/// cannot be resumed from. `None` *is* the failed case.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CandidateRecord {
+    pub id: String,
+    pub hash: String,
+    pub parent: Option<String>,
+    pub features: FeatureVector,
+    pub criterion: Option<f64>,
+    pub ofv: Option<f64>,
+    pub converged: bool,
+    pub passed: bool,
+    pub failures: Vec<String>,
+    pub skipped: Vec<String>,
+    pub seconds: f64,
+    pub error: Option<String>,
+    /// Whether a `fits/<hash>.json` was written for this row. `false` for a
+    /// failed fit; `true` does not promise the file is still readable.
+    pub has_fit: bool,
+}
+
+pub fn journal_path(dir: &Path) -> PathBuf {
+    dir.join("search_journal.jsonl")
+}
+
+pub fn manifest_path(dir: &Path) -> PathBuf {
+    dir.join("search_run.json")
+}
+
+pub fn fits_dir(dir: &Path) -> PathBuf {
+    dir.join("fits")
+}
+
+pub fn fit_path(dir: &Path, hash: &str) -> PathBuf {
+    fits_dir(dir).join(format!("{hash}.json"))
+}
+
+/// The temp sibling a file is rewritten through, in the same directory so the
+/// `rename` that swaps it in is atomic.
+fn part_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".part");
+    path.with_file_name(name)
+}
+
+/// Every well-formed record in `path`, in file order.
+///
+/// Malformed lines — including the truncated final line of a hard kill — are
+/// dropped. Dropping a row only costs a refit; keeping a half-parsed one would
+/// cost a wrong answer. A missing file is an empty journal, not an error: that
+/// is what a first run looks like.
+pub fn read_records(path: &Path) -> Vec<CandidateRecord> {
+    let Ok(file) = File::open(path) else {
+        return Vec::new();
+    };
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<CandidateRecord>(&line).ok())
+        .collect()
+}
+
+/// Read a cached fit, or `None` when it is absent or unreadable.
+pub fn load_fit(dir: &Path, hash: &str) -> Option<FitResult> {
+    let text = std::fs::read_to_string(fit_path(dir, hash)).ok()?;
+    serde_json::from_str(&text).ok()
+}
+
+/// Write a fit to the cache, through a `.part` sibling so a reader never sees a
+/// half-written file.
+fn store_fit(dir: &Path, hash: &str, fit: &FitResult) -> Result<(), String> {
+    let final_path = fit_path(dir, hash);
+    std::fs::create_dir_all(fits_dir(dir))
+        .map_err(|e| format!("cannot create `{}`: {e}", fits_dir(dir).display()))?;
+    let temp = part_path(&final_path);
+    let text = serde_json::to_string(fit)
+        .map_err(|e| format!("cannot serialize the fit of `{hash}`: {e}"))?;
+    std::fs::write(&temp, text).map_err(|e| format!("cannot write `{}`: {e}", temp.display()))?;
+    std::fs::rename(&temp, &final_path).map_err(|e| {
+        let _ = std::fs::remove_file(&temp);
+        format!("cannot rename `{}`: {e}", temp.display())
+    })
+}
+
+/// An append-as-you-go log of finished candidates.
+pub struct Journal {
+    dir: PathBuf,
+    file: Mutex<File>,
+    /// The first write failure, reported once by [`Journal::into_result`]
+    /// rather than from inside the parallel fit loop, where there is nothing
+    /// useful to do with it.
+    error: Mutex<Option<String>>,
+}
+
+impl Journal {
+    /// Open the journal in `dir`, rewritten from `kept`.
+    ///
+    /// The file is rewritten rather than appended to even on a resume, which is
+    /// what makes a truncated trailing row self-healing: the dropped row is
+    /// simply absent from `kept`, so the rewritten file is well-formed and the
+    /// next append lands on a line boundary.
+    pub fn create(dir: &Path, kept: &[CandidateRecord]) -> Result<Journal, String> {
+        std::fs::create_dir_all(dir)
+            .map_err(|e| format!("cannot create search directory `{}`: {e}", dir.display()))?;
+        let final_path = journal_path(dir);
+        let temp = part_path(&final_path);
+        {
+            let mut out = File::create(&temp)
+                .map_err(|e| format!("cannot create `{}`: {e}", temp.display()))?;
+            for record in kept {
+                write_line(&mut out, record)?;
+            }
+            out.flush()
+                .map_err(|e| format!("cannot flush `{}`: {e}", temp.display()))?;
+        }
+        std::fs::rename(&temp, &final_path).map_err(|e| {
+            let _ = std::fs::remove_file(&temp);
+            format!("cannot rename `{}`: {e}", temp.display())
+        })?;
+        let file = OpenOptions::new()
+            .append(true)
+            .open(&final_path)
+            .map_err(|e| format!("cannot open `{}` for appending: {e}", final_path.display()))?;
+        Ok(Journal {
+            dir: dir.to_path_buf(),
+            file: Mutex::new(file),
+            error: Mutex::new(None),
+        })
+    }
+
+    /// Append one finished candidate, and cache its fit when there is one.
+    ///
+    /// The fit is written **before** the row, so a journal row claiming
+    /// `has_fit` can only be read after the file it names is complete. Failures
+    /// are recorded, not returned: the caller is inside the parallel loop and
+    /// aborting it would throw away the fits still in flight.
+    pub fn append(&self, record: &CandidateRecord, fit: Option<&FitResult>) {
+        if let Some(fit) = fit {
+            if let Err(e) = store_fit(&self.dir, &record.hash, fit) {
+                self.record_error(e);
+                return;
+            }
+        }
+        let mut guard = match self.file.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Err(e) = write_line(&mut *guard, record).and_then(|()| {
+            guard
+                .flush()
+                .map_err(|e| format!("cannot flush the search journal: {e}"))
+        }) {
+            drop(guard);
+            self.record_error(e);
+        }
+    }
+
+    fn record_error(&self, message: String) {
+        let mut slot = match self.error.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if slot.is_none() {
+            *slot = Some(message);
+        }
+    }
+
+    /// Close the journal, surfacing the first write failure seen inside the
+    /// parallel loop.
+    pub fn into_result(self) -> Result<(), String> {
+        match self.error.into_inner() {
+            Ok(Some(e)) => Err(e),
+            Ok(None) => Ok(()),
+            Err(poisoned) => match poisoned.into_inner() {
+                Some(e) => Err(e),
+                None => Ok(()),
+            },
+        }
+    }
+}
+
+fn write_line(out: &mut File, record: &CandidateRecord) -> Result<(), String> {
+    let line = serde_json::to_string(record)
+        .map_err(|e| format!("cannot serialize the journal row of `{}`: {e}", record.id))?;
+    writeln!(out, "{line}").map_err(|e| format!("cannot write the search journal: {e}"))
+}
+
+/// What a search directory was created from — the resume compatibility check.
+///
+/// Reusing a journalled candidate means trusting a *number another process
+/// computed*. Its criterion was evaluated under one [`Criterion`](super::Criterion),
+/// and its verdict under one [`Strictness`]; reusing rows written under either
+/// of those set differently gives a ranking whose entries do not mean the same
+/// thing, and nothing downstream could detect it. Same for the dataset: the
+/// same candidate fitted to different data is a different fit.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchManifest {
+    /// [`Criterion::label`](super::Criterion::label) — stable across a refactor
+    /// of the enum, and readable when a user opens the file to see why their
+    /// resume was refused.
+    pub criterion: String,
+    pub n_starts: usize,
+    pub strictness: Strictness,
+    pub n_subjects: usize,
+    pub n_observations: usize,
+    /// SHA-256 over the subject ids, their observation counts and the DV column
+    /// name — enough to catch "resumed against a different dataset" without
+    /// hashing a file the runner never sees (it is handed a `Population`).
+    pub data_fingerprint: String,
+}
+
+impl SearchManifest {
+    pub fn new(options: &RunOptions, data: &Population) -> Self {
+        Self {
+            criterion: options.criterion.label().to_string(),
+            n_starts: options.n_starts.max(1),
+            strictness: options.strictness.clone(),
+            n_subjects: data.subjects.len(),
+            n_observations: data.subjects.iter().map(|s| s.observations.len()).sum(),
+            data_fingerprint: data_fingerprint(data),
+        }
+    }
+
+    pub fn write(&self, path: &Path) -> Result<(), String> {
+        let text = serde_json::to_string_pretty(self)
+            .map_err(|e| format!("cannot serialize the search manifest: {e}"))?;
+        std::fs::write(path, text).map_err(|e| format!("cannot write `{}`: {e}", path.display()))
+    }
+
+    pub fn read(path: &Path) -> Result<Self, String> {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("cannot read `{}`: {e}", path.display()))?;
+        serde_json::from_str(&text).map_err(|e| format!("cannot parse `{}`: {e}", path.display()))
+    }
+
+    /// Refuse a resume whose inputs differ from the ones on disk, naming the
+    /// field that differs.
+    pub fn check_compatible(&self, disk: &SearchManifest, dir: &Path) -> Result<(), String> {
+        let refuse = |field: &str, disk: String, now: String| {
+            Err(format!(
+                "cannot resume the search in `{}`: {field} differs (on disk: {disk}, now: {now}). \
+                 Point `--resume` at the directory it was created in, or start a fresh one.",
+                dir.display()
+            ))
+        };
+        if disk.criterion != self.criterion {
+            return refuse(
+                "the ranking criterion",
+                disk.criterion.clone(),
+                self.criterion.clone(),
+            );
+        }
+        if disk.n_starts != self.n_starts {
+            return refuse(
+                "the number of starts per candidate",
+                disk.n_starts.to_string(),
+                self.n_starts.to_string(),
+            );
+        }
+        if disk.strictness != self.strictness {
+            return refuse(
+                "the strictness gate",
+                format!("{:?}", disk.strictness),
+                format!("{:?}", self.strictness),
+            );
+        }
+        if disk.data_fingerprint != self.data_fingerprint
+            || disk.n_subjects != self.n_subjects
+            || disk.n_observations != self.n_observations
+        {
+            return refuse(
+                "the dataset",
+                format!(
+                    "{} subjects / {} observations ({})",
+                    disk.n_subjects, disk.n_observations, disk.data_fingerprint
+                ),
+                format!(
+                    "{} subjects / {} observations ({})",
+                    self.n_subjects, self.n_observations, self.data_fingerprint
+                ),
+            );
+        }
+        Ok(())
+    }
+}
+
+/// SHA-256 of the dataset's identity — subject ids, per-subject observation
+/// counts, and the DV column.
+fn data_fingerprint(data: &Population) -> String {
+    let mut buf = String::new();
+    buf.push_str(&data.dv_column);
+    buf.push('\n');
+    for subject in &data.subjects {
+        buf.push_str(&subject.id);
+        buf.push(':');
+        buf.push_str(&subject.observations.len().to_string());
+        buf.push('\n');
+    }
+    ferx_core::io::hash::sha256_bytes(buf.as_bytes())
+}
+
+#[cfg(test)]
+#[path = "journal_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/search/journal_tests.rs
+++ b/crates/ferx-tools/src/search/journal_tests.rs
@@ -1,5 +1,12 @@
 //! The candidate journal, the fit cache and the resume manifest (#1178).
 
+use std::collections::HashMap;
+
+use ferx_core::{
+    BloqMethod, CancelFlag, DoseEvent, EstimationMethod, FitOptions, GradientMethod, Population,
+    Subject,
+};
+
 use super::*;
 use crate::search::candidate::{Criterion, FeatureVector};
 use crate::search::test_support::{converged_fit, population};
@@ -147,7 +154,7 @@ fn each_difference_is_refused_by_name() {
     let data = population(&["1", "2"]);
     let manifest = SearchManifest::new(&options(), &data);
 
-    let cases: [(SearchManifest, &str); 4] = [
+    let cases: [(SearchManifest, &str); 5] = [
         (
             SearchManifest::new(
                 &RunOptions {
@@ -182,6 +189,16 @@ fn each_difference_is_refused_by_name() {
             SearchManifest::new(&options(), &population(&["1", "3"])),
             "dataset",
         ),
+        (
+            SearchManifest::new(
+                &RunOptions {
+                    fit_options: Some(ferx_core::FitOptions::default()),
+                    ..options()
+                },
+                &data,
+            ),
+            "fit settings",
+        ),
     ];
 
     for (disk, expected) in cases {
@@ -206,4 +223,215 @@ fn the_data_fingerprint_moves_with_the_data_and_not_with_anything_else() {
         "a different subject set hashed the same"
     );
     assert_eq!(a.data_fingerprint.len(), 64);
+}
+
+/// One subject with every kind of content the fingerprint has to see: doses,
+/// observations, compartments, censoring, occasions, and covariates.
+fn loaded_subject(id: &str) -> Subject {
+    let mut covariates = HashMap::new();
+    covariates.insert("WT".to_string(), 70.0);
+    covariates.insert("AGE".to_string(), 40.0);
+    Subject {
+        id: id.to_string(),
+        doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        obs_times: vec![1.0, 4.0],
+        observations: vec![5.5, 2.5],
+        obs_cmts: vec![1, 1],
+        cens: vec![0, 0],
+        occasions: vec![1, 1],
+        covariates,
+        ..Default::default()
+    }
+}
+
+fn loaded_population() -> Population {
+    Population {
+        subjects: vec![loaded_subject("1"), loaded_subject("2")],
+        covariate_names: vec!["WT".into(), "AGE".into()],
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+#[test]
+fn the_fingerprint_sees_the_contents_and_not_only_the_shape() {
+    // The regression this exists to catch: a fingerprint over ids and counts
+    // alone leaves a resume blind to a *changed dataset of the same shape*. It
+    // then reuses every candidate and returns criteria computed from the old
+    // data — a wrong ranking, with nothing downstream able to detect it. Every
+    // mutation below preserves the subject ids and the observation counts.
+    let base = SearchManifest::new(&options(), &loaded_population());
+
+    let mutate = |f: &dyn Fn(&mut Population)| {
+        let mut data = loaded_population();
+        f(&mut data);
+        SearchManifest::new(&options(), &data)
+    };
+
+    let cases: [(&str, &dyn Fn(&mut Population)); 7] = [
+        ("a DV value", &|d: &mut Population| {
+            d.subjects[0].observations[1] = 2.6;
+        }),
+        ("an observation time", &|d: &mut Population| {
+            d.subjects[1].obs_times[0] = 1.5;
+        }),
+        ("a dose amount", &|d: &mut Population| {
+            d.subjects[0].doses[0].amt = 200.0;
+        }),
+        ("a dose compartment", &|d: &mut Population| {
+            // `cmt` is private, so the whole event is rebuilt into another one.
+            d.subjects[0].doses[0] = DoseEvent::new(0.0, 100.0, 2, 0.0, false, 0.0);
+        }),
+        ("an observation compartment", &|d: &mut Population| {
+            d.subjects[0].obs_cmts[1] = 2;
+        }),
+        ("a censoring flag", &|d: &mut Population| {
+            d.subjects[0].cens[0] = 1;
+        }),
+        ("a covariate value", &|d: &mut Population| {
+            d.subjects[1].covariates.insert("WT".into(), 90.0);
+        }),
+    ];
+
+    for (what, mutation) in cases {
+        let changed = mutate(mutation);
+        assert_eq!(
+            (changed.n_subjects, changed.n_observations),
+            (base.n_subjects, base.n_observations),
+            "the {what} case changed the shape, so it does not test the contents"
+        );
+        assert_ne!(
+            changed.data_fingerprint, base.data_fingerprint,
+            "changing {what} left the fingerprint unmoved"
+        );
+        assert!(
+            base.check_compatible(&changed, std::path::Path::new("."))
+                .is_err(),
+            "a resume against changed {what} was accepted"
+        );
+    }
+}
+
+#[test]
+fn the_fingerprint_is_stable_across_repeated_construction() {
+    // Covariates live in `HashMap`s, whose iteration order varies per process.
+    // Hashing them unsorted would produce a fresh digest on every call and
+    // refuse every resume — the failure mode opposite to the one above.
+    let first = SearchManifest::new(&options(), &loaded_population());
+    for _ in 0..8 {
+        let again = SearchManifest::new(&options(), &loaded_population());
+        assert_eq!(again.data_fingerprint, first.data_fingerprint);
+    }
+    assert!(first
+        .check_compatible(
+            &SearchManifest::new(&options(), &loaded_population()),
+            std::path::Path::new(".")
+        )
+        .is_ok());
+}
+
+// ── the fit-settings fingerprint ─────────────────────────────────────────────
+
+fn with_fit_options(fit_options: Option<FitOptions>) -> SearchManifest {
+    SearchManifest::new(
+        &RunOptions {
+            fit_options,
+            ..options()
+        },
+        &loaded_population(),
+    )
+}
+
+#[test]
+fn the_fit_settings_fingerprint_moves_with_every_setting_that_changes_a_fit() {
+    // A candidate's hash covers its own `[fit_options]` block, but not an
+    // override handed to the runner — that lives outside `ModelText`. Without
+    // this fingerprint a run could be resumed under another method, iteration
+    // cap or censoring convention and reuse scores the override never produced.
+    let base = FitOptions::default();
+    let reference = with_fit_options(Some(base.clone()));
+
+    let mutate = |f: &dyn Fn(&mut FitOptions)| {
+        let mut options = base.clone();
+        f(&mut options);
+        with_fit_options(Some(options))
+    };
+
+    let cases: [(&str, &dyn Fn(&mut FitOptions)); 6] = [
+        ("the estimation method", &|o: &mut FitOptions| {
+            o.method = EstimationMethod::Saem;
+        }),
+        ("the outer iteration cap", &|o: &mut FitOptions| {
+            o.outer_maxiter = 7;
+        }),
+        ("the covariance step", &|o: &mut FitOptions| {
+            o.run_covariance_step = !o.run_covariance_step;
+        }),
+        ("the BLOQ convention", &|o: &mut FitOptions| {
+            o.bloq_method = BloqMethod::M3;
+        }),
+        ("the gradient method", &|o: &mut FitOptions| {
+            o.gradient_method = GradientMethod::Fd;
+        }),
+        ("the multi-start seed", &|o: &mut FitOptions| {
+            o.multi_start_seed = Some(1234);
+        }),
+    ];
+
+    for (what, mutation) in cases {
+        let changed = mutate(mutation);
+        assert_ne!(
+            changed.fit_options_fingerprint, reference.fit_options_fingerprint,
+            "changing {what} left the fit-settings fingerprint unmoved"
+        );
+        assert!(
+            reference
+                .check_compatible(&changed, std::path::Path::new("."))
+                .is_err(),
+            "a resume against changed {what} was accepted"
+        );
+    }
+}
+
+#[test]
+fn the_fit_settings_fingerprint_ignores_this_runs_scheduling() {
+    // The runner overrides these four per candidate, so they say nothing about
+    // the numbers a journalled row holds. Including them would refuse resumes
+    // that are in fact identical.
+    let base = FitOptions::default();
+    let reference = with_fit_options(Some(base.clone()));
+
+    let mut rescheduled = base.clone();
+    rescheduled.threads = Some(7);
+    rescheduled.cancel = Some(CancelFlag::new());
+    rescheduled.n_starts = 9;
+    rescheduled.verbose = true;
+    rescheduled.user_set_keys = vec!["method".to_string()];
+    let same = with_fit_options(Some(rescheduled));
+
+    assert_eq!(
+        same.fit_options_fingerprint, reference.fit_options_fingerprint,
+        "a run-scheduling knob leaked into the fit-settings fingerprint"
+    );
+    assert!(reference
+        .check_compatible(&same, std::path::Path::new("."))
+        .is_ok());
+}
+
+#[test]
+fn no_override_and_an_override_are_not_interchangeable() {
+    // `None` means "each candidate's own `[fit_options]`" — a different thing
+    // from any particular override, even the default one.
+    let none = with_fit_options(None);
+    let default_override = with_fit_options(Some(FitOptions::default()));
+    assert!(none.fit_options_fingerprint.is_none());
+    assert!(default_override.fit_options_fingerprint.is_some());
+    assert!(none
+        .check_compatible(&default_override, std::path::Path::new("."))
+        .is_err());
+    assert!(default_override
+        .check_compatible(&none, std::path::Path::new("."))
+        .is_err());
 }

--- a/crates/ferx-tools/src/search/journal_tests.rs
+++ b/crates/ferx-tools/src/search/journal_tests.rs
@@ -25,6 +25,7 @@ fn record(id: &str, hash: &str) -> CandidateRecord {
         skipped: vec![],
         seconds: 1.5,
         error: None,
+        retryable: false,
         has_fit: false,
     }
 }

--- a/crates/ferx-tools/src/search/journal_tests.rs
+++ b/crates/ferx-tools/src/search/journal_tests.rs
@@ -38,6 +38,57 @@ fn options() -> RunOptions {
     }
 }
 
+// ── the numbers survive the round trip ───────────────────────────────────────
+
+#[test]
+fn a_journalled_criterion_and_ofv_come_back_bit_for_bit() {
+    // `serde_json` parses floats with a fast algorithm that is accurate only to
+    // within 1 ULP unless its `float_roundtrip` feature is on — and the journal
+    // exists to answer "what did the interrupted run score this candidate?".
+    // A resumed run that reports a *different number* from the one it is
+    // replaying breaks the contract in the module docs, and it breaks it
+    // invisibly: the CSV prints six decimals, so nothing downstream would show
+    // the drift.
+    //
+    // `-200.28784144636057` is the value that actually caught this, from the
+    // warfarin evaluation in `search_runner_end_to_end`. It is one ULP from
+    // `-200.28784144636055`, and each is its own shortest decimal form, so a
+    // correct parser cannot confuse them.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let awkward = [
+        -200.28784144636057_f64,
+        -200.28784144636055,
+        f64::MIN_POSITIVE,
+        1.0 / 3.0,
+        (2.0_f64).sqrt(),
+        1e308,
+        -0.0,
+    ];
+
+    let journal = Journal::create(dir.path(), &[]).expect("create");
+    for (i, value) in awkward.iter().enumerate() {
+        let mut row = record(&format!("c{i}"), &format!("{i:064x}"));
+        row.criterion = Some(*value);
+        row.ofv = Some(*value);
+        row.seconds = *value;
+        journal.append(&row, None);
+    }
+    journal.into_result().expect("no write failure");
+
+    let back = read_records(&journal_path(dir.path()));
+    assert_eq!(back.len(), awkward.len());
+    for (row, want) in back.iter().zip(&awkward) {
+        assert_eq!(
+            row.criterion.map(f64::to_bits),
+            Some(want.to_bits()),
+            "criterion {want:?} drifted to {:?}",
+            row.criterion
+        );
+        assert_eq!(row.ofv.map(f64::to_bits), Some(want.to_bits()));
+        assert_eq!(row.seconds.to_bits(), want.to_bits());
+    }
+}
+
 // ── append and read ──────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/ferx-tools/src/search/journal_tests.rs
+++ b/crates/ferx-tools/src/search/journal_tests.rs
@@ -1,0 +1,209 @@
+//! The candidate journal, the fit cache and the resume manifest (#1178).
+
+use super::*;
+use crate::search::candidate::{Criterion, FeatureVector};
+use crate::search::test_support::{converged_fit, population};
+
+fn record(id: &str, hash: &str) -> CandidateRecord {
+    CandidateRecord {
+        id: id.to_string(),
+        hash: hash.to_string(),
+        parent: None,
+        features: FeatureVector::new().with("CL-WT", "pow"),
+        criterion: Some(12.5),
+        ofv: Some(10.0),
+        converged: true,
+        passed: true,
+        failures: vec![],
+        skipped: vec![],
+        seconds: 1.5,
+        error: None,
+        has_fit: false,
+    }
+}
+
+fn options() -> RunOptions {
+    RunOptions {
+        criterion: Criterion::Ofv,
+        n_starts: 2,
+        ..RunOptions::default()
+    }
+}
+
+// ── append and read ──────────────────────────────────────────────────────────
+
+#[test]
+fn rows_round_trip_in_completion_order() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let journal = Journal::create(dir.path(), &[]).expect("create");
+    journal.append(&record("b", "bb"), None);
+    journal.append(&record("a", "aa"), None);
+    journal.into_result().expect("no write failure");
+
+    let back = read_records(&journal_path(dir.path()));
+    assert_eq!(back.len(), 2);
+    assert_eq!(back[0].id, "b", "the log was reordered");
+    assert_eq!(back[1].id, "a");
+    assert_eq!(back[0], record("b", "bb"));
+}
+
+#[test]
+fn a_truncated_or_garbled_line_is_dropped_and_the_rest_survives() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = journal_path(dir.path());
+    let good = serde_json::to_string(&record("a", "aa")).expect("serialize");
+    let cut = &good[..good.len() / 2];
+    std::fs::write(&path, format!("{good}\nnot json at all\n{good}\n{cut}"))
+        .expect("write journal");
+
+    let back = read_records(&path);
+    assert_eq!(back.len(), 2, "a malformed line took a good one with it");
+    assert!(back.iter().all(|r| r.id == "a"));
+}
+
+#[test]
+fn a_missing_journal_is_an_empty_one() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    assert!(read_records(&journal_path(dir.path())).is_empty());
+}
+
+#[test]
+fn creating_the_journal_rewrites_it_from_the_kept_rows() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = journal_path(dir.path());
+    std::fs::write(&path, "garbage that must not survive\n").expect("seed");
+
+    let kept = vec![record("a", "aa")];
+    let journal = Journal::create(dir.path(), &kept).expect("create");
+    journal.append(&record("b", "bb"), None);
+    journal.into_result().expect("no write failure");
+
+    let back = read_records(&path);
+    assert_eq!(back.len(), 2);
+    assert_eq!(back[0].id, "a");
+    assert_eq!(back[1].id, "b");
+    let text = std::fs::read_to_string(&path).expect("read");
+    assert!(!text.contains("garbage"));
+    // The `.part` sibling the rewrite went through is gone.
+    assert!(!dir.path().join("search_journal.jsonl.part").exists());
+}
+
+// ── the fit cache ────────────────────────────────────────────────────────────
+
+#[test]
+fn a_cached_fit_round_trips_and_a_missing_one_is_none() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let journal = Journal::create(dir.path(), &[]).expect("create");
+    let mut row = record("a", "aa");
+    row.has_fit = true;
+    let fit = converged_fit(42.0);
+    journal.append(&row, Some(&fit));
+    journal.into_result().expect("no write failure");
+
+    let loaded = load_fit(dir.path(), "aa").expect("the cached fit");
+    assert_eq!(loaded.ofv, 42.0);
+    assert_eq!(loaded.theta, fit.theta);
+    assert!(loaded.converged);
+
+    assert!(load_fit(dir.path(), "never-written").is_none());
+}
+
+#[test]
+fn an_unreadable_cached_fit_is_none_rather_than_a_panic() {
+    // The cache is a cache: a corrupt file costs the reused candidate its
+    // `FitResult`, never the run.
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(fits_dir(dir.path())).expect("fits dir");
+    std::fs::write(fit_path(dir.path(), "aa"), "{ not a fit }").expect("write");
+    assert!(load_fit(dir.path(), "aa").is_none());
+}
+
+// ── the manifest ─────────────────────────────────────────────────────────────
+
+#[test]
+fn the_manifest_round_trips_through_disk() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let manifest = SearchManifest::new(&options(), &population(&["1", "2"]));
+    let path = manifest_path(dir.path());
+    manifest.write(&path).expect("write");
+    assert_eq!(SearchManifest::read(&path).expect("read"), manifest);
+    assert_eq!(manifest.criterion, "ofv");
+    assert_eq!(manifest.n_starts, 2);
+    assert_eq!(manifest.n_subjects, 2);
+}
+
+#[test]
+fn an_identical_manifest_is_compatible() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let data = population(&["1", "2"]);
+    let manifest = SearchManifest::new(&options(), &data);
+    let disk = SearchManifest::new(&options(), &data);
+    assert!(manifest.check_compatible(&disk, dir.path()).is_ok());
+}
+
+#[test]
+fn each_difference_is_refused_by_name() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let data = population(&["1", "2"]);
+    let manifest = SearchManifest::new(&options(), &data);
+
+    let cases: [(SearchManifest, &str); 4] = [
+        (
+            SearchManifest::new(
+                &RunOptions {
+                    criterion: Criterion::Aic,
+                    ..options()
+                },
+                &data,
+            ),
+            "ranking criterion",
+        ),
+        (
+            SearchManifest::new(
+                &RunOptions {
+                    n_starts: 5,
+                    ..options()
+                },
+                &data,
+            ),
+            "starts",
+        ),
+        (
+            SearchManifest::new(
+                &RunOptions {
+                    strictness: ferx_core::Strictness::none(),
+                    ..options()
+                },
+                &data,
+            ),
+            "strictness",
+        ),
+        (
+            SearchManifest::new(&options(), &population(&["1", "3"])),
+            "dataset",
+        ),
+    ];
+
+    for (disk, expected) in cases {
+        let err = manifest
+            .check_compatible(&disk, dir.path())
+            .expect_err("an incompatible resume must be refused");
+        assert!(
+            err.contains(expected),
+            "expected the message to name `{expected}`, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn the_data_fingerprint_moves_with_the_data_and_not_with_anything_else() {
+    let a = SearchManifest::new(&options(), &population(&["1", "2"]));
+    let same = SearchManifest::new(&options(), &population(&["1", "2"]));
+    let renamed = SearchManifest::new(&options(), &population(&["1", "9"]));
+    assert_eq!(a.data_fingerprint, same.data_fingerprint);
+    assert_ne!(
+        a.data_fingerprint, renamed.data_fingerprint,
+        "a different subject set hashed the same"
+    );
+    assert_eq!(a.data_fingerprint.len(), 64);
+}

--- a/crates/ferx-tools/src/search/mod.rs
+++ b/crates/ferx-tools/src/search/mod.rs
@@ -43,7 +43,9 @@ mod runner;
 #[cfg(test)]
 mod test_support;
 
-pub use candidate::{Candidate, CandidateResult, Criterion, FeatureVector, RunOptions};
+pub use candidate::{
+    Candidate, CandidateError, CandidateResult, Criterion, FeatureVector, RunOptions,
+};
 pub use journal::{CandidateRecord, SearchManifest};
 pub use output::{partial_table_path, table_path, COLUMNS as TABLE_COLUMNS};
 pub use runner::{RunReport, Runner};

--- a/crates/ferx-tools/src/search/mod.rs
+++ b/crates/ferx-tools/src/search/mod.rs
@@ -45,5 +45,5 @@ mod test_support;
 
 pub use candidate::{Candidate, CandidateResult, Criterion, FeatureVector, RunOptions};
 pub use journal::{CandidateRecord, SearchManifest};
-pub use output::{table_path, COLUMNS as TABLE_COLUMNS};
+pub use output::{partial_table_path, table_path, COLUMNS as TABLE_COLUMNS};
 pub use runner::{RunReport, Runner};

--- a/crates/ferx-tools/src/search/mod.rs
+++ b/crates/ferx-tools/src/search/mod.rs
@@ -1,0 +1,49 @@
+//! Model-space search: the shared machinery every search tool sits on (#1175).
+//!
+//! `ferx-core::edit` can *generate* a candidate model, `ferx_core::fit` can fit
+//! one and `ferx_core::bic` / `ferx_core::check_strictness` can rank and judge
+//! one. What every search tool in the epic — covsearch, modelsearch, iivsearch,
+//! ruvsearch — additionally needs is the orchestration between those verbs:
+//! fit N candidates in parallel without oversubscribing the machine,
+//! deduplicate the ones that render to the same model, journal each outcome so
+//! an interrupted overnight search resumes, and report every candidate
+//! including the ones that failed.
+//!
+//! That is [`Runner`] (#1178). It is written once here rather than four times
+//! in the tools above it.
+//!
+//! ```no_run
+//! use ferx_core::edit::ModelText;
+//! use ferx_tools::search::{Candidate, FeatureVector, RunOptions, Runner};
+//!
+//! # fn demo(base: &ModelText, data: &ferx_core::Population) -> Result<(), String> {
+//! let candidates = vec![
+//!     Candidate::new("base", base.clone()),
+//!     Candidate::new("cl-wt-pow", base.clone())
+//!         .parent("base")
+//!         .features(FeatureVector::new().with("CL-WT", "pow")),
+//! ];
+//!
+//! let report = Runner::new()
+//!     .threads(8)
+//!     .cache_dir(".ferx-search")
+//!     .run(&candidates, data, &RunOptions::default())?;
+//!
+//! if let Some(best) = report.best() {
+//!     println!("winner: {} ({:.3})", best.id, best.criterion);
+//! }
+//! # Ok(())
+//! # }
+//! ```
+
+mod candidate;
+pub mod journal;
+mod output;
+mod runner;
+#[cfg(test)]
+mod test_support;
+
+pub use candidate::{Candidate, CandidateResult, Criterion, FeatureVector, RunOptions};
+pub use journal::{CandidateRecord, SearchManifest};
+pub use output::{table_path, COLUMNS as TABLE_COLUMNS};
+pub use runner::{RunReport, Runner};

--- a/crates/ferx-tools/src/search/output.rs
+++ b/crates/ferx-tools/src/search/output.rs
@@ -18,6 +18,18 @@ pub fn table_path(dir: &Path) -> PathBuf {
     dir.join("candidates.csv")
 }
 
+/// Where a **cancelled** run's partial table goes.
+///
+/// A cancelled run has a report worth reading and a `candidates.csv` it must
+/// not be the one to destroy: the run it resumed may have finished hundreds of
+/// candidates, and `csv::Writer::from_path` truncates. So the partial table is
+/// a file of its own, and a run that reaches the end removes it — a stale
+/// partial next to a complete table would be the more confusing of the two
+/// failure modes.
+pub fn partial_table_path(dir: &Path) -> PathBuf {
+    dir.join("candidates.partial.csv")
+}
+
 /// The columns of `candidates.csv`, in order.
 pub const COLUMNS: [&str; 14] = [
     "id",
@@ -53,41 +65,65 @@ fn reasons(list: &[String]) -> String {
     list.join("; ")
 }
 
-/// Write `candidates.csv` into `dir`.
+/// Write `candidates.csv` into `dir`, and drop any partial table left by an
+/// earlier cancelled run.
 pub fn write_table(dir: &Path, results: &[CandidateResult]) -> Result<(), String> {
+    write_table_to(&table_path(dir), dir, results)?;
+    // Best-effort: a partial table that outlives its complete successor is
+    // confusing, but failing the run over it would be worse.
+    let _ = std::fs::remove_file(partial_table_path(dir));
+    Ok(())
+}
+
+/// Write a cancelled run's rows to [`partial_table_path`], leaving any complete
+/// `candidates.csv` beside it untouched.
+pub fn write_partial_table(dir: &Path, results: &[CandidateResult]) -> Result<(), String> {
+    write_table_to(&partial_table_path(dir), dir, results)
+}
+
+/// The table itself, written through a `.part` sibling renamed into place so a
+/// reader never sees a half-written file and a failure mid-write does not
+/// destroy the previous one.
+fn write_table_to(path: &Path, dir: &Path, results: &[CandidateResult]) -> Result<(), String> {
     std::fs::create_dir_all(dir)
         .map_err(|e| format!("cannot create search directory `{}`: {e}", dir.display()))?;
-    let path = table_path(dir);
-    let mut writer = csv::Writer::from_path(&path)
-        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
-    writer
-        .write_record(COLUMNS)
-        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
-    for r in results {
-        let ofv = r.fit.as_ref().map(|f| f.ofv).unwrap_or(f64::NAN);
-        let converged = r.fit.as_ref().map(|f| f.converged);
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".part");
+    let temp = path.with_file_name(name);
+    {
+        let mut writer = csv::Writer::from_path(&temp)
+            .map_err(|e| format!("cannot write `{}`: {e}", temp.display()))?;
         writer
-            .write_record([
-                r.id.clone(),
-                r.parent.clone().unwrap_or_default(),
-                r.hash.clone(),
-                r.features.render(),
-                number(r.criterion),
-                number(ofv),
-                converged.map(|c| c.to_string()).unwrap_or_default(),
-                r.verdict.passed.to_string(),
-                reasons(&r.verdict.failures),
-                reasons(&r.verdict.skipped),
-                number(r.seconds),
-                r.error.clone().unwrap_or_default(),
-                r.duplicate_of.clone().unwrap_or_default(),
-                r.reused.to_string(),
-            ])
-            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+            .write_record(COLUMNS)
+            .map_err(|e| format!("cannot write `{}`: {e}", temp.display()))?;
+        for r in results {
+            writer
+                .write_record([
+                    r.id.clone(),
+                    r.parent.clone().unwrap_or_default(),
+                    r.hash.clone(),
+                    r.features.render(),
+                    number(r.criterion),
+                    number(r.ofv.unwrap_or(f64::NAN)),
+                    r.converged.map(|c| c.to_string()).unwrap_or_default(),
+                    r.verdict.passed.to_string(),
+                    reasons(&r.verdict.failures),
+                    reasons(&r.verdict.skipped),
+                    number(r.seconds),
+                    r.error.clone().unwrap_or_default(),
+                    r.duplicate_of.clone().unwrap_or_default(),
+                    r.reused.to_string(),
+                ])
+                .map_err(|e| format!("cannot write `{}`: {e}", temp.display()))?;
+        }
+        writer
+            .flush()
+            .map_err(|e| format!("cannot flush `{}`: {e}", temp.display()))?;
     }
-    writer
-        .flush()
-        .map_err(|e| format!("cannot flush `{}`: {e}", path.display()))
+    std::fs::rename(&temp, path).map_err(|e| {
+        let _ = std::fs::remove_file(&temp);
+        format!("cannot rename `{}`: {e}", temp.display())
+    })
 }
 
 #[cfg(test)]

--- a/crates/ferx-tools/src/search/output.rs
+++ b/crates/ferx-tools/src/search/output.rs
@@ -31,7 +31,7 @@ pub fn partial_table_path(dir: &Path) -> PathBuf {
 }
 
 /// The columns of `candidates.csv`, in order.
-pub const COLUMNS: [&str; 14] = [
+pub const COLUMNS: [&str; 15] = [
     "id",
     "parent",
     "hash",
@@ -44,6 +44,7 @@ pub const COLUMNS: [&str; 14] = [
     "skipped",
     "seconds",
     "error",
+    "retryable",
     "duplicate_of",
     "reused",
 ];
@@ -110,7 +111,17 @@ fn write_table_to(path: &Path, dir: &Path, results: &[CandidateResult]) -> Resul
                     reasons(&r.verdict.failures),
                     reasons(&r.verdict.skipped),
                     number(r.seconds),
-                    r.error.clone().unwrap_or_default(),
+                    r.error
+                        .as_ref()
+                        .map(|e| e.message.clone())
+                        .unwrap_or_default(),
+                    // Empty rather than `false` when there is no failure to
+                    // describe: the column answers "will a resume try this
+                    // again?", and a row that succeeded is not asking.
+                    r.error
+                        .as_ref()
+                        .map(|e| e.retryable.to_string())
+                        .unwrap_or_default(),
                     r.duplicate_of.clone().unwrap_or_default(),
                     r.reused.to_string(),
                 ])

--- a/crates/ferx-tools/src/search/output.rs
+++ b/crates/ferx-tools/src/search/output.rs
@@ -1,0 +1,95 @@
+//! `candidates.csv` — the per-candidate table (#1178).
+//!
+//! One row per candidate the run was given, in the order it was given them,
+//! including the ones that failed. A candidate excluded by the strictness gate
+//! carries *why* in its `failures` cell rather than being absent: a candidate
+//! missing from a search report cannot be told apart from one that was never
+//! generated, which is exactly the question a user reading the report is asking.
+//!
+//! The table is rewritten from the finished results, so a completed run's file
+//! is in candidate order however its fits were scheduled — the journal beside
+//! it is in completion order and is the recovery log, not the report.
+
+use std::path::{Path, PathBuf};
+
+use super::CandidateResult;
+
+pub fn table_path(dir: &Path) -> PathBuf {
+    dir.join("candidates.csv")
+}
+
+/// The columns of `candidates.csv`, in order.
+pub const COLUMNS: [&str; 14] = [
+    "id",
+    "parent",
+    "hash",
+    "features",
+    "criterion",
+    "ofv",
+    "converged",
+    "passed",
+    "failures",
+    "skipped",
+    "seconds",
+    "error",
+    "duplicate_of",
+    "reused",
+];
+
+/// A non-finite number has no cell — an empty string beats `NaN` in a file
+/// meant to be opened in a spreadsheet, and it is what "there is no criterion"
+/// actually means.
+fn number(value: f64) -> String {
+    if value.is_finite() {
+        format!("{value:.6}")
+    } else {
+        String::new()
+    }
+}
+
+/// Multiple reasons in one cell, `;`-joined. The CSV writer quotes the cell, so
+/// a reason containing a comma survives.
+fn reasons(list: &[String]) -> String {
+    list.join("; ")
+}
+
+/// Write `candidates.csv` into `dir`.
+pub fn write_table(dir: &Path, results: &[CandidateResult]) -> Result<(), String> {
+    std::fs::create_dir_all(dir)
+        .map_err(|e| format!("cannot create search directory `{}`: {e}", dir.display()))?;
+    let path = table_path(dir);
+    let mut writer = csv::Writer::from_path(&path)
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    writer
+        .write_record(COLUMNS)
+        .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    for r in results {
+        let ofv = r.fit.as_ref().map(|f| f.ofv).unwrap_or(f64::NAN);
+        let converged = r.fit.as_ref().map(|f| f.converged);
+        writer
+            .write_record([
+                r.id.clone(),
+                r.parent.clone().unwrap_or_default(),
+                r.hash.clone(),
+                r.features.render(),
+                number(r.criterion),
+                number(ofv),
+                converged.map(|c| c.to_string()).unwrap_or_default(),
+                r.verdict.passed.to_string(),
+                reasons(&r.verdict.failures),
+                reasons(&r.verdict.skipped),
+                number(r.seconds),
+                r.error.clone().unwrap_or_default(),
+                r.duplicate_of.clone().unwrap_or_default(),
+                r.reused.to_string(),
+            ])
+            .map_err(|e| format!("cannot write `{}`: {e}", path.display()))?;
+    }
+    writer
+        .flush()
+        .map_err(|e| format!("cannot flush `{}`: {e}", path.display()))
+}
+
+#[cfg(test)]
+#[path = "output_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/search/output_tests.rs
+++ b/crates/ferx-tools/src/search/output_tests.rs
@@ -3,7 +3,7 @@
 use ferx_core::StrictnessVerdict;
 
 use super::*;
-use crate::search::candidate::{CandidateResult, FeatureVector};
+use crate::search::candidate::{CandidateError, CandidateResult, FeatureVector};
 use crate::search::test_support::converged_fit;
 
 fn result(id: &str) -> CandidateResult {
@@ -101,7 +101,7 @@ fn a_candidate_without_a_fit_leaves_its_numeric_cells_empty() {
     failed.ofv = None;
     failed.converged = None;
     failed.criterion = f64::NAN;
-    failed.error = Some("does not compile".into());
+    failed.error = Some(CandidateError::model("does not compile"));
     write_table(dir.path(), &[failed]).expect("write");
 
     let rows = rows(dir.path());

--- a/crates/ferx-tools/src/search/output_tests.rs
+++ b/crates/ferx-tools/src/search/output_tests.rs
@@ -13,6 +13,8 @@ fn result(id: &str) -> CandidateResult {
         parent: Some("base".into()),
         features: FeatureVector::new().with("CL-WT", "pow"),
         fit: Some(converged_fit(12.0)),
+        ofv: Some(12.0),
+        converged: Some(true),
         verdict: StrictnessVerdict {
             passed: true,
             failures: vec![],
@@ -96,6 +98,8 @@ fn a_candidate_without_a_fit_leaves_its_numeric_cells_empty() {
     let dir = tempfile::tempdir().expect("tempdir");
     let mut failed = result("broken");
     failed.fit = None;
+    failed.ofv = None;
+    failed.converged = None;
     failed.criterion = f64::NAN;
     failed.error = Some("does not compile".into());
     write_table(dir.path(), &[failed]).expect("write");
@@ -108,6 +112,77 @@ fn a_candidate_without_a_fit_leaves_its_numeric_cells_empty() {
     assert_eq!(cell("ofv"), "");
     assert_eq!(cell("converged"), "");
     assert_eq!(cell("error"), "does not compile");
+}
+
+#[test]
+fn a_reused_row_reports_its_ofv_after_the_cached_fit_is_gone() {
+    // The degraded resume the journal is built for: `fits/<hash>.json` was
+    // deleted or truncated, so `fit` is `None` — but the journal row it came
+    // from still holds the OFV and the convergence flag, and reading those two
+    // columns off `fit` alone would blank them for a candidate that fitted
+    // perfectly well. This is the whole reason `ofv`/`converged` sit beside
+    // `fit` rather than inside it.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut lost = result("reused");
+    lost.fit = None;
+    lost.reused = true;
+    write_table(dir.path(), &[lost]).expect("write");
+
+    let rows = rows(dir.path());
+    let cell = |name: &str| rows[1][COLUMNS.iter().position(|c| *c == name).unwrap()].clone();
+    assert_eq!(cell("ofv"), "12.000000");
+    assert_eq!(cell("converged"), "true");
+    assert_eq!(cell("criterion"), "17.000000");
+}
+
+#[test]
+fn a_cancelled_runs_partial_table_does_not_replace_a_complete_one() {
+    // `csv::Writer::from_path` truncates, so a run cancelled two candidates
+    // into a resume would otherwise overwrite the 500-row table of the run it
+    // resumed with a two-row one.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let complete: Vec<CandidateResult> = ["a", "b", "c"].iter().map(|id| result(id)).collect();
+    write_table(dir.path(), &complete).expect("write");
+    write_partial_table(dir.path(), &[result("a")]).expect("write partial");
+
+    assert_eq!(
+        rows(dir.path()).len(),
+        4,
+        "the complete table was rewritten"
+    );
+    let mut reader =
+        csv::Reader::from_path(partial_table_path(dir.path())).expect("candidates.partial.csv");
+    assert_eq!(reader.records().count(), 1);
+}
+
+#[test]
+fn a_completed_run_clears_the_partial_table_beside_it() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_partial_table(dir.path(), &[result("a")]).expect("write partial");
+    write_table(dir.path(), &[result("a"), result("b")]).expect("write");
+    assert!(
+        !partial_table_path(dir.path()).exists(),
+        "a stale partial outlived the complete table"
+    );
+}
+
+#[test]
+fn a_failed_write_leaves_the_previous_table_intact() {
+    // The `.part` + rename is what makes this true: without it the truncate
+    // happens first and a failure mid-write destroys the old table. A
+    // *directory* at the temp path is a write that cannot succeed.
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_table(dir.path(), &[result("a"), result("b")]).expect("write");
+    let before = std::fs::read_to_string(table_path(dir.path())).expect("read");
+
+    std::fs::create_dir(dir.path().join("candidates.csv.part")).expect("blocker");
+    assert!(write_table(dir.path(), &[result("c")]).is_err());
+
+    assert_eq!(
+        std::fs::read_to_string(table_path(dir.path())).expect("read"),
+        before,
+        "a failed write truncated the previous table"
+    );
 }
 
 #[test]

--- a/crates/ferx-tools/src/search/output_tests.rs
+++ b/crates/ferx-tools/src/search/output_tests.rs
@@ -1,0 +1,130 @@
+//! `candidates.csv` (#1178).
+
+use ferx_core::StrictnessVerdict;
+
+use super::*;
+use crate::search::candidate::{CandidateResult, FeatureVector};
+use crate::search::test_support::converged_fit;
+
+fn result(id: &str) -> CandidateResult {
+    CandidateResult {
+        id: id.to_string(),
+        hash: "ab".repeat(32),
+        parent: Some("base".into()),
+        features: FeatureVector::new().with("CL-WT", "pow"),
+        fit: Some(converged_fit(12.0)),
+        verdict: StrictnessVerdict {
+            passed: true,
+            failures: vec![],
+            skipped: vec![],
+        },
+        criterion: 17.0,
+        seconds: 2.5,
+        error: None,
+        duplicate_of: None,
+        reused: false,
+    }
+}
+
+fn rows(dir: &std::path::Path) -> Vec<Vec<String>> {
+    let mut reader = csv::Reader::from_path(table_path(dir)).expect("candidates.csv");
+    let header: Vec<String> = reader
+        .headers()
+        .expect("header")
+        .iter()
+        .map(str::to_string)
+        .collect();
+    let mut out = vec![header];
+    for record in reader.records() {
+        out.push(record.expect("row").iter().map(str::to_string).collect());
+    }
+    out
+}
+
+#[test]
+fn a_passing_candidate_fills_every_column() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    write_table(dir.path(), &[result("cand")]).expect("write");
+
+    let rows = rows(dir.path());
+    assert_eq!(rows[0], COLUMNS.to_vec());
+    let row = &rows[1];
+    let cell = |name: &str| row[COLUMNS.iter().position(|c| *c == name).unwrap()].as_str();
+    assert_eq!(cell("id"), "cand");
+    assert_eq!(cell("parent"), "base");
+    assert_eq!(cell("hash").len(), 64);
+    assert_eq!(cell("features"), "CL-WT=pow");
+    assert_eq!(cell("criterion"), "17.000000");
+    assert_eq!(cell("ofv"), "12.000000");
+    assert_eq!(cell("converged"), "true");
+    assert_eq!(cell("passed"), "true");
+    assert_eq!(cell("failures"), "");
+    assert_eq!(cell("seconds"), "2.500000");
+    assert_eq!(cell("error"), "");
+    assert_eq!(cell("duplicate_of"), "");
+    assert_eq!(cell("reused"), "false");
+}
+
+#[test]
+fn a_failing_candidate_carries_its_reasons_in_one_cell() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut failed = result("bad");
+    failed.verdict = StrictnessVerdict {
+        passed: false,
+        failures: vec![
+            "did not converge (`converged = false`)".into(),
+            "condition number 1.2e4 exceeds 1.0e3".into(),
+        ],
+        skipped: vec!["correlation: no covariance matrix".into()],
+    };
+    write_table(dir.path(), &[failed]).expect("write");
+
+    let rows = rows(dir.path());
+    let cell = |name: &str| rows[1][COLUMNS.iter().position(|c| *c == name).unwrap()].clone();
+    // The CSV writer quotes the cell, so a reason containing a comma survives
+    // reading back as one field rather than splitting the row.
+    assert_eq!(
+        cell("failures"),
+        "did not converge (`converged = false`); condition number 1.2e4 exceeds 1.0e3"
+    );
+    assert_eq!(cell("skipped"), "correlation: no covariance matrix");
+    assert_eq!(cell("passed"), "false");
+}
+
+#[test]
+fn a_candidate_without_a_fit_leaves_its_numeric_cells_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut failed = result("broken");
+    failed.fit = None;
+    failed.criterion = f64::NAN;
+    failed.error = Some("does not compile".into());
+    write_table(dir.path(), &[failed]).expect("write");
+
+    let rows = rows(dir.path());
+    let cell = |name: &str| rows[1][COLUMNS.iter().position(|c| *c == name).unwrap()].clone();
+    // Not "NaN": an empty cell is what "there is no criterion" means, and it is
+    // what a spreadsheet and a `read.csv` both read as missing.
+    assert_eq!(cell("criterion"), "");
+    assert_eq!(cell("ofv"), "");
+    assert_eq!(cell("converged"), "");
+    assert_eq!(cell("error"), "does not compile");
+}
+
+#[test]
+fn rows_keep_the_order_they_were_given_in() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let results: Vec<CandidateResult> = ["c", "a", "b"].iter().map(|id| result(id)).collect();
+    write_table(dir.path(), &results).expect("write");
+
+    let rows = rows(dir.path());
+    let ids: Vec<&str> = rows[1..].iter().map(|r| r[0].as_str()).collect();
+    assert_eq!(ids, vec!["c", "a", "b"], "the table sorted its rows");
+}
+
+#[test]
+fn writing_the_table_creates_the_directory() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let nested = dir.path().join("does/not/exist");
+    write_table(&nested, &[result("cand")]).expect("write");
+    assert!(table_path(&nested).exists());
+}

--- a/crates/ferx-tools/src/search/runner.rs
+++ b/crates/ferx-tools/src/search/runner.rs
@@ -29,7 +29,10 @@
 //!   finishes and a resumed run refits only what is missing — see
 //!   [`super::journal`]. The directory is claimed for the length of the run
 //!   ([`journal::DirLock`]), because two runs sharing one silently destroy each
-//!   other's journal.
+//!   other's journal; a claim whose owner was hard-killed is taken over rather
+//!   than needing a manual delete. What is refitted is decided by
+//!   [`CandidateError::retryable`]: a model that does not compile is remembered,
+//!   a fit the *machine* failed is tried again.
 //! * **Cancellation.** A flipped [`CancelFlag`] stops the run *between*
 //!   candidates and returns what finished, with [`RunReport::cancelled`] set.
 //!   Its partial rows go to `candidates.partial.csv`, never over the complete
@@ -59,7 +62,7 @@ use ferx_core::{
 };
 use rayon::prelude::*;
 
-use super::candidate::{Candidate, CandidateResult, RunOptions};
+use super::candidate::{Candidate, CandidateError, CandidateResult, RunOptions};
 use super::journal::{self, CandidateRecord, Journal, SearchManifest};
 use super::output;
 
@@ -197,7 +200,7 @@ impl Runner {
         fitter: F,
     ) -> Result<RunReport, String>
     where
-        F: Fn(&Candidate, usize) -> Result<FitResult, String> + Sync,
+        F: Fn(&Candidate, usize) -> Result<FitResult, CandidateError> + Sync,
     {
         reject_duplicate_ids(candidates)?;
 
@@ -461,10 +464,10 @@ fn reject_duplicate_ids(candidates: &[Candidate]) -> Result<(), String> {
 
 /// The verdict of a candidate that produced no fit at all. Not `passed`, and
 /// the reason is the failure itself.
-fn failed_verdict(error: &str) -> StrictnessVerdict {
+fn failed_verdict(error: &CandidateError) -> StrictnessVerdict {
     StrictnessVerdict {
         passed: false,
-        failures: vec![format!("no fit: {error}")],
+        failures: vec![format!("no fit: {}", error.message)],
         skipped: Vec::new(),
     }
 }
@@ -482,7 +485,8 @@ fn record_of(result: &CandidateResult) -> CandidateRecord {
         failures: result.verdict.failures.clone(),
         skipped: result.verdict.skipped.clone(),
         seconds: result.seconds,
-        error: result.error.clone(),
+        error: result.error.as_ref().map(|e| e.message.clone()),
+        retryable: result.error.as_ref().is_some_and(|e| e.retryable),
         has_fit: result.fit.is_some(),
     }
 }
@@ -515,7 +519,10 @@ fn reused_result(
         },
         criterion: record.criterion.unwrap_or(f64::NAN),
         seconds: record.seconds,
-        error: record.error.clone(),
+        error: record.error.clone().map(|message| CandidateError {
+            message,
+            retryable: record.retryable,
+        }),
         duplicate_of: None,
         reused: true,
     }
@@ -539,18 +546,16 @@ fn load_resumable(dir: &Path, manifest: &SearchManifest) -> Result<Vec<Candidate
     let mut seen: HashSet<String> = HashSet::new();
     let mut kept = Vec::new();
     for record in journal::read_records(&journal::journal_path(dir)) {
-        // A row with an `error` is not reused. `error` means the candidate
-        // produced no fit at all, and the runner cannot tell *why* from here:
-        // a model that does not compile fails the same way as one whose fit
-        // hit a transient resource limit — `install_on_fit_pool` returns `Err`
-        // when the machine is briefly out of threads. Carrying that forward
+        // A *retryable* failure is not reused. The row says the run failed, not
+        // that the candidate is bad — `install_on_fit_pool` returns `Err` when
+        // the machine is briefly out of threads — and carrying that forward
         // would have one bad minute permanently mark a fittable model as
-        // unfittable in every later resume. Refitting a genuinely broken
-        // candidate costs a parse; believing a false failure costs the search.
+        // unfittable in every later resume. A model that does not compile is
+        // kept, because it will not compile next time either.
         //
-        // Filtered *before* the dedup below, or an error row would consume the
-        // hash and hide the successful refit appended after it.
-        if record.error.is_some() {
+        // Filtered *before* the dedup below, or a discarded row would consume
+        // the hash and hide the successful refit appended after it.
+        if record.error.is_some() && record.retryable {
             continue;
         }
         // A hash appearing twice — two runs over the same directory — keeps the
@@ -580,15 +585,26 @@ fn compile_and_fit(
     options: &RunOptions,
     threads_per_fit: usize,
     cancel: &Option<CancelFlag>,
-) -> Result<FitResult, String> {
+) -> Result<FitResult, CandidateError> {
+    // Compilation and binding are properties of the candidate and this run's
+    // data, both of which the resume manifest pins — so they fail the same way
+    // every time and a resumed run can trust the row rather than re-deriving
+    // it. Everything below `fit()` is classified the other way; see
+    // [`CandidateError`].
     let text = candidate.model.render();
-    let mut parsed = parse_full_model(&text)
-        .map_err(|e| format!("candidate `{}` does not compile: {e}", candidate.id))?;
+    let mut parsed = parse_full_model(&text).map_err(|e| {
+        CandidateError::model(format!(
+            "candidate `{}` does not compile: {e}",
+            candidate.id
+        ))
+    })?;
     let mut population = Cow::Borrowed(data);
     if !parsed.model.theta_blocks().level_blocks().is_empty() {
-        bind_theta_levels(&mut parsed, &text, population.to_mut())?;
+        bind_theta_levels(&mut parsed, &text, population.to_mut())
+            .map_err(CandidateError::model)?;
     }
-    ferx_core::api::bind_covariate_stats(&mut parsed, &text, &population)?;
+    ferx_core::api::bind_covariate_stats(&mut parsed, &text, &population)
+        .map_err(CandidateError::model)?;
 
     // The caller's settings replace the file's wholesale when given; the four
     // overrides below are the runner's own and always win.
@@ -621,7 +637,12 @@ fn compile_and_fit(
     fit_options.threads = Some(threads_per_fit);
     fit_options.cancel = cancel.clone();
 
-    fit(&parsed.model, &population, &init_params, &fit_options)
+    // Retryable, because the thing `fit()` most plausibly fails on here is the
+    // machine rather than the model: `install_on_fit_pool` returns `Err` when a
+    // pool cannot be built, and the model-shaped bad outcome — a fit that
+    // finishes without converging — is an `Ok` judged by the strictness gate,
+    // not an error at all.
+    fit(&parsed.model, &population, &init_params, &fit_options).map_err(CandidateError::environment)
 }
 
 #[cfg(test)]

--- a/crates/ferx-tools/src/search/runner.rs
+++ b/crates/ferx-tools/src/search/runner.rs
@@ -1,0 +1,531 @@
+//! The shared candidate runner (#1178): fit N candidates in parallel,
+//! deduplicate, cache, journal, and report every one of them.
+//!
+//! Every tool in the #1175 search epic — covsearch, modelsearch, iivsearch,
+//! ruvsearch — is *generate candidates → fit them → rank them*, and the middle
+//! verb is the same code four times over. This is that code once.
+//!
+//! # What the runner is responsible for
+//!
+//! * **Identity.** A candidate is its rendered model text, keyed by
+//!   [`ModelText::canonical_hash`](ferx_core::edit::ModelText::canonical_hash).
+//!   Two candidates the search reached by different step orders render to the
+//!   same canonical text and are fitted **once** — pyDarwin's "model
+//!   uniqueness", for free, and the same key the journal and the fit cache use.
+//! * **Parallelism that does not oversubscribe.** Candidates are embarrassingly
+//!   parallel and `fit()` already `par_iter`s over subjects, so a naive outer
+//!   `par_iter` nests two pools competing for the same workers. The split is a
+//!   [`PoolPlan`] (#1115), which also gives the outer pool the ferx worker stack
+//!   rather than Rayon's 2 MiB default.
+//! * **Retries before the gate.** Each candidate is fitted with
+//!   [`RunOptions::n_starts`] starts, and only then judged by
+//!   [`check_strictness`]. Under automation an init stall (#751) or an inner-EBE
+//!   mode (#864, #891) is a *model-selection* error: it ranks a model on an OFV
+//!   that says nothing about the model.
+//! * **Nothing is dropped silently.** A candidate that failed to compile,
+//!   failed to fit or failed the gate comes back with its reason attached and
+//!   appears in `candidates.csv`.
+//! * **Resume.** With a cache directory, each outcome is journalled as it
+//!   finishes and a resumed run refits only what is missing — see
+//!   [`super::journal`].
+//! * **Cancellation.** A flipped [`CancelFlag`] stops the run *between*
+//!   candidates and returns what finished, with [`RunReport::cancelled`] set.
+//!
+//! # What it is not responsible for
+//!
+//! Generating candidates, deciding which to keep, and the step logic on top —
+//! those are the individual search tools. The runner takes a list and returns
+//! the same list scored.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
+use ferx_core::cancel::is_cancelled;
+use ferx_core::parser::model_parser::parse_full_model;
+use ferx_core::{
+    bind_theta_levels, check_strictness, fit, CancelFlag, FitResult, GradientMethod, PoolPlan,
+    Population, StrictnessVerdict,
+};
+use rayon::prelude::*;
+
+use super::candidate::{Candidate, CandidateResult, RunOptions};
+use super::journal::{self, CandidateRecord, Journal, SearchManifest};
+use super::output;
+
+/// What one [`Runner::run`] did.
+#[derive(Debug, Clone)]
+pub struct RunReport {
+    /// One entry per candidate, in the order they were submitted — minus any
+    /// the run never reached because it was cancelled.
+    pub results: Vec<CandidateResult>,
+    /// The run stopped early on a flipped [`CancelFlag`]; `results` is partial.
+    pub cancelled: bool,
+    /// Candidates actually fitted in this run.
+    pub fitted: usize,
+    /// Candidates whose outcome came from the journal.
+    pub reused: usize,
+    /// Candidates that shared another candidate's canonical text and were
+    /// therefore not fitted — the fits this run did not have to run.
+    pub deduped: usize,
+}
+
+impl RunReport {
+    /// The eligible result with the lowest criterion — every
+    /// [`Criterion`](super::Criterion) is lower-is-better — or `None` when
+    /// nothing passed the gate.
+    ///
+    /// Ties go to the earlier candidate, so a search that generates its
+    /// candidates in a deterministic order gets a deterministic winner.
+    pub fn best(&self) -> Option<&CandidateResult> {
+        self.results
+            .iter()
+            .filter(|r| r.eligible())
+            .min_by(|a, b| a.criterion.total_cmp(&b.criterion))
+    }
+}
+
+/// The runner: a thread budget, an optional cache directory, an optional
+/// cancellation flag.
+///
+/// ```no_run
+/// use ferx_tools::search::{Candidate, RunOptions, Runner};
+/// # fn demo(candidates: Vec<Candidate>, data: &ferx_core::Population) -> Result<(), String> {
+/// let report = Runner::new()
+///     .threads(8)
+///     .cache_dir(".ferx-search")
+///     .run(&candidates, data, &RunOptions::default())?;
+/// println!("{} fitted, {} reused, {} deduped", report.fitted, report.reused, report.deduped);
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct Runner {
+    threads: usize,
+    cache_dir: Option<PathBuf>,
+    cancel: Option<CancelFlag>,
+}
+
+impl Runner {
+    /// A runner on the engine's default thread budget, with no cache directory
+    /// (so no journal, no resume and no `candidates.csv`) and no cancellation.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Total worker threads across both levels of parallelism. `0` — the
+    /// default — means the engine default, i.e. whatever an unpinned `fit()`
+    /// would run on. See [`PoolPlan::from_budget`] for how the budget splits.
+    pub fn threads(mut self, threads: usize) -> Self {
+        self.threads = threads;
+        self
+    }
+
+    /// Where the journal, the fit cache and `candidates.csv` are written.
+    /// Without one the run holds everything in memory and is not resumable.
+    pub fn cache_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.cache_dir = Some(dir.into());
+        self
+    }
+
+    /// The flag that stops the run between candidates. It is also handed to
+    /// each `fit()`, so a long individual fit unwinds rather than running to
+    /// completion after the user has asked to stop.
+    pub fn cancel(mut self, flag: CancelFlag) -> Self {
+        self.cancel = Some(flag);
+        self
+    }
+
+    /// Fit every candidate against `data` and return them scored.
+    ///
+    /// Each candidate's model text is parsed on its own, bound to the data
+    /// (`theta NAME[COL]` level counts and symbolic `[covariate_model]`
+    /// statistics), and fitted from its own `[fit_options]` with the runner's
+    /// quiet / thread / start / cancel overrides applied on top.
+    ///
+    /// # Errors
+    ///
+    /// Only for failures of the *run*, not of a candidate: duplicate candidate
+    /// ids, an unusable cache directory, an incompatible resume. A candidate
+    /// that does not compile or does not fit is a [`CandidateResult`] carrying
+    /// the reason.
+    pub fn run(
+        &self,
+        candidates: &[Candidate],
+        data: &Population,
+        options: &RunOptions,
+    ) -> Result<RunReport, String> {
+        self.run_with_fitter(candidates, data, options, |candidate, threads_per_fit| {
+            compile_and_fit(candidate, data, options, threads_per_fit, &self.cancel)
+        })
+    }
+
+    /// The body of [`run`](Self::run), with the fit itself injected.
+    ///
+    /// The seam exists so the orchestration — dedup, thread budget, journal,
+    /// resume, cancellation — can be tested against a fitter that counts its
+    /// callers instead of against real fits, which would put every one of those
+    /// tests in the slow tier and make the concurrency assertion untestable
+    /// (there is no way to observe "two fits are in flight" from outside
+    /// `fit()`).
+    fn run_with_fitter<F>(
+        &self,
+        candidates: &[Candidate],
+        data: &Population,
+        options: &RunOptions,
+        fitter: F,
+    ) -> Result<RunReport, String>
+    where
+        F: Fn(&Candidate, usize) -> Result<FitResult, String> + Sync,
+    {
+        reject_duplicate_ids(candidates)?;
+
+        // ── identity ────────────────────────────────────────────────────────
+        // The representative of a hash is the first candidate that carries it;
+        // every later one is a duplicate and is never fitted.
+        let hashes: Vec<String> = candidates.iter().map(Candidate::hash).collect();
+        let mut representative: HashMap<&str, usize> = HashMap::new();
+        let mut duplicate_of: Vec<Option<usize>> = vec![None; candidates.len()];
+        for (i, hash) in hashes.iter().enumerate() {
+            match representative.get(hash.as_str()) {
+                Some(&first) => duplicate_of[i] = Some(first),
+                None => {
+                    representative.insert(hash.as_str(), i);
+                }
+            }
+        }
+        let deduped = duplicate_of.iter().filter(|d| d.is_some()).count();
+
+        // ── resume ──────────────────────────────────────────────────────────
+        let manifest = SearchManifest::new(options, data);
+        let kept = match (&self.cache_dir, options.resume) {
+            (Some(dir), true) => load_resumable(dir, &manifest)?,
+            _ => Vec::new(),
+        };
+        let reused: HashMap<&str, &CandidateRecord> = kept
+            .iter()
+            .map(|record| (record.hash.as_str(), record))
+            .collect();
+
+        // Checked before the journal is opened, not after: opening it rewrites
+        // the journal file, and a run cancelled before it started must not be
+        // what truncates the previous run's recovery data.
+        if is_cancelled(&self.cancel) {
+            return Ok(RunReport {
+                results: Vec::new(),
+                cancelled: true,
+                fitted: 0,
+                reused: 0,
+                deduped: 0,
+            });
+        }
+
+        // ── the journal ─────────────────────────────────────────────────────
+        // Opened before the first fit so that a kill at any point from here on
+        // leaves a directory the next resume can read.
+        let journal = match &self.cache_dir {
+            Some(dir) => {
+                let j = Journal::create(dir, &kept)?;
+                manifest.write(&journal::manifest_path(dir))?;
+                Some(j)
+            }
+            None => None,
+        };
+
+        // ── what has to be fitted ───────────────────────────────────────────
+        let todo: Vec<usize> = (0..candidates.len())
+            .filter(|i| duplicate_of[*i].is_none())
+            .filter(|i| !reused.contains_key(hashes[*i].as_str()))
+            .collect();
+
+        let plan = PoolPlan::from_budget(self.threads, todo.len());
+        let threads_per_fit = plan.threads_per_fit();
+        let n_fitted = AtomicUsize::new(0);
+
+        let fit_one = |&i: &usize| -> Option<(usize, CandidateResult)> {
+            // Between candidates, not inside one: this is the granularity the
+            // cancellation contract promises, and it is why a cancelled run can
+            // still return everything that finished.
+            if is_cancelled(&self.cancel) {
+                return None;
+            }
+            let candidate = &candidates[i];
+            let started = Instant::now();
+            let outcome = fitter(candidate, threads_per_fit);
+            let seconds = started.elapsed().as_secs_f64();
+            let result = match outcome {
+                Ok(fitted) => {
+                    let verdict = check_strictness(&fitted, &options.strictness);
+                    let criterion = options.criterion.of(&fitted);
+                    CandidateResult {
+                        id: candidate.id.clone(),
+                        hash: hashes[i].clone(),
+                        parent: candidate.parent.clone(),
+                        features: candidate.features.clone(),
+                        fit: Some(fitted),
+                        verdict,
+                        criterion,
+                        seconds,
+                        error: None,
+                        duplicate_of: None,
+                        reused: false,
+                    }
+                }
+                // A fit that failed while the flag was set cannot be told apart
+                // from one the flag itself unwound, so it is dropped rather
+                // than journalled — journalling it would make the next resume
+                // carry a failure forward that was never the candidate's.
+                Err(_) if is_cancelled(&self.cancel) => return None,
+                Err(e) => CandidateResult {
+                    id: candidate.id.clone(),
+                    hash: hashes[i].clone(),
+                    parent: candidate.parent.clone(),
+                    features: candidate.features.clone(),
+                    fit: None,
+                    verdict: failed_verdict(&e),
+                    criterion: f64::NAN,
+                    seconds,
+                    error: Some(e),
+                    duplicate_of: None,
+                    reused: false,
+                },
+            };
+            if let Some(j) = &journal {
+                j.append(&record_of(&result), result.fit.as_ref());
+            }
+            n_fitted.fetch_add(1, Ordering::Relaxed);
+            Some((i, result))
+        };
+
+        let fitted: Vec<(usize, CandidateResult)> = if todo.is_empty() {
+            Vec::new()
+        } else {
+            plan.install(|| todo.par_iter().filter_map(fit_one).collect())?
+        };
+
+        // Closed before the table is written, and the point at which a write
+        // failure inside the parallel loop surfaces.
+        if let Some(j) = journal {
+            j.into_result()?;
+        }
+
+        // ── assembly, in submission order ───────────────────────────────────
+        let mut by_index: HashMap<usize, CandidateResult> = fitted.into_iter().collect();
+        let mut outcomes: HashMap<usize, CandidateResult> = HashMap::new();
+        let mut n_reused = 0usize;
+        for i in (0..candidates.len()).filter(|i| duplicate_of[*i].is_none()) {
+            if let Some(result) = by_index.remove(&i) {
+                outcomes.insert(i, result);
+            } else if let Some(record) = reused.get(hashes[i].as_str()) {
+                n_reused += 1;
+                outcomes.insert(
+                    i,
+                    reused_result(&candidates[i], record, self.cache_dir.as_deref()),
+                );
+            }
+        }
+
+        let mut results = Vec::with_capacity(candidates.len());
+        for i in 0..candidates.len() {
+            match duplicate_of[i] {
+                None => {
+                    if let Some(result) = outcomes.get(&i) {
+                        results.push(result.clone());
+                    }
+                }
+                // A duplicate carries the representative's verdict and
+                // criterion but not its `FitResult`: the fit is one object and
+                // cloning it per duplicate would cost more than the answer is
+                // worth. `duplicate_of` names where to find it.
+                Some(first) => {
+                    if let Some(source) = outcomes.get(&first) {
+                        results.push(CandidateResult {
+                            id: candidates[i].id.clone(),
+                            hash: hashes[i].clone(),
+                            parent: candidates[i].parent.clone(),
+                            features: candidates[i].features.clone(),
+                            fit: None,
+                            verdict: source.verdict.clone(),
+                            criterion: source.criterion,
+                            seconds: 0.0,
+                            error: source.error.clone(),
+                            duplicate_of: Some(source.id.clone()),
+                            reused: source.reused,
+                        });
+                    }
+                }
+            }
+        }
+
+        if let Some(dir) = &self.cache_dir {
+            output::write_table(dir, &results)?;
+        }
+
+        Ok(RunReport {
+            results,
+            cancelled: is_cancelled(&self.cancel),
+            fitted: n_fitted.load(Ordering::Relaxed),
+            reused: n_reused,
+            deduped,
+        })
+    }
+}
+
+/// Ids are how a search refers back to its candidates and how the table is
+/// keyed, so two candidates sharing one is a bug in the caller, not something
+/// to paper over by renaming.
+fn reject_duplicate_ids(candidates: &[Candidate]) -> Result<(), String> {
+    let mut seen: HashSet<&str> = HashSet::with_capacity(candidates.len());
+    for candidate in candidates {
+        if candidate.id.trim().is_empty() {
+            return Err("a candidate has an empty id".to_string());
+        }
+        if !seen.insert(candidate.id.as_str()) {
+            return Err(format!(
+                "two candidates share the id `{}`; ids must be unique within one run",
+                candidate.id
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// The verdict of a candidate that produced no fit at all. Not `passed`, and
+/// the reason is the failure itself.
+fn failed_verdict(error: &str) -> StrictnessVerdict {
+    StrictnessVerdict {
+        passed: false,
+        failures: vec![format!("no fit: {error}")],
+        skipped: Vec::new(),
+    }
+}
+
+fn record_of(result: &CandidateResult) -> CandidateRecord {
+    CandidateRecord {
+        id: result.id.clone(),
+        hash: result.hash.clone(),
+        parent: result.parent.clone(),
+        features: result.features.clone(),
+        criterion: result.criterion.is_finite().then_some(result.criterion),
+        ofv: result
+            .fit
+            .as_ref()
+            .map(|f| f.ofv)
+            .filter(|ofv| ofv.is_finite()),
+        converged: result.fit.as_ref().is_some_and(|f| f.converged),
+        passed: result.verdict.passed,
+        failures: result.verdict.failures.clone(),
+        skipped: result.verdict.skipped.clone(),
+        seconds: result.seconds,
+        error: result.error.clone(),
+        has_fit: result.fit.is_some(),
+    }
+}
+
+/// Rebuild a result from a journalled row, loading the cached fit when it is
+/// still readable. A missing cache file costs the `FitResult`, not the row.
+fn reused_result(
+    candidate: &Candidate,
+    record: &CandidateRecord,
+    dir: Option<&Path>,
+) -> CandidateResult {
+    let fit = match (record.has_fit, dir) {
+        (true, Some(dir)) => journal::load_fit(dir, &record.hash),
+        _ => None,
+    };
+    CandidateResult {
+        id: candidate.id.clone(),
+        hash: record.hash.clone(),
+        parent: candidate.parent.clone(),
+        features: candidate.features.clone(),
+        fit,
+        verdict: StrictnessVerdict {
+            passed: record.passed,
+            failures: record.failures.clone(),
+            skipped: record.skipped.clone(),
+        },
+        criterion: record.criterion.unwrap_or(f64::NAN),
+        seconds: record.seconds,
+        error: record.error.clone(),
+        duplicate_of: None,
+        reused: true,
+    }
+}
+
+/// Read an interrupted run's finished candidates back out of its directory.
+///
+/// Anything dropped here is simply refitted, so the read errs towards dropping.
+/// The one unsafe outcome is *keeping* a row that does not belong to this run,
+/// which is what [`SearchManifest::check_compatible`] rules out.
+fn load_resumable(dir: &Path, manifest: &SearchManifest) -> Result<Vec<CandidateRecord>, String> {
+    let manifest_path = journal::manifest_path(dir);
+    if !manifest_path.exists() {
+        // Nothing to be incompatible with — a directory that was never written
+        // resumes as an empty run rather than failing.
+        return Ok(Vec::new());
+    }
+    let disk = SearchManifest::read(&manifest_path)?;
+    manifest.check_compatible(&disk, dir)?;
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut kept = Vec::new();
+    for record in journal::read_records(&journal::journal_path(dir)) {
+        // A hash appearing twice — two runs over the same directory — keeps the
+        // first row, so a resume is not sensitive to the order of the log.
+        if seen.insert(record.hash.clone()) {
+            kept.push(record);
+        }
+    }
+    Ok(kept)
+}
+
+/// Compile one candidate against the data and fit it.
+///
+/// The population is cloned per candidate because binding mutates it:
+/// `theta NAME[COL]` synthesizes a per-record level-index column (#1064), and
+/// the binder that does it takes `&mut Population`. A candidate whose model has
+/// no such block is unchanged by the clone, but the runner cannot know that
+/// without compiling first, and a shared mutable population across concurrent
+/// candidates would be a data race by construction.
+fn compile_and_fit(
+    candidate: &Candidate,
+    data: &Population,
+    options: &RunOptions,
+    threads_per_fit: usize,
+    cancel: &Option<CancelFlag>,
+) -> Result<FitResult, String> {
+    let text = candidate.model.render();
+    let mut parsed = parse_full_model(&text)
+        .map_err(|e| format!("candidate `{}` does not compile: {e}", candidate.id))?;
+    let mut population = data.clone();
+    bind_theta_levels(&mut parsed, &text, &mut population)?;
+    ferx_core::api::bind_covariate_stats(&mut parsed, &text, &population)?;
+
+    // The caller's settings replace the file's wholesale when given; the four
+    // overrides below are the runner's own and always win.
+    let base = options
+        .fit_options
+        .clone()
+        .unwrap_or_else(|| parsed.fit_options.clone());
+
+    // Mirrors `prepare_run`: the file's `gradient = ...` reaches the engine
+    // through `model.gradient_method`, and an SDE model is forced to FD.
+    parsed.model.gradient_method = if parsed.model.is_sde() {
+        GradientMethod::Fd
+    } else {
+        base.gradient_method
+    };
+
+    let init_params = parsed.model.default_params.clone();
+    let mut fit_options = base.quiet();
+    fit_options.n_starts = options.n_starts.max(1);
+    fit_options.threads = Some(threads_per_fit);
+    fit_options.cancel = cancel.clone();
+
+    fit(&parsed.model, &population, &init_params, &fit_options)
+}
+
+#[cfg(test)]
+#[path = "runner_tests.rs"]
+mod tests;

--- a/crates/ferx-tools/src/search/runner.rs
+++ b/crates/ferx-tools/src/search/runner.rs
@@ -27,9 +27,17 @@
 //!   appears in `candidates.csv`.
 //! * **Resume.** With a cache directory, each outcome is journalled as it
 //!   finishes and a resumed run refits only what is missing — see
-//!   [`super::journal`].
+//!   [`super::journal`]. The directory is claimed for the length of the run
+//!   ([`journal::DirLock`]), because two runs sharing one silently destroy each
+//!   other's journal.
 //! * **Cancellation.** A flipped [`CancelFlag`] stops the run *between*
 //!   candidates and returns what finished, with [`RunReport::cancelled`] set.
+//!   Its partial rows go to `candidates.partial.csv`, never over the complete
+//!   `candidates.csv` a resumed run may already have.
+//! * **The results outrank the files.** The journal and the table are *derived*
+//!   from the results, so a directory that cannot be written costs the resume
+//!   and the report, not the fits: those failures come back in
+//!   [`RunReport::warnings`] with the run intact.
 //!
 //! # What it is not responsible for
 //!
@@ -37,6 +45,7 @@
 //! those are the individual search tools. The runner takes a list and returns
 //! the same list scored.
 
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -69,6 +78,17 @@ pub struct RunReport {
     /// Candidates that shared another candidate's canonical text and were
     /// therefore not fitted — the fits this run did not have to run.
     pub deduped: usize,
+    /// Non-fatal problems: a journal row that could not be written, a table
+    /// that could not be rewritten.
+    ///
+    /// Everything the cache directory holds is *derived* from `results` — the
+    /// journal is a recovery log and `candidates.csv` is a report — so a
+    /// failure to write one is not a reason to throw away the fits themselves.
+    /// A disk that fills on candidate 3 of 500 used to lose the two that had
+    /// finished and every one still running; now it costs the resume, and says
+    /// so here. Collected rather than printed, per the crate's warning
+    /// convention.
+    pub warnings: Vec<String>,
 }
 
 impl RunReport {
@@ -197,10 +217,27 @@ impl Runner {
         }
         let deduped = duplicate_of.iter().filter(|d| d.is_some()).count();
 
+        // ── the directory ───────────────────────────────────────────────────
+        // Claimed before anything is read from it, since the resume read and
+        // the journal rewrite that follows it have to be one transaction with
+        // respect to another run. Dropped — and the lock file removed — on
+        // every path out of this function, including the early cancel below.
+        let _lock = match &self.cache_dir {
+            Some(dir) => Some(journal::DirLock::acquire(dir)?),
+            None => None,
+        };
+
         // ── resume ──────────────────────────────────────────────────────────
-        let manifest = SearchManifest::new(options, data);
-        let kept = match (&self.cache_dir, options.resume) {
-            (Some(dir), true) => load_resumable(dir, &manifest)?,
+        // Built only when there is a directory to write it to: the manifest
+        // fingerprints the *whole dataset* — a SHA-256 over every field of
+        // every subject — so computing one for a cacheless run would hash
+        // hundreds of megabytes for a value nothing reads.
+        let manifest = self
+            .cache_dir
+            .as_ref()
+            .map(|_| SearchManifest::new(options, data));
+        let kept = match (&self.cache_dir, &manifest, options.resume) {
+            (Some(dir), Some(manifest), true) => load_resumable(dir, manifest)?,
             _ => Vec::new(),
         };
         let reused: HashMap<&str, &CandidateRecord> = kept
@@ -218,19 +255,20 @@ impl Runner {
                 fitted: 0,
                 reused: 0,
                 deduped: 0,
+                warnings: Vec::new(),
             });
         }
 
         // ── the journal ─────────────────────────────────────────────────────
         // Opened before the first fit so that a kill at any point from here on
         // leaves a directory the next resume can read.
-        let journal = match &self.cache_dir {
-            Some(dir) => {
+        let journal = match (&self.cache_dir, &manifest) {
+            (Some(dir), Some(manifest)) => {
                 let j = Journal::create(dir, &kept)?;
                 manifest.write(&journal::manifest_path(dir))?;
                 Some(j)
             }
-            None => None,
+            _ => None,
         };
 
         // ── what has to be fitted ───────────────────────────────────────────
@@ -258,12 +296,15 @@ impl Runner {
                 Ok(fitted) => {
                     let verdict = check_strictness(&fitted, &options.strictness);
                     let criterion = options.criterion.of(&fitted);
+                    let (ofv, converged) = (Some(fitted.ofv), Some(fitted.converged));
                     CandidateResult {
                         id: candidate.id.clone(),
                         hash: hashes[i].clone(),
                         parent: candidate.parent.clone(),
                         features: candidate.features.clone(),
                         fit: Some(fitted),
+                        ofv,
+                        converged,
                         verdict,
                         criterion,
                         seconds,
@@ -283,6 +324,8 @@ impl Runner {
                     parent: candidate.parent.clone(),
                     features: candidate.features.clone(),
                     fit: None,
+                    ofv: None,
+                    converged: None,
                     verdict: failed_verdict(&e),
                     criterion: f64::NAN,
                     seconds,
@@ -305,9 +348,17 @@ impl Runner {
         };
 
         // Closed before the table is written, and the point at which a write
-        // failure inside the parallel loop surfaces.
+        // failure inside the parallel loop surfaces. It is a *warning*, not a
+        // run failure: the journal exists so a future run need not repeat these
+        // fits, and returning `Err` here would throw away the very fits it
+        // failed to protect.
+        let mut warnings: Vec<String> = Vec::new();
         if let Some(j) = journal {
-            j.into_result()?;
+            if let Err(e) = j.into_result() {
+                warnings.push(format!(
+                    "the search journal could not be written, so this run is not resumable: {e}"
+                ));
+            }
         }
 
         // ── assembly, in submission order ───────────────────────────────────
@@ -346,6 +397,8 @@ impl Runner {
                             parent: candidates[i].parent.clone(),
                             features: candidates[i].features.clone(),
                             fit: None,
+                            ofv: source.ofv,
+                            converged: source.converged,
                             verdict: source.verdict.clone(),
                             criterion: source.criterion,
                             seconds: 0.0,
@@ -358,16 +411,31 @@ impl Runner {
             }
         }
 
+        // A cancelled run's rows are partial, and `candidates.csv` is rewritten
+        // from scratch — so writing them there would have a run cancelled two
+        // candidates into a resume replace the complete table of the run it
+        // resumed with a two-row one. The partial goes to a file of its own.
+        let cancelled = is_cancelled(&self.cancel);
         if let Some(dir) = &self.cache_dir {
-            output::write_table(dir, &results)?;
+            let written = if cancelled {
+                output::write_partial_table(dir, &results)
+            } else {
+                output::write_table(dir, &results)
+            };
+            // Same reasoning as the journal above: the table is derived from
+            // `results`, which the caller is about to receive either way.
+            if let Err(e) = written {
+                warnings.push(format!("the candidate table could not be written: {e}"));
+            }
         }
 
         Ok(RunReport {
             results,
-            cancelled: is_cancelled(&self.cancel),
+            cancelled,
             fitted: n_fitted.load(Ordering::Relaxed),
             reused: n_reused,
             deduped,
+            warnings,
         })
     }
 }
@@ -408,12 +476,8 @@ fn record_of(result: &CandidateResult) -> CandidateRecord {
         parent: result.parent.clone(),
         features: result.features.clone(),
         criterion: result.criterion.is_finite().then_some(result.criterion),
-        ofv: result
-            .fit
-            .as_ref()
-            .map(|f| f.ofv)
-            .filter(|ofv| ofv.is_finite()),
-        converged: result.fit.as_ref().is_some_and(|f| f.converged),
+        ofv: result.ofv.filter(|ofv| ofv.is_finite()),
+        converged: result.converged.unwrap_or(false),
         passed: result.verdict.passed,
         failures: result.verdict.failures.clone(),
         skipped: result.verdict.skipped.clone(),
@@ -424,7 +488,9 @@ fn record_of(result: &CandidateResult) -> CandidateRecord {
 }
 
 /// Rebuild a result from a journalled row, loading the cached fit when it is
-/// still readable. A missing cache file costs the `FitResult`, not the row.
+/// still readable. A missing cache file costs the `FitResult`, not the row —
+/// including the row's `ofv` and `converged`, which are carried across from the
+/// journal rather than read back off the fit that may be gone.
 fn reused_result(
     candidate: &Candidate,
     record: &CandidateRecord,
@@ -440,6 +506,8 @@ fn reused_result(
         parent: candidate.parent.clone(),
         features: candidate.features.clone(),
         fit,
+        ofv: record.ofv,
+        converged: record.has_fit.then_some(record.converged),
         verdict: StrictnessVerdict {
             passed: record.passed,
             failures: record.failures.clone(),
@@ -471,6 +539,20 @@ fn load_resumable(dir: &Path, manifest: &SearchManifest) -> Result<Vec<Candidate
     let mut seen: HashSet<String> = HashSet::new();
     let mut kept = Vec::new();
     for record in journal::read_records(&journal::journal_path(dir)) {
+        // A row with an `error` is not reused. `error` means the candidate
+        // produced no fit at all, and the runner cannot tell *why* from here:
+        // a model that does not compile fails the same way as one whose fit
+        // hit a transient resource limit — `install_on_fit_pool` returns `Err`
+        // when the machine is briefly out of threads. Carrying that forward
+        // would have one bad minute permanently mark a fittable model as
+        // unfittable in every later resume. Refitting a genuinely broken
+        // candidate costs a parse; believing a false failure costs the search.
+        //
+        // Filtered *before* the dedup below, or an error row would consume the
+        // hash and hide the successful refit appended after it.
+        if record.error.is_some() {
+            continue;
+        }
         // A hash appearing twice — two runs over the same directory — keeps the
         // first row, so a resume is not sensitive to the order of the log.
         if seen.insert(record.hash.clone()) {
@@ -482,12 +564,16 @@ fn load_resumable(dir: &Path, manifest: &SearchManifest) -> Result<Vec<Candidate
 
 /// Compile one candidate against the data and fit it.
 ///
-/// The population is cloned per candidate because binding mutates it:
-/// `theta NAME[COL]` synthesizes a per-record level-index column (#1064), and
-/// the binder that does it takes `&mut Population`. A candidate whose model has
-/// no such block is unchanged by the clone, but the runner cannot know that
-/// without compiling first, and a shared mutable population across concurrent
-/// candidates would be a data race by construction.
+/// The population is cloned per candidate **only when binding actually mutates
+/// it**: `theta NAME[COL]` synthesizes a per-record level-index column (#1064),
+/// and the binder that does it takes `&mut Population`, so a shared mutable
+/// population across concurrent candidates would be a data race by
+/// construction. But a model with no level block is left untouched by that
+/// binder — it early-returns on the same emptiness test as the `Cow` below —
+/// and `bind_covariate_stats` only ever reads. Cloning unconditionally put one
+/// copy of the dataset per in-flight candidate on top of the one `fit()` may
+/// make for itself (`api/fit.rs` is `Cow` for the same reason), so a 16-wide
+/// plan held up to 32 copies of data nothing was going to modify.
 fn compile_and_fit(
     candidate: &Candidate,
     data: &Population,
@@ -498,8 +584,10 @@ fn compile_and_fit(
     let text = candidate.model.render();
     let mut parsed = parse_full_model(&text)
         .map_err(|e| format!("candidate `{}` does not compile: {e}", candidate.id))?;
-    let mut population = data.clone();
-    bind_theta_levels(&mut parsed, &text, &mut population)?;
+    let mut population = Cow::Borrowed(data);
+    if !parsed.model.theta_blocks().level_blocks().is_empty() {
+        bind_theta_levels(&mut parsed, &text, population.to_mut())?;
+    }
     ferx_core::api::bind_covariate_stats(&mut parsed, &text, &population)?;
 
     // The caller's settings replace the file's wholesale when given; the four

--- a/crates/ferx-tools/src/search/runner.rs
+++ b/crates/ferx-tools/src/search/runner.rs
@@ -509,8 +509,18 @@ fn compile_and_fit(
         .clone()
         .unwrap_or_else(|| parsed.fit_options.clone());
 
-    // Mirrors `prepare_run`: the file's `gradient = ...` reaches the engine
-    // through `model.gradient_method`, and an SDE model is forced to FD.
+    // Two `FitOptions` keys reach the engine through the *model* rather than
+    // through the options, so an override that only lands in `fit_options` is an
+    // override the fit does not see. `fit_from_files` stamps both; so does this.
+    //
+    // `bloq_method` is the one that bites: the censored-data likelihood reads
+    // `model.bloq_method`, so a candidate run with an override from `drop` to
+    // `m3` (or back) would report the requested setting and score the other
+    // one's likelihood — a wrong ranking, silently. Parsing already stamps the
+    // *file's* value, which is why this is invisible until a caller supplies
+    // `RunOptions::fit_options`.
+    parsed.model.bloq_method = base.bloq_method;
+    // And the file's `gradient = ...`, with an SDE model forced to FD.
     parsed.model.gradient_method = if parsed.model.is_sde() {
         GradientMethod::Fd
     } else {

--- a/crates/ferx-tools/src/search/runner_tests.rs
+++ b/crates/ferx-tools/src/search/runner_tests.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use ferx_core::{BicType, Strictness};
+use ferx_core::{BicType, EstimationMethod, FitOptions, Strictness};
 
 use super::*;
 use crate::search::candidate::{Candidate, Criterion, FeatureVector, RunOptions};
@@ -53,6 +53,18 @@ impl Recorder {
         let mut ids = self.calls.lock().unwrap().clone();
         ids.sort();
         ids
+    }
+}
+
+/// `expect_err` on a `Result<RunReport, _>` dumps every `FitResult` the report
+/// holds into the panic message — megabytes of noise around a one-line failure.
+fn expect_refusal(outcome: Result<RunReport, String>, what: &str) -> String {
+    match outcome {
+        Err(message) => message,
+        Ok(report) => panic!(
+            "{what}: the run was accepted ({} fitted, {} reused)",
+            report.fitted, report.reused
+        ),
     }
 }
 
@@ -122,11 +134,12 @@ fn duplicate_ids_are_rejected() {
         candidate("same", "[parameters]\ntheta CL = 1\n"),
         candidate("same", "[parameters]\ntheta CL = 2\n"),
     ];
-    let err = Runner::new()
-        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+    let err = expect_refusal(
+        Runner::new().run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
             Ok(converged_fit(1.0))
-        })
-        .expect_err("duplicate ids must be refused");
+        }),
+        "duplicate ids must be refused",
+    );
     assert!(err.contains("`same`"), "unhelpful message: {err}");
 }
 
@@ -545,12 +558,15 @@ fn a_resume_against_a_different_criterion_is_refused() {
         criterion: Criterion::Bic(BicType::Mixed),
         ..lenient()
     };
-    let err = Runner::new()
-        .cache_dir(dir.path())
-        .run_with_fitter(&candidates, &population(&["1"]), &options, |_, _| {
-            Ok(converged_fit(1.0))
-        })
-        .expect_err("resuming under another criterion must be refused");
+    let err = expect_refusal(
+        Runner::new().cache_dir(dir.path()).run_with_fitter(
+            &candidates,
+            &population(&["1"]),
+            &options,
+            |_, _| Ok(converged_fit(1.0)),
+        ),
+        "resuming under another criterion must be refused",
+    );
     assert!(
         err.contains("ranking criterion"),
         "unhelpful message: {err}"
@@ -567,13 +583,126 @@ fn a_resume_against_a_different_dataset_is_refused() {
         resume: true,
         ..lenient()
     };
-    let err = Runner::new()
+    let err = expect_refusal(
+        Runner::new().cache_dir(dir.path()).run_with_fitter(
+            &candidates,
+            &population(&["1", "2"]),
+            &options,
+            |_, _| Ok(converged_fit(1.0)),
+        ),
+        "resuming against other data must be refused",
+    );
+    assert!(err.contains("dataset"), "unhelpful message: {err}");
+}
+
+#[test]
+fn a_resume_against_the_same_shaped_but_edited_dataset_is_refused() {
+    // The dangerous case, because nothing about it *looks* different: same
+    // subject ids, same observation counts, one changed measurement. A
+    // fingerprint over the shape alone would reuse every candidate and return
+    // scores computed from the previous dataset.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+
+    let mut data = population(&["1", "2"]);
+    for subject in &mut data.subjects {
+        subject.obs_times = vec![1.0, 4.0];
+        subject.observations = vec![5.5, 2.5];
+        subject.obs_cmts = vec![1, 1];
+    }
+    Runner::new()
+        .threads(1)
         .cache_dir(dir.path())
-        .run_with_fitter(&candidates, &population(&["1", "2"]), &options, |_, _| {
+        .run_with_fitter(&candidates, &data, &lenient(), |_, _| {
             Ok(converged_fit(1.0))
         })
-        .expect_err("resuming against other data must be refused");
+        .expect("first run");
+
+    let mut edited = data.clone();
+    edited.subjects[1].observations[0] = 5.6;
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    let err = expect_refusal(
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(&candidates, &edited, &options, |_, _| {
+                Ok(converged_fit(1.0))
+            }),
+        "resuming against edited data must be refused",
+    );
     assert!(err.contains("dataset"), "unhelpful message: {err}");
+
+    // The premise, so the test cannot pass for the wrong reason: the edit did
+    // not change the shape the old fingerprint saw.
+    assert_eq!(edited.subjects.len(), data.subjects.len());
+    assert_eq!(
+        edited.subjects[1].observations.len(),
+        data.subjects[1].observations.len()
+    );
+}
+
+#[test]
+fn a_resume_under_different_fit_settings_is_refused() {
+    // A candidate's hash covers the `[fit_options]` in its own model text, but
+    // an override handed to the runner sits outside `ModelText` — so without
+    // the manifest's fit-settings fingerprint this resume would reuse scores
+    // produced under another method or iteration cap.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    let with = |method: EstimationMethod, resume: bool| {
+        let mut fit_options = FitOptions::default();
+        fit_options.method = method;
+        RunOptions {
+            fit_options: Some(fit_options),
+            resume,
+            ..lenient()
+        }
+    };
+
+    Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(
+            &candidates,
+            &population(&["1"]),
+            &with(EstimationMethod::FoceI, false),
+            |_, _| Ok(converged_fit(1.0)),
+        )
+        .expect("first run");
+
+    let err = expect_refusal(
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(
+                &candidates,
+                &population(&["1"]),
+                &with(EstimationMethod::Saem, true),
+                |_, _| Ok(converged_fit(1.0)),
+            ),
+        "resuming under other fit settings must be refused",
+    );
+    assert!(err.contains("fit settings"), "unhelpful message: {err}");
+
+    // The same settings still resume, so the gate is not simply refusing
+    // everything with an override.
+    let (report, _) = (
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(
+                &candidates,
+                &population(&["1"]),
+                &with(EstimationMethod::FoceI, true),
+                |_, _| panic!("a journalled candidate was refitted"),
+            )
+            .expect("resume under the original settings"),
+        (),
+    );
+    assert_eq!((report.fitted, report.reused), (0, 1));
 }
 
 #[test]

--- a/crates/ferx-tools/src/search/runner_tests.rs
+++ b/crates/ferx-tools/src/search/runner_tests.rs
@@ -319,7 +319,9 @@ fn a_failed_fit_is_reported_with_its_error() {
     let candidates = vec![candidate("broken", "[parameters]\ntheta CL = 1\n")];
     let report = Runner::new()
         .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
-            Err("does not compile: unknown block `[wat]`".to_string())
+            Err(CandidateError::model(
+                "does not compile: unknown block `[wat]`",
+            ))
         })
         .expect("run");
 
@@ -329,7 +331,7 @@ fn a_failed_fit_is_reported_with_its_error() {
     assert!(!result.verdict.passed);
     assert!(result.verdict.failures[0].contains("unknown block"));
     assert_eq!(
-        result.error.as_deref(),
+        result.error.as_ref().map(|e| e.message.as_str()),
         Some("does not compile: unknown block `[wat]`")
     );
     assert!(!result.eligible());
@@ -749,7 +751,7 @@ fn every_candidate_appears_in_the_table_in_submission_order() {
         .cache_dir(dir.path())
         .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
             match c.id.as_str() {
-                "broken" => Err("the model does not compile".to_string()),
+                "broken" => Err(CandidateError::model("the model does not compile")),
                 "bad" => {
                     let mut result = converged_fit(3.0);
                     result.converged = false;
@@ -897,34 +899,57 @@ fn a_completed_run_clears_the_partial_table_of_the_run_it_resumed() {
 
 // ── failures are not permanent ───────────────────────────────────────────────
 
-#[test]
-fn a_resume_refits_a_candidate_whose_first_run_errored() {
-    // `install_on_fit_pool` returns `Err` when the machine is briefly out of
-    // threads, and a compile failure returns `Err` too — from here the two are
-    // one string. Journalling the outcome as final would have one bad minute
-    // mark a perfectly fittable model unfittable in every later resume, with
-    // nothing to tell the user which kind of failure they were looking at.
-    let dir = tempfile::tempdir().expect("tempdir");
-    let candidates = vec![
+/// The three candidates a resume has to tell apart: one that fitted, one whose
+/// failure describes the machine, and one whose failure describes the model.
+fn ok_flaky_broken() -> Vec<Candidate> {
+    vec![
         candidate("ok", "[parameters]\ntheta CL = 1\n"),
         candidate("flaky", "[parameters]\ntheta CL = 2\n"),
-    ];
-    let first =
-        Runner::new()
-            .threads(1)
-            .cache_dir(dir.path())
-            .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |c, _| match c
-                .id
-                .as_str()
-            {
-                "flaky" => {
-                    Err("cannot build the fit pool: Resource temporarily unavailable".to_string())
-                }
+        candidate("broken", "[parameters]\ntheta CL = 3\n"),
+    ]
+}
+
+fn first_run_over(dir: &std::path::Path, candidates: &[Candidate]) -> RunReport {
+    Runner::new()
+        .threads(1)
+        .cache_dir(dir)
+        .run_with_fitter(
+            candidates,
+            &population(&["1"]),
+            &lenient(),
+            |c, _| match c.id.as_str() {
+                "flaky" => Err(CandidateError::environment(
+                    "cannot build the fit pool: Resource temporarily unavailable",
+                )),
+                "broken" => Err(CandidateError::model(
+                    "candidate `broken` does not compile: unknown block `[wat]`",
+                )),
                 _ => Ok(converged_fit(1.0)),
-            })
-            .expect("first run");
-    assert_eq!(first.results.len(), 2);
-    assert!(first.results[1].error.is_some());
+            },
+        )
+        .expect("first run")
+}
+
+#[test]
+fn a_resume_refits_an_environment_failure_and_trusts_a_model_failure() {
+    // The two `Err`s are one string from inside the runner, which is why the
+    // classification is made where the failure is raised. Journalling a pool
+    // that could not be built as final would have one bad minute mark a
+    // fittable model dead for the rest of the search's life; re-parsing a model
+    // that does not compile, on every resume, for ever, is the opposite waste.
+    //
+    // Both candidates are here so the pair straddles the predicate: a filter
+    // that dropped *every* error row, or none, agrees with the fix on one of
+    // them, and a test carrying only one would pass either way.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = ok_flaky_broken();
+    let first = first_run_over(dir.path(), &candidates);
+    assert_eq!(first.results.len(), 3);
+    assert!(first.results[1].error.as_ref().is_some_and(|e| e.retryable));
+    assert!(first.results[2]
+        .error
+        .as_ref()
+        .is_some_and(|e| !e.retryable));
 
     let recorder = Recorder::new();
     let options = RunOptions {
@@ -943,14 +968,20 @@ fn a_resume_refits_a_candidate_whose_first_run_errored() {
     assert_eq!(
         recorder.ids(),
         vec!["flaky"],
-        "the error row was carried forward"
+        "the resume refit the wrong set"
     );
-    assert_eq!((second.fitted, second.reused), (1, 1));
+    assert_eq!((second.fitted, second.reused), (1, 2));
     assert!(second.results[1].error.is_none());
     assert_eq!(second.results[1].ofv, Some(2.0));
+    // The model failure comes back with its reason rather than as a hole in the
+    // report — it is reused, not dropped.
+    let reused_failure = second.results[2].error.as_ref().expect("reason");
+    assert!(reused_failure.message.contains("unknown block"));
+    assert!(!reused_failure.retryable);
+    assert!(second.results[2].reused);
 
-    // A third resume reuses it, so the refit landed in the journal rather than
-    // the candidate being refitted for ever.
+    // A third resume reuses the refit too, so the successful retry landed in
+    // the journal rather than the candidate being refitted for ever.
     let third = Runner::new()
         .threads(1)
         .cache_dir(dir.path())
@@ -958,7 +989,48 @@ fn a_resume_refits_a_candidate_whose_first_run_errored() {
             panic!("`{}` was refitted after a successful run", c.id)
         })
         .expect("second resume");
-    assert_eq!((third.fitted, third.reused), (0, 2));
+    assert_eq!((third.fitted, third.reused), (0, 3));
+}
+
+#[test]
+fn a_journal_row_written_before_the_flag_existed_is_refitted() {
+    // `CandidateRecord::retryable` defaults to `true` on a row that predates
+    // the field, so an old journal refits its failures instead of believing
+    // them. The safe direction: a needless refit costs time, a wrongly trusted
+    // failure costs the candidate.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = ok_flaky_broken();
+    first_run_over(dir.path(), &candidates);
+
+    // Strip the field from every row, as a journal written by the previous
+    // version would have.
+    let path = journal::journal_path(dir.path());
+    let aged: String = std::fs::read_to_string(&path)
+        .expect("journal")
+        .lines()
+        .map(|line| {
+            let mut row: serde_json::Value = serde_json::from_str(line).expect("row");
+            row.as_object_mut().expect("object").remove("retryable");
+            format!("{row}\n")
+        })
+        .collect();
+    assert!(!aged.contains("retryable"), "the field survived the strip");
+    std::fs::write(&path, aged).expect("write");
+
+    let recorder = Recorder::new();
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
+            recorder.record(&c.id);
+            Ok(converged_fit(2.0))
+        })
+        .expect("resumed run");
+    assert_eq!(recorder.ids(), vec!["broken", "flaky"]);
 }
 
 // ── the shared population ────────────────────────────────────────────────────
@@ -1034,6 +1106,73 @@ fn a_second_run_over_a_live_directory_is_refused_by_name() {
         !journal::lock_path(dir.path()).exists(),
         "the run kept the lock"
     );
+}
+
+#[test]
+#[cfg(unix)]
+fn a_lock_left_behind_by_a_dead_process_is_taken_over() {
+    // Resuming after a hard kill is the case the journal exists for, and a hard
+    // kill releases no lock file — so a lock that had to be deleted by hand
+    // would break exactly the workflow the directory is built around.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+
+    // A pid that is not running. Spawning and reaping a real process is what
+    // makes this a *dead* pid rather than one that was never alive, which the
+    // takeover has to treat the same way but which a reader could dismiss.
+    let mut corpse = std::process::Command::new("true")
+        .spawn()
+        .expect("spawn a process to outlive");
+    let dead = corpse.id();
+    corpse.wait().expect("reap");
+    std::fs::create_dir_all(dir.path()).expect("dir");
+    std::fs::write(journal::lock_path(dir.path()), format!("pid {dead}\n")).expect("stale lock");
+
+    let report = Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            Ok(converged_fit(1.0))
+        })
+        .expect("a stale lock must not block a resume");
+    assert_eq!(report.fitted, 1);
+    assert!(!journal::lock_path(dir.path()).exists());
+
+    // The other side of the predicate: *this* process is running, so its lock
+    // is not stale and the same code path refuses instead of stealing.
+    std::fs::write(
+        journal::lock_path(dir.path()),
+        format!("pid {}\n", std::process::id()),
+    )
+    .expect("live lock");
+    let err = expect_refusal(
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+                Ok(converged_fit(1.0))
+            }),
+        "a live owner must not be stolen from",
+    );
+    assert!(err.contains("already in use"), "unhelpful message: {err}");
+    std::fs::remove_file(journal::lock_path(dir.path())).expect("cleanup");
+}
+
+#[test]
+fn a_lock_whose_owner_cannot_be_read_is_never_stolen() {
+    // Takeover is the only path that deletes another run's lock, so anything it
+    // cannot positively establish has to fall on the refusing side — an empty
+    // file (the write after `create_new` did not land) or a garbled one.
+    for contents in ["", "pid \n", "held by someone", "pid not-a-number"] {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(dir.path()).expect("dir");
+        std::fs::write(journal::lock_path(dir.path()), contents).expect("lock");
+        let err = journal::DirLock::acquire(dir.path())
+            .err()
+            .unwrap_or_else(|| panic!("`{contents:?}` was treated as stale"));
+        assert!(err.contains("already in use"), "unhelpful message: {err}");
+        assert!(journal::lock_path(dir.path()).exists());
+    }
 }
 
 #[test]

--- a/crates/ferx-tools/src/search/runner_tests.rs
+++ b/crates/ferx-tools/src/search/runner_tests.rs
@@ -806,3 +806,265 @@ fn the_default_options_retry_and_gate() {
     assert!(!options.resume);
     assert!(options.fit_options.is_none());
 }
+
+// ── the results outrank the files ────────────────────────────────────────────
+
+#[test]
+fn a_journal_that_cannot_be_written_warns_and_keeps_every_fit() {
+    // An overnight run that hits ENOSPC on candidate 3 of 500 used to return a
+    // `String` and nothing else: the fits already finished, and every one still
+    // in flight, went with it. The journal is a *recovery log* derived from the
+    // results — losing it costs the resume, not the run.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![
+        candidate("a", "[parameters]\ntheta CL = 1\n"),
+        candidate("b", "[parameters]\ntheta CL = 2\n"),
+    ];
+    // A plain file where the fit cache wants its directory: every `store_fit`
+    // then fails from inside the parallel loop, exactly as a full disk would.
+    std::fs::write(journal::fits_dir(dir.path()), b"not a directory").expect("blocker");
+
+    let report = Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            Ok(converged_fit(3.0))
+        })
+        .expect("a journal failure is not a run failure");
+
+    assert_eq!(report.results.len(), 2, "the finished fits were discarded");
+    assert_eq!(report.fitted, 2);
+    assert!(report.results.iter().all(|r| r.fit.is_some()));
+    assert_eq!(report.warnings.len(), 1, "{:?}", report.warnings);
+    assert!(
+        report.warnings[0].contains("not resumable"),
+        "unhelpful warning: {}",
+        report.warnings[0]
+    );
+    // …and the report the run *can* still write is written.
+    assert!(output::table_path(dir.path()).exists());
+}
+
+#[test]
+fn a_cancelled_run_does_not_overwrite_the_table_it_resumed() {
+    // `csv::Writer::from_path` truncates, so writing a cancelled run's partial
+    // rows to `candidates.csv` destroys the complete table of the run being
+    // resumed — the one human-readable artefact the module promises.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![
+        candidate("a", "[parameters]\ntheta CL = 1\n"),
+        candidate("b", "[parameters]\ntheta CL = 2\n"),
+        candidate("c", "[parameters]\ntheta CL = 3\n"),
+    ];
+    let (complete, _) = run_over(dir.path(), &candidates, &lenient());
+    assert_eq!(complete.results.len(), 3);
+    let table_before = std::fs::read_to_string(output::table_path(dir.path())).expect("table");
+
+    let flag = CancelFlag::new();
+    let report = Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .cancel(flag.clone())
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            flag.cancel();
+            Ok(converged_fit(1.0))
+        })
+        .expect("a cancelled run still reports");
+    assert!(report.cancelled);
+    assert!(
+        report.results.len() < 3,
+        "the run was not actually cut short"
+    );
+
+    assert_eq!(
+        std::fs::read_to_string(output::table_path(dir.path())).expect("table"),
+        table_before,
+        "the cancelled run overwrote the complete table"
+    );
+    // The partial rows are not thrown away either — they go beside it.
+    let partial = std::fs::read_to_string(output::partial_table_path(dir.path())).expect("partial");
+    assert_eq!(partial.lines().count(), report.results.len() + 1);
+}
+
+#[test]
+fn a_completed_run_clears_the_partial_table_of_the_run_it_resumed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    output::write_partial_table(dir.path(), &[]).expect("stale partial");
+    run_over(dir.path(), &candidates, &lenient());
+    assert!(!output::partial_table_path(dir.path()).exists());
+}
+
+// ── failures are not permanent ───────────────────────────────────────────────
+
+#[test]
+fn a_resume_refits_a_candidate_whose_first_run_errored() {
+    // `install_on_fit_pool` returns `Err` when the machine is briefly out of
+    // threads, and a compile failure returns `Err` too — from here the two are
+    // one string. Journalling the outcome as final would have one bad minute
+    // mark a perfectly fittable model unfittable in every later resume, with
+    // nothing to tell the user which kind of failure they were looking at.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![
+        candidate("ok", "[parameters]\ntheta CL = 1\n"),
+        candidate("flaky", "[parameters]\ntheta CL = 2\n"),
+    ];
+    let first =
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |c, _| match c
+                .id
+                .as_str()
+            {
+                "flaky" => {
+                    Err("cannot build the fit pool: Resource temporarily unavailable".to_string())
+                }
+                _ => Ok(converged_fit(1.0)),
+            })
+            .expect("first run");
+    assert_eq!(first.results.len(), 2);
+    assert!(first.results[1].error.is_some());
+
+    let recorder = Recorder::new();
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    let second = Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
+            recorder.record(&c.id);
+            Ok(converged_fit(2.0))
+        })
+        .expect("resumed run");
+
+    assert_eq!(
+        recorder.ids(),
+        vec!["flaky"],
+        "the error row was carried forward"
+    );
+    assert_eq!((second.fitted, second.reused), (1, 1));
+    assert!(second.results[1].error.is_none());
+    assert_eq!(second.results[1].ofv, Some(2.0));
+
+    // A third resume reuses it, so the refit landed in the journal rather than
+    // the candidate being refitted for ever.
+    let third = Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
+            panic!("`{}` was refitted after a successful run", c.id)
+        })
+        .expect("second resume");
+    assert_eq!((third.fitted, third.reused), (0, 2));
+}
+
+// ── the shared population ────────────────────────────────────────────────────
+
+#[test]
+fn a_model_with_no_level_block_leaves_the_population_untouched() {
+    // `compile_and_fit` skips its per-candidate `Population` clone on exactly
+    // the emptiness test `bind_theta_levels` early-returns on, and the two
+    // cannot be allowed to drift: if the binder ever mutated a population for a
+    // model with no level block, the runner would hand `fit()` an unbound one.
+    // Pinned on the binder rather than on the clone because the absence of a
+    // copy is not observable from outside.
+    let text = std::fs::read_to_string(crate::search::test_support::MODEL).expect("model source");
+    let mut parsed = ferx_core::parser::model_parser::parse_full_model(&text).expect("parse");
+    assert!(
+        parsed.model.theta_blocks().level_blocks().is_empty(),
+        "the fixture declares a level block, so it cannot test the skip"
+    );
+
+    let prepared = ferx_core::prepare_run(
+        crate::search::test_support::MODEL,
+        Some(crate::search::test_support::DATA),
+    )
+    .expect("warfarin model + data load");
+    let before = SearchManifest::new(&lenient(), &prepared.population).data_fingerprint;
+    let mut population = prepared.population.clone();
+    ferx_core::bind_theta_levels(&mut parsed, &text, &mut population).expect("bind");
+
+    assert_eq!(
+        SearchManifest::new(&lenient(), &population).data_fingerprint,
+        before,
+        "the binder mutated a population the runner now shares between candidates"
+    );
+}
+
+// ── one run per directory ────────────────────────────────────────────────────
+
+#[test]
+fn a_second_run_over_a_live_directory_is_refused_by_name() {
+    // Not a nicety: `Journal::create` renames a fresh file over
+    // `search_journal.jsonl`, so the run already appending keeps writing into
+    // an unlinked inode and every row it produces afterwards is gone, with
+    // nothing on disk to say so.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    let held = journal::DirLock::acquire(dir.path()).expect("lock");
+
+    let err = expect_refusal(
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+                panic!("nothing may be fitted while the directory is held")
+            }),
+        "a second run over a live directory must be refused",
+    );
+    assert!(err.contains("already in use"), "unhelpful message: {err}");
+    assert!(
+        err.contains("delete"),
+        "the message does not say how to clear a stale lock: {err}"
+    );
+
+    // Releasing it lets the next run through, so the lock is not a one-way door.
+    drop(held);
+    Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            Ok(converged_fit(1.0))
+        })
+        .expect("run after the lock was released");
+    assert!(
+        !journal::lock_path(dir.path()).exists(),
+        "the run kept the lock"
+    );
+}
+
+#[test]
+fn a_run_refused_after_it_took_the_lock_still_releases_it() {
+    // The refusal has to happen *past* the acquisition or this passes for the
+    // wrong reason, so it is an incompatible resume — which is checked with the
+    // directory already claimed.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    run_over(dir.path(), &candidates, &lenient());
+
+    let options = RunOptions {
+        criterion: Criterion::Aic,
+        resume: true,
+        ..lenient()
+    };
+    let err = expect_refusal(
+        Runner::new()
+            .threads(1)
+            .cache_dir(dir.path())
+            .run_with_fitter(&candidates, &population(&["1"]), &options, |_, _| {
+                Ok(converged_fit(1.0))
+            }),
+        "an incompatible resume must be refused",
+    );
+    assert!(
+        err.contains("ranking criterion"),
+        "unhelpful message: {err}"
+    );
+    assert!(
+        !journal::lock_path(dir.path()).exists(),
+        "a refused run left the directory locked"
+    );
+}

--- a/crates/ferx-tools/src/search/runner_tests.rs
+++ b/crates/ferx-tools/src/search/runner_tests.rs
@@ -1,0 +1,679 @@
+//! Orchestration tests for [`Runner`] (#1178).
+//!
+//! Every test here drives [`Runner::run_with_fitter`] rather than `run`, so the
+//! thing under test is the orchestration — dedup, the thread budget, the
+//! journal, resume, cancellation — and not the engine. That is not a
+//! convenience: "two fits are in flight at once" is not observable from outside
+//! `fit()`, so the concurrency bound could not be *asserted* against real fits,
+//! only assumed. The real compile-and-fit path is covered end-to-end in
+//! `tests/search_runner_end_to_end.rs`.
+//!
+//! The fixtures — including the one genuine evaluation every `FitResult` here
+//! is cloned from — live in [`crate::search::test_support`].
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use ferx_core::{BicType, Strictness};
+
+use super::*;
+use crate::search::candidate::{Candidate, Criterion, FeatureVector, RunOptions};
+use crate::search::test_support::{candidate, converged_fit, population, same_model_two_ways};
+
+/// `RunOptions` with every gate off — the tests that are not about strictness
+/// do not want an evaluation's init stall failing them.
+fn lenient() -> RunOptions {
+    RunOptions {
+        criterion: Criterion::Ofv,
+        strictness: Strictness::none(),
+        n_starts: 1,
+        resume: false,
+        fit_options: None,
+    }
+}
+
+/// A fitter that records which candidates it was asked for.
+struct Recorder {
+    calls: Mutex<Vec<String>>,
+}
+
+impl Recorder {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn record(&self, id: &str) {
+        self.calls.lock().unwrap().push(id.to_string());
+    }
+
+    fn ids(&self) -> Vec<String> {
+        let mut ids = self.calls.lock().unwrap().clone();
+        ids.sort();
+        ids
+    }
+}
+
+// ── identity ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn two_candidates_with_the_same_canonical_text_are_fitted_once() {
+    let (a, b) = same_model_two_ways();
+    // The premise, asserted rather than assumed: the two are *not* the same
+    // bytes, so a dedup that keyed on the rendered text would fit both and this
+    // test would still be testing something.
+    assert_ne!(a.render(), b.render(), "the fixtures are byte-identical");
+    assert_eq!(a.canonical_hash(), b.canonical_hash());
+
+    let candidates = vec![
+        Candidate::new("first", a),
+        Candidate::new("second", b).parent("first"),
+    ];
+    let recorder = Recorder::new();
+    let report = Runner::new()
+        .threads(1)
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |c, _| {
+            recorder.record(&c.id);
+            Ok(converged_fit(100.0))
+        })
+        .expect("run");
+
+    assert_eq!(recorder.ids(), vec!["first"], "the duplicate was fitted");
+    assert_eq!(report.fitted, 1);
+    assert_eq!(report.deduped, 1);
+
+    // Both candidates still come back — a search that generated a duplicate
+    // needs to know its score, not to find its id missing from the report.
+    assert_eq!(report.results.len(), 2);
+    assert_eq!(report.results[1].duplicate_of.as_deref(), Some("first"));
+    assert_eq!(report.results[1].criterion, report.results[0].criterion);
+    assert!(report.results[1].fit.is_none());
+    assert!(report.results[0].fit.is_some());
+    // Provenance is the duplicate's own, not the representative's.
+    assert_eq!(report.results[1].parent.as_deref(), Some("first"));
+}
+
+#[test]
+fn candidates_with_different_text_are_each_fitted() {
+    let candidates = vec![
+        candidate("a", "[parameters]\ntheta CL = 1\n"),
+        candidate("b", "[parameters]\ntheta CL = 2\n"),
+    ];
+    let recorder = Recorder::new();
+    let report = Runner::new()
+        .threads(1)
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |c, _| {
+            recorder.record(&c.id);
+            Ok(converged_fit(100.0))
+        })
+        .expect("run");
+
+    assert_eq!(recorder.ids(), vec!["a", "b"]);
+    assert_eq!(report.fitted, 2);
+    assert_eq!(report.deduped, 0);
+    assert!(report.results.iter().all(|r| r.duplicate_of.is_none()));
+}
+
+#[test]
+fn duplicate_ids_are_rejected() {
+    let candidates = vec![
+        candidate("same", "[parameters]\ntheta CL = 1\n"),
+        candidate("same", "[parameters]\ntheta CL = 2\n"),
+    ];
+    let err = Runner::new()
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            Ok(converged_fit(1.0))
+        })
+        .expect_err("duplicate ids must be refused");
+    assert!(err.contains("`same`"), "unhelpful message: {err}");
+}
+
+// ── the thread budget ────────────────────────────────────────────────────────
+
+/// Counts concurrent fitter calls, and records whether two were ever in flight
+/// at the same moment.
+struct Gauge {
+    live: AtomicUsize,
+    max: AtomicUsize,
+    paired: AtomicBool,
+}
+
+impl Gauge {
+    fn new() -> Self {
+        Self {
+            live: AtomicUsize::new(0),
+            max: AtomicUsize::new(0),
+            paired: AtomicBool::new(false),
+        }
+    }
+
+    /// Enter, dwell for the **whole** of `dwell`, and leave.
+    ///
+    /// Two properties the assertions need, and one trap that cost a mutation
+    /// check. Dwelling makes overlap observable at all, and recording
+    /// [`paired`](Self::paired) proves the run really was concurrent, so
+    /// `max <= 2` bounds something that happened rather than a run that
+    /// serialised for unrelated reasons.
+    ///
+    /// The trap: an earlier version *left as soon as* a second caller appeared.
+    /// Every worker then spent microseconds inside, so even an unbounded pool
+    /// rarely had three in flight at once and `max <= 2` passed under a
+    /// deliberately broken thread budget. Holding the full dwell is what makes
+    /// a wider pool actually reach a wider `max`.
+    fn enter(&self, dwell: Duration) {
+        let live = self.live.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max.fetch_max(live, Ordering::SeqCst);
+        let deadline = Instant::now() + dwell;
+        while Instant::now() < deadline {
+            if self.live.load(Ordering::SeqCst) >= 2 {
+                self.paired.store(true, Ordering::SeqCst);
+            }
+            std::thread::sleep(Duration::from_millis(1));
+        }
+        self.live.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn the_thread_budget_bounds_concurrent_fits() {
+    let candidates: Vec<Candidate> = (0..6)
+        .map(|i| candidate(&format!("c{i}"), &format!("[parameters]\ntheta CL = {i}\n")))
+        .collect();
+    let gauge = Gauge::new();
+    let report = Runner::new()
+        .threads(2)
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            gauge.enter(Duration::from_millis(60));
+            Ok(converged_fit(10.0))
+        })
+        .expect("run");
+
+    assert_eq!(report.fitted, 6);
+    assert!(
+        gauge.paired.load(Ordering::SeqCst),
+        "no two fits were ever in flight together: the bound below is vacuous"
+    );
+    assert!(
+        gauge.max.load(Ordering::SeqCst) <= 2,
+        "a `threads = 2` run reached {} concurrent fits",
+        gauge.max.load(Ordering::SeqCst)
+    );
+}
+
+#[test]
+fn a_single_thread_budget_serialises_the_fits() {
+    let candidates: Vec<Candidate> = (0..3)
+        .map(|i| candidate(&format!("c{i}"), &format!("[parameters]\ntheta CL = {i}\n")))
+        .collect();
+    let gauge = Gauge::new();
+    Runner::new()
+        .threads(1)
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            gauge.enter(Duration::from_millis(20));
+            Ok(converged_fit(10.0))
+        })
+        .expect("run");
+
+    assert_eq!(
+        gauge.max.load(Ordering::SeqCst),
+        1,
+        "a `threads = 1` run overlapped its fits"
+    );
+    assert!(!gauge.paired.load(Ordering::SeqCst));
+}
+
+#[test]
+fn the_inner_fit_is_pinned_to_the_plans_share_of_the_budget() {
+    // The other half of #1115: the outer width is not the whole story, the
+    // inner `fit()` has to be told what is left for it or the two levels
+    // oversubscribe. Six candidates over two threads is `2 × 1`.
+    let candidates: Vec<Candidate> = (0..6)
+        .map(|i| candidate(&format!("c{i}"), &format!("[parameters]\ntheta CL = {i}\n")))
+        .collect();
+    let seen = Mutex::new(Vec::new());
+    Runner::new()
+        .threads(2)
+        .run_with_fitter(
+            &candidates,
+            &population(&["1"]),
+            &lenient(),
+            |_, threads| {
+                seen.lock().unwrap().push(threads);
+                Ok(converged_fit(10.0))
+            },
+        )
+        .expect("run");
+    assert_eq!(seen.lock().unwrap().as_slice(), &[1, 1, 1, 1, 1, 1]);
+
+    // And with more budget than candidates, the surplus goes to the inner fit
+    // rather than to idle outer workers.
+    let two: Vec<Candidate> = candidates.iter().take(2).cloned().collect();
+    let seen = Mutex::new(Vec::new());
+    Runner::new()
+        .threads(8)
+        .run_with_fitter(&two, &population(&["1"]), &lenient(), |_, threads| {
+            seen.lock().unwrap().push(threads);
+            Ok(converged_fit(10.0))
+        })
+        .expect("run");
+    assert_eq!(seen.lock().unwrap().as_slice(), &[4, 4]);
+}
+
+// ── strictness and failures ──────────────────────────────────────────────────
+
+#[test]
+fn a_candidate_failing_strictness_keeps_its_reasons() {
+    let candidates = vec![
+        candidate("good", "[parameters]\ntheta CL = 1\n"),
+        candidate("bad", "[parameters]\ntheta CL = 2\n"),
+    ];
+    let options = RunOptions {
+        criterion: Criterion::Ofv,
+        strictness: Strictness {
+            require_converged: true,
+            ..Strictness::none()
+        },
+        ..lenient()
+    };
+    let report = Runner::new()
+        .threads(1)
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
+            let mut result = converged_fit(10.0);
+            if c.id == "bad" {
+                result.converged = false;
+            }
+            Ok(result)
+        })
+        .expect("run");
+
+    assert_eq!(report.results.len(), 2, "a failing candidate was dropped");
+    let bad = &report.results[1];
+    assert!(!bad.verdict.passed);
+    assert_eq!(bad.verdict.failures.len(), 1);
+    assert!(bad.verdict.failures[0].contains("converge"));
+    assert!(!bad.eligible());
+    // Its criterion is still recorded — the gate says "do not rank this", not
+    // "there is nothing to see".
+    assert_eq!(bad.criterion, 10.0);
+    assert!(report.results[0].eligible());
+    assert_eq!(report.best().map(|r| r.id.as_str()), Some("good"));
+}
+
+#[test]
+fn a_failed_fit_is_reported_with_its_error() {
+    let candidates = vec![candidate("broken", "[parameters]\ntheta CL = 1\n")];
+    let report = Runner::new()
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            Err("does not compile: unknown block `[wat]`".to_string())
+        })
+        .expect("run");
+
+    let result = &report.results[0];
+    assert!(result.fit.is_none());
+    assert!(result.criterion.is_nan());
+    assert!(!result.verdict.passed);
+    assert!(result.verdict.failures[0].contains("unknown block"));
+    assert_eq!(
+        result.error.as_deref(),
+        Some("does not compile: unknown block `[wat]`")
+    );
+    assert!(!result.eligible());
+    assert!(report.best().is_none());
+}
+
+#[test]
+fn best_is_the_lowest_criterion_among_eligible_candidates() {
+    let candidates: Vec<Candidate> = (0..3)
+        .map(|i| candidate(&format!("c{i}"), &format!("[parameters]\ntheta CL = {i}\n")))
+        .collect();
+    let options = RunOptions {
+        criterion: Criterion::Bic(BicType::Fixed),
+        strictness: Strictness {
+            require_converged: true,
+            ..Strictness::none()
+        },
+        ..lenient()
+    };
+    let report = Runner::new()
+        .threads(1)
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
+            // c1 is the lowest OFV but did not converge, so c2 must win.
+            let ofv = match c.id.as_str() {
+                "c0" => 100.0,
+                "c1" => 1.0,
+                _ => 50.0,
+            };
+            let mut result = converged_fit(ofv);
+            result.converged = c.id != "c1";
+            Ok(result)
+        })
+        .expect("run");
+
+    assert_eq!(report.best().map(|r| r.id.as_str()), Some("c2"));
+}
+
+// ── cancellation ─────────────────────────────────────────────────────────────
+
+#[test]
+fn cancellation_stops_between_candidates_and_returns_partial_results() {
+    let candidates: Vec<Candidate> = (0..5)
+        .map(|i| candidate(&format!("c{i}"), &format!("[parameters]\ntheta CL = {i}\n")))
+        .collect();
+    let flag = CancelFlag::new();
+    let recorder = Recorder::new();
+    let report = Runner::new()
+        .threads(1)
+        .cancel(flag.clone())
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |c, _| {
+            recorder.record(&c.id);
+            flag.cancel();
+            Ok(converged_fit(1.0))
+        })
+        .expect("a cancelled run still reports");
+
+    assert!(report.cancelled);
+    assert_eq!(recorder.ids().len(), 1, "the run kept fitting after cancel");
+    assert_eq!(report.results.len(), 1, "the finished candidate was lost");
+    assert_eq!(report.results[0].id, "c0");
+}
+
+#[test]
+fn a_run_cancelled_before_it_starts_fits_nothing() {
+    let candidates = vec![candidate("c0", "[parameters]\ntheta CL = 1\n")];
+    let flag = CancelFlag::new();
+    flag.cancel();
+    let report = Runner::new()
+        .cancel(flag)
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            panic!("nothing may be fitted after a pre-run cancel");
+        })
+        .expect("run");
+    assert!(report.cancelled);
+    assert!(report.results.is_empty());
+}
+
+#[test]
+fn a_pre_run_cancel_does_not_truncate_an_existing_journal() {
+    // The reason the flag is checked *before* `Journal::create`: opening the
+    // journal rewrites it, and a cancelled run must not be what destroys the
+    // previous run's recovery data.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("c0", "[parameters]\ntheta CL = 1\n")];
+    let runner = Runner::new().threads(1).cache_dir(dir.path());
+    let mut options = lenient();
+    runner
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |_, _| {
+            Ok(converged_fit(7.0))
+        })
+        .expect("first run");
+    let before = std::fs::read_to_string(journal::journal_path(dir.path())).expect("journal");
+    assert!(!before.trim().is_empty());
+
+    options.resume = true;
+    let flag = CancelFlag::new();
+    flag.cancel();
+    Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .cancel(flag)
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |_, _| {
+            panic!("nothing may be fitted after a pre-run cancel")
+        })
+        .expect("cancelled run");
+
+    let after = std::fs::read_to_string(journal::journal_path(dir.path())).expect("journal");
+    assert_eq!(before, after, "the cancelled run rewrote the journal");
+}
+
+// ── journal and resume ───────────────────────────────────────────────────────
+
+/// Run `ids` through a fresh runner over `dir`, returning what it fitted.
+fn run_over(
+    dir: &std::path::Path,
+    candidates: &[Candidate],
+    options: &RunOptions,
+) -> (RunReport, Vec<String>) {
+    let recorder = Recorder::new();
+    let report = Runner::new()
+        .threads(1)
+        .cache_dir(dir)
+        .run_with_fitter(candidates, &population(&["1"]), options, |c, _| {
+            recorder.record(&c.id);
+            let ofv = 100.0 + c.id.len() as f64;
+            Ok(converged_fit(ofv))
+        })
+        .expect("run");
+    (report, recorder.ids())
+}
+
+#[test]
+fn a_resumed_run_refits_nothing_already_journalled() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let first = vec![
+        candidate("a", "[parameters]\ntheta CL = 1\n"),
+        candidate("bb", "[parameters]\ntheta CL = 2\n"),
+    ];
+    let (initial, fitted) = run_over(dir.path(), &first, &lenient());
+    assert_eq!(fitted, vec!["a", "bb"]);
+    assert_eq!(initial.fitted, 2);
+
+    let mut second = first.clone();
+    second.push(candidate("ccc", "[parameters]\ntheta CL = 3\n"));
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    let (resumed, fitted) = run_over(dir.path(), &second, &options);
+
+    assert_eq!(fitted, vec!["ccc"], "a journalled candidate was refitted");
+    assert_eq!((resumed.fitted, resumed.reused), (1, 2));
+    assert_eq!(resumed.results.len(), 3);
+    assert!(resumed.results[0].reused && resumed.results[1].reused);
+    assert!(!resumed.results[2].reused);
+    // The reused rows carry the criterion the interrupted run computed…
+    assert_eq!(resumed.results[0].criterion, initial.results[0].criterion);
+    assert_eq!(resumed.results[1].criterion, initial.results[1].criterion);
+    // …and their cached `FitResult`, so a resumed run is not a degraded one.
+    assert_eq!(
+        resumed.results[0].fit.as_ref().map(|f| f.ofv),
+        initial.results[0].fit.as_ref().map(|f| f.ofv)
+    );
+}
+
+#[test]
+fn a_resumed_run_matches_on_the_canonical_hash_not_the_id() {
+    // The same model under a new id must still be reused: a search that renames
+    // its candidates between steps (or reaches one by another route) would
+    // otherwise refit everything it had already paid for.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (a, b) = same_model_two_ways();
+    let (_, fitted) = run_over(dir.path(), &[Candidate::new("step1", a)], &lenient());
+    assert_eq!(fitted, vec!["step1"]);
+
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    let (resumed, fitted) = run_over(dir.path(), &[Candidate::new("step2", b)], &options);
+    assert!(fitted.is_empty(), "the same model was fitted twice");
+    assert_eq!(resumed.reused, 1);
+    assert_eq!(resumed.results[0].id, "step2");
+}
+
+#[test]
+fn a_truncated_final_journal_line_costs_one_refit_and_no_more() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![
+        candidate("a", "[parameters]\ntheta CL = 1\n"),
+        candidate("bb", "[parameters]\ntheta CL = 2\n"),
+    ];
+    run_over(dir.path(), &candidates, &lenient());
+
+    // Simulate a kill mid-write: chop the last line in half.
+    let path = journal::journal_path(dir.path());
+    let text = std::fs::read_to_string(&path).expect("journal");
+    let mut lines: Vec<&str> = text.lines().collect();
+    assert_eq!(lines.len(), 2);
+    let cut = &lines[1][..lines[1].len() / 2];
+    lines[1] = cut;
+    std::fs::write(&path, lines.join("\n")).expect("truncate");
+
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    let (resumed, fitted) = run_over(dir.path(), &candidates, &options);
+    assert_eq!(fitted, vec!["bb"], "the intact row was not reused");
+    assert_eq!((resumed.fitted, resumed.reused), (1, 1));
+
+    // And the rewritten journal is well-formed again — the next resume reads
+    // two rows, not one row and a fragment.
+    let records = journal::read_records(&journal::journal_path(dir.path()));
+    assert_eq!(records.len(), 2);
+}
+
+#[test]
+fn a_resume_against_a_different_criterion_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    run_over(dir.path(), &candidates, &lenient());
+
+    let options = RunOptions {
+        resume: true,
+        criterion: Criterion::Bic(BicType::Mixed),
+        ..lenient()
+    };
+    let err = Runner::new()
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |_, _| {
+            Ok(converged_fit(1.0))
+        })
+        .expect_err("resuming under another criterion must be refused");
+    assert!(
+        err.contains("ranking criterion"),
+        "unhelpful message: {err}"
+    );
+}
+
+#[test]
+fn a_resume_against_a_different_dataset_is_refused() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    run_over(dir.path(), &candidates, &lenient());
+
+    let options = RunOptions {
+        resume: true,
+        ..lenient()
+    };
+    let err = Runner::new()
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1", "2"]), &options, |_, _| {
+            Ok(converged_fit(1.0))
+        })
+        .expect_err("resuming against other data must be refused");
+    assert!(err.contains("dataset"), "unhelpful message: {err}");
+}
+
+#[test]
+fn without_resume_the_journal_is_started_over() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    run_over(dir.path(), &candidates, &lenient());
+    let (report, fitted) = run_over(dir.path(), &candidates, &lenient());
+
+    assert_eq!(
+        fitted,
+        vec!["a"],
+        "an unrequested resume reused a candidate"
+    );
+    assert_eq!(report.reused, 0);
+    assert_eq!(
+        journal::read_records(&journal::journal_path(dir.path())).len(),
+        1,
+        "the journal accumulated a second copy of the same candidate"
+    );
+}
+
+// ── the table ────────────────────────────────────────────────────────────────
+
+#[test]
+fn every_candidate_appears_in_the_table_in_submission_order() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (a, b) = same_model_two_ways();
+    let candidates = vec![
+        Candidate::new("good", a).features(FeatureVector::new().with("CL-WT", "pow")),
+        Candidate::new("dup", b),
+        candidate("bad", "[parameters]\ntheta CL = 9\n"),
+        candidate("broken", "[parameters]\ntheta CL = 8\n"),
+    ];
+    let options = RunOptions {
+        strictness: Strictness {
+            require_converged: true,
+            ..Strictness::none()
+        },
+        ..lenient()
+    };
+    Runner::new()
+        .threads(1)
+        .cache_dir(dir.path())
+        .run_with_fitter(&candidates, &population(&["1"]), &options, |c, _| {
+            match c.id.as_str() {
+                "broken" => Err("the model does not compile".to_string()),
+                "bad" => {
+                    let mut result = converged_fit(3.0);
+                    result.converged = false;
+                    Ok(result)
+                }
+                _ => Ok(converged_fit(1.0)),
+            }
+        })
+        .expect("run");
+
+    let text = std::fs::read_to_string(output::table_path(dir.path())).expect("candidates.csv");
+    let rows: Vec<&str> = text.lines().collect();
+    assert!(rows[0].starts_with("id,parent,hash,features,criterion"));
+    assert_eq!(rows.len(), 5, "not every candidate reached the table");
+    assert!(rows[1].starts_with("good,"));
+    assert!(rows[1].contains("CL-WT=pow"));
+    assert!(rows[2].starts_with("dup,"));
+    assert!(rows[2].contains("good"), "the duplicate lost its source");
+    // The two failures are present *with their reasons* — a search report that
+    // silently omitted them could not be told apart from one whose candidate
+    // generator never produced them.
+    assert!(rows[3].starts_with("bad,"));
+    assert!(rows[3].contains("converge"));
+    assert!(rows[4].starts_with("broken,"));
+    assert!(rows[4].contains("does not compile"));
+}
+
+#[test]
+fn a_run_without_a_cache_directory_writes_nothing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let before: Vec<_> = std::fs::read_dir(dir.path()).unwrap().collect();
+    assert!(before.is_empty());
+
+    let candidates = vec![candidate("a", "[parameters]\ntheta CL = 1\n")];
+    let report = Runner::new()
+        .run_with_fitter(&candidates, &population(&["1"]), &lenient(), |_, _| {
+            Ok(converged_fit(1.0))
+        })
+        .expect("run");
+    assert_eq!(report.results.len(), 1);
+    assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+}
+
+// ── options plumbing ─────────────────────────────────────────────────────────
+
+#[test]
+fn the_default_options_retry_and_gate() {
+    // The two non-negotiables of the epic, pinned so a "simplification" cannot
+    // quietly turn a search into single-start, ungated ranking.
+    let options = RunOptions::default();
+    assert_eq!(options.n_starts, 3);
+    assert!(options.strictness.require_converged);
+    assert_eq!(options.criterion, Criterion::Bic(BicType::Mixed));
+    assert!(!options.resume);
+    assert!(options.fit_options.is_none());
+}

--- a/crates/ferx-tools/src/search/test_support.rs
+++ b/crates/ferx-tools/src/search/test_support.rs
@@ -1,0 +1,99 @@
+//! Fixtures shared by the `search` unit tests.
+//!
+//! The one thing these tests cannot fake is a [`FitResult`]: it has 130-odd
+//! fields and no constructor, so there is no way to build one field by field.
+//! [`fixture_fit`] is therefore one genuine `outer_maxiter = 0` **evaluation**
+//! of `examples/warfarin.ferx` — ferx's `MAXEVAL=0`, the same trick
+//! `tests/bootstrap_end_to_end.rs` uses — computed once per test binary and
+//! cloned. Tests that need a different fit mutate the clone.
+
+use std::sync::OnceLock;
+
+use ferx_core::edit::ModelText;
+use ferx_core::{fit, prepare_run, FitResult, Population, Subject};
+
+use super::candidate::Candidate;
+
+pub(crate) const MODEL: &str = "../../examples/warfarin.ferx";
+pub(crate) const DATA: &str = "../../data/warfarin.csv";
+
+/// One real evaluation of the warfarin model, memoized.
+///
+/// The initialisation runs on a **dedicated thread the caller joins**, and that
+/// is load-bearing rather than tidy. The tests call this from inside the
+/// runner's Rayon pool, and the evaluation itself enters a nested pool; a Rayon
+/// worker blocked on a nested `install` keeps stealing work, so it can re-enter
+/// this function *in the middle of its own* `get_or_init` and deadlock against
+/// the `OnceLock` it is already initialising. Observed, not theorised: a
+/// two-candidate run on a one-worker pool hung there. Blocking on a plain
+/// `JoinHandle` is not a Rayon latch, so the waiting worker steals nothing and
+/// the initialisation cannot be re-entered.
+pub(crate) fn fixture_fit() -> FitResult {
+    static FIT: OnceLock<FitResult> = OnceLock::new();
+    FIT.get_or_init(|| {
+        std::thread::spawn(|| {
+            let prepared = prepare_run(MODEL, Some(DATA)).expect("warfarin model + data load");
+            let mut options = prepared.parsed.fit_options.clone();
+            options.outer_maxiter = 0;
+            options.run_covariance_step = false;
+            options.verbose = false;
+            options.threads = Some(1);
+            options.checkpoint = false;
+            fit(
+                &prepared.parsed.model,
+                &prepared.population,
+                &prepared.init_params,
+                &options,
+            )
+            .expect("warfarin evaluation")
+        })
+        .join()
+        .expect("the fixture thread panicked")
+    })
+    .clone()
+}
+
+/// The fixture with `converged` set and a chosen OFV / AIC / BIC.
+pub(crate) fn converged_fit(ofv: f64) -> FitResult {
+    let mut result = fixture_fit();
+    result.converged = true;
+    result.ofv = ofv;
+    result.aic = ofv + 2.0;
+    result.bic = ofv + 5.0;
+    result
+}
+
+/// The smallest population the runner will accept. It is only ever read for the
+/// resume manifest's data fingerprint, since these tests inject the fitter.
+pub(crate) fn population(ids: &[&str]) -> Population {
+    Population {
+        subjects: ids
+            .iter()
+            .map(|id| Subject {
+                id: (*id).to_string(),
+                ..Default::default()
+            })
+            .collect(),
+        covariate_names: vec![],
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+pub(crate) fn model_text(body: &str) -> ModelText {
+    ModelText::parse(body).expect("fixture model text")
+}
+
+/// Two spellings of one model: different bytes, identical canonical form.
+pub(crate) fn same_model_two_ways() -> (ModelText, ModelText) {
+    (
+        model_text("[parameters]\ntheta CL = 1\ntheta V = 10\n"),
+        model_text("[parameters]   # a comment\n\ntheta CL = 1\n   theta V  =  10\n"),
+    )
+}
+
+pub(crate) fn candidate(id: &str, body: &str) -> Candidate {
+    Candidate::new(id, model_text(body))
+}

--- a/crates/ferx-tools/tests/search_runner_end_to_end.rs
+++ b/crates/ferx-tools/tests/search_runner_end_to_end.rs
@@ -17,7 +17,7 @@
 use std::path::Path;
 
 use ferx_core::edit::{ModelEdit, ModelText};
-use ferx_core::{fit, prepare_run, CancelFlag, FitOptions, PreparedRun, Strictness};
+use ferx_core::{fit, prepare_run, BloqMethod, CancelFlag, FitOptions, PreparedRun, Strictness};
 use ferx_tools::search::{Candidate, Criterion, FeatureVector, RunOptions, Runner};
 
 const MODEL: &str = "../../examples/warfarin.ferx";
@@ -329,10 +329,103 @@ fn an_edit_that_changes_the_random_effects_changes_the_bic_it_is_ranked_on() {
     );
 }
 
+// ── options that reach the engine through the model, not the options ─────────
+
+const BLOQ_MODEL: &str = "../../examples/warfarin_bloq.ferx";
+const BLOQ_DATA: &str = "../../data/warfarin_bloq.csv";
+
+fn bloq_options(base: &FitOptions, bloq: BloqMethod) -> FitOptions {
+    let mut o = eval_options(base);
+    o.bloq_method = bloq;
+    o
+}
+
+/// The reference: an evaluation with `bloq` stamped onto **both** the options
+/// and the model, which is what `fit_from_files` does.
+fn direct_bloq_ofv(bloq: BloqMethod) -> f64 {
+    let mut p = prepare_run(BLOQ_MODEL, Some(BLOQ_DATA)).expect("bloq model + data load");
+    let options = bloq_options(&p.parsed.fit_options, bloq);
+    p.parsed.model.bloq_method = bloq;
+    fit(&p.parsed.model, &p.population, &p.init_params, &options)
+        .expect("censored evaluation")
+        .ofv
+}
+
+#[test]
+fn a_bloq_override_reaches_the_censored_likelihood_in_both_directions() {
+    // `bloq_method` is one of the two keys the engine reads off the *model*
+    // rather than off `FitOptions`, and parsing stamps the candidate file's
+    // value there. A `RunOptions::fit_options` override that only landed in the
+    // options would report the requested convention and score the other one's
+    // likelihood — a wrong ranking, silently.
+    let p = prepare_run(BLOQ_MODEL, Some(BLOQ_DATA)).expect("bloq model + data load");
+    let m3 = direct_bloq_ofv(BloqMethod::M3);
+    let dropped = direct_bloq_ofv(BloqMethod::Drop);
+    // Non-degeneracy: on a dataset with no censored rows the two conventions
+    // agree and everything below would pass without testing anything.
+    assert!(
+        p.population
+            .subjects
+            .iter()
+            .any(|s| s.has_censored_observation()),
+        "the fixture carries no censored rows"
+    );
+    assert_ne!(
+        m3.to_bits(),
+        dropped.to_bits(),
+        "M3 and drop agree on this data, so the assertions below are vacuous"
+    );
+
+    let file_m3 = ModelText::parse(&std::fs::read_to_string(BLOQ_MODEL).expect("read the model"))
+        .expect("parse the model");
+    let mut file_drop = file_m3.clone();
+    file_drop
+        .apply(ModelEdit::SetFitOption {
+            key: "bloq_method".to_string(),
+            value: "drop".to_string(),
+        })
+        .expect("set bloq_method = drop");
+
+    // Both directions: the file's value and the override disagree each way
+    // round, and the override has to win each time.
+    for (label, text, override_with, want) in [
+        ("m3 file, drop override", file_m3, BloqMethod::Drop, dropped),
+        ("drop file, m3 override", file_drop, BloqMethod::M3, m3),
+    ] {
+        let report = Runner::new()
+            .threads(1)
+            .run(
+                &[Candidate::new("candidate", text)],
+                &p.population,
+                &RunOptions {
+                    criterion: Criterion::Ofv,
+                    strictness: Strictness::none(),
+                    n_starts: 1,
+                    resume: false,
+                    fit_options: Some(bloq_options(&p.parsed.fit_options, override_with)),
+                },
+            )
+            .expect("run");
+
+        let got = report.results[0]
+            .fit
+            .as_ref()
+            .unwrap_or_else(|| panic!("{label}: no fit — {:?}", report.results[0].error))
+            .ofv;
+        assert_eq!(
+            got.to_bits(),
+            want.to_bits(),
+            "{label}: the fit scored OFV {got}, the requested convention gives {want}"
+        );
+    }
+}
+
 #[test]
 fn the_fixtures_exist() {
     // A wrong relative path would turn every test above into a `prepare_run`
     // failure that reads like an engine problem.
     assert!(Path::new(MODEL).exists(), "missing {MODEL}");
     assert!(Path::new(DATA).exists(), "missing {DATA}");
+    assert!(Path::new(BLOQ_MODEL).exists(), "missing {BLOQ_MODEL}");
+    assert!(Path::new(BLOQ_DATA).exists(), "missing {BLOQ_DATA}");
 }

--- a/crates/ferx-tools/tests/search_runner_end_to_end.rs
+++ b/crates/ferx-tools/tests/search_runner_end_to_end.rs
@@ -1,0 +1,338 @@
+//! Tier-2 end-to-end checks for the candidate runner (#1178), on a real model
+//! and dataset but never to convergence: every fit here is an evaluation
+//! (`outer_maxiter = 0`, ferx's `MAXEVAL=0`).
+//!
+//! The unit tests in `src/search/runner_tests.rs` inject the fitter, so they
+//! test the orchestration and deliberately never compile a candidate. This file
+//! is the other half: the path from `ModelText` through `parse_full_model`, the
+//! data binders and `fit()`.
+//!
+//! Its oracle is **degenerate**: a candidate that is the base model unedited
+//! must give the OFV `fit()` gives on the same model and population, bit for
+//! bit. Anything the runner's own compile path drops — a covariate binding, the
+//! file's `[fit_options]`, the initial estimates — moves that number, and
+//! nothing else here would notice, because there is no second copy of the
+//! compile path to disagree with it.
+
+use std::path::Path;
+
+use ferx_core::edit::{ModelEdit, ModelText};
+use ferx_core::{fit, prepare_run, CancelFlag, FitOptions, PreparedRun, Strictness};
+use ferx_tools::search::{Candidate, Criterion, FeatureVector, RunOptions, Runner};
+
+const MODEL: &str = "../../examples/warfarin.ferx";
+const DATA: &str = "../../data/warfarin.csv";
+
+fn prepared() -> PreparedRun {
+    prepare_run(MODEL, Some(DATA)).expect("warfarin model + data load")
+}
+
+fn base_text() -> ModelText {
+    ModelText::parse(&std::fs::read_to_string(MODEL).expect("read warfarin.ferx"))
+        .expect("parse warfarin.ferx")
+}
+
+/// An evaluation, not a fit.
+fn eval_options(base: &FitOptions) -> FitOptions {
+    let mut o = base.clone();
+    o.outer_maxiter = 0;
+    o.run_covariance_step = false;
+    o.verbose = false;
+    o.checkpoint = false;
+    o
+}
+
+fn run_options(base: &FitOptions) -> RunOptions {
+    RunOptions {
+        criterion: Criterion::Ofv,
+        // Every gate off: an `outer_maxiter = 0` evaluation *is* an init stall,
+        // and this file is not testing the gate (the unit tests are).
+        strictness: Strictness::none(),
+        n_starts: 1,
+        resume: false,
+        fit_options: Some(eval_options(base)),
+    }
+}
+
+/// The candidate list used by most tests: the base model, a byte-different but
+/// canonically identical copy of it, and a genuinely different model (ETA_KA
+/// dropped).
+fn candidates() -> Vec<Candidate> {
+    let base = base_text();
+    let commented = ModelText::parse(&format!(
+        "# a comment the canonical form must ignore\n{}",
+        base.render()
+    ))
+    .expect("parse the commented copy");
+    let mut no_ka_iiv = base.clone();
+    no_ka_iiv
+        .apply(ModelEdit::DropIiv {
+            param: "KA".to_string(),
+        })
+        .expect("drop the KA IIV");
+
+    vec![
+        Candidate::new("base", base),
+        Candidate::new("base-again", commented).parent("base"),
+        Candidate::new("no-ka-iiv", no_ka_iiv)
+            .parent("base")
+            .features(FeatureVector::new().with("IIV-KA", "off")),
+    ]
+}
+
+#[test]
+fn an_unedited_candidate_reproduces_a_direct_fit_exactly() {
+    let p = prepared();
+    let options = run_options(&p.parsed.fit_options);
+    let direct = fit(
+        &p.parsed.model,
+        &p.population,
+        &p.init_params,
+        &eval_options(&p.parsed.fit_options),
+    )
+    .expect("direct evaluation");
+
+    let report = Runner::new()
+        .threads(1)
+        .run(&candidates()[..1], &p.population, &options)
+        .expect("run");
+
+    let base = report.results[0].fit.as_ref().expect("the base fit");
+    // Bit-for-bit. "Close" is exactly what a dropped covariate binding or a
+    // silently substituted set of initial estimates looks like at this scale.
+    assert_eq!(
+        base.ofv.to_bits(),
+        direct.ofv.to_bits(),
+        "runner OFV {} vs direct {}",
+        base.ofv,
+        direct.ofv
+    );
+    assert_eq!(base.n_obs, direct.n_obs);
+    assert_eq!(base.n_subjects, direct.n_subjects);
+    assert_eq!(report.results[0].criterion, direct.ofv);
+}
+
+#[test]
+fn a_real_search_step_dedups_fits_and_ranks_what_is_left() {
+    let p = prepared();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = run_options(&p.parsed.fit_options);
+    let report = Runner::new()
+        .threads(2)
+        .cache_dir(dir.path())
+        .run(&candidates(), &p.population, &options)
+        .expect("run");
+
+    assert_eq!((report.fitted, report.deduped, report.reused), (2, 1, 0));
+    assert_eq!(report.results.len(), 3);
+
+    // The commented copy is the same model: same hash, no fit of its own, and
+    // the base model's criterion.
+    assert_eq!(report.results[1].hash, report.results[0].hash);
+    assert_eq!(report.results[1].duplicate_of.as_deref(), Some("base"));
+    assert_eq!(report.results[1].criterion, report.results[0].criterion);
+
+    // Dropping an η is a different model, so it is a different hash and a
+    // different objective — the edit reached the engine.
+    assert_ne!(report.results[2].hash, report.results[0].hash);
+    let no_ka = report.results[2].fit.as_ref().expect("the edited fit");
+    assert_ne!(
+        no_ka.ofv.to_bits(),
+        report.results[0].fit.as_ref().unwrap().ofv.to_bits(),
+        "dropping the KA IIV did not change the objective"
+    );
+    assert_eq!(no_ka.eta_names.len(), 2, "the η was not dropped");
+    assert!(report.best().is_some());
+
+    // Both artefacts are on disk, and the journal holds one row per *fit*, not
+    // per candidate.
+    let table = std::fs::read_to_string(dir.path().join("candidates.csv")).expect("table");
+    assert_eq!(table.lines().count(), 4);
+    assert!(table.contains("IIV-KA=off"));
+    let journal =
+        std::fs::read_to_string(dir.path().join("search_journal.jsonl")).expect("journal");
+    assert_eq!(journal.lines().count(), 2);
+    assert!(dir.path().join("search_run.json").exists());
+}
+
+#[test]
+fn a_resumed_run_refits_nothing_and_reports_the_same_numbers() {
+    let p = prepared();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let options = run_options(&p.parsed.fit_options);
+    let first = Runner::new()
+        .threads(2)
+        .cache_dir(dir.path())
+        .run(&candidates(), &p.population, &options)
+        .expect("first run");
+
+    let resumed = Runner::new()
+        .threads(2)
+        .cache_dir(dir.path())
+        .run(
+            &candidates(),
+            &p.population,
+            &RunOptions {
+                resume: true,
+                ..run_options(&p.parsed.fit_options)
+            },
+        )
+        .expect("resumed run");
+
+    assert_eq!((resumed.fitted, resumed.reused), (0, 2));
+    assert_eq!(resumed.results.len(), 3);
+    for (before, after) in first.results.iter().zip(&resumed.results) {
+        assert_eq!(before.id, after.id);
+        assert_eq!(before.criterion, after.criterion);
+        assert_eq!(
+            before.fit.as_ref().map(|f| f.ofv.to_bits()),
+            after.fit.as_ref().map(|f| f.ofv.to_bits()),
+            "the cached fit of `{}` came back different",
+            before.id
+        );
+    }
+    assert!(resumed.results[0].reused);
+}
+
+#[test]
+fn a_candidate_that_does_not_compile_is_reported_not_fatal() {
+    let p = prepared();
+    // A model whose `[individual_parameters]` reference a parameter that does
+    // not exist: structurally a valid `.ferx` file, rejected by the compiler.
+    let broken = ModelText::parse("[parameters]\n  theta TVCL(0.2, 0.001, 10.0)\n\n[individual_parameters]\n  CL = NOSUCHTHETA\n")
+        .expect("the text still parses structurally");
+
+    let mut list = candidates();
+    list.push(Candidate::new("broken", broken));
+    let report = Runner::new()
+        .threads(1)
+        .run(&list, &p.population, &run_options(&p.parsed.fit_options))
+        .expect("a failing candidate must not fail the run");
+
+    let failed = report
+        .results
+        .iter()
+        .find(|r| r.id == "broken")
+        .expect("the broken candidate is missing from the report");
+    assert!(failed.fit.is_none());
+    assert!(failed.error.is_some(), "no reason was recorded");
+    assert!(!failed.eligible());
+    // The rest of the run is unaffected.
+    assert_eq!(report.fitted, 3);
+    assert!(report.best().is_some());
+}
+
+#[test]
+fn cancelling_a_run_returns_what_finished() {
+    let p = prepared();
+    let flag = CancelFlag::new();
+    flag.cancel();
+    let report = Runner::new()
+        .threads(1)
+        .cancel(flag)
+        .run(
+            &candidates(),
+            &p.population,
+            &run_options(&p.parsed.fit_options),
+        )
+        .expect("a cancelled run still reports");
+    assert!(report.cancelled);
+    assert_eq!(report.fitted, 0);
+}
+
+#[test]
+fn the_candidates_own_fit_options_are_used_when_none_are_given() {
+    // `fit_options: None` means "each candidate carries its own", which is what
+    // a search over models edited from one base file wants. The base file says
+    // `method = foce`; a candidate that sets `method = focei` must be fitted
+    // that way rather than under the runner's or its parent's choice.
+    let p = prepared();
+    let mut focei = base_text();
+    focei
+        .apply(ModelEdit::SetFitOption {
+            key: "method".to_string(),
+            value: "focei".to_string(),
+        })
+        .expect("set the method");
+    focei
+        .apply(ModelEdit::SetFitOption {
+            key: "maxiter".to_string(),
+            value: "0".to_string(),
+        })
+        .expect("cap the iterations");
+    let mut foce = base_text();
+    foce.apply(ModelEdit::SetFitOption {
+        key: "maxiter".to_string(),
+        value: "0".to_string(),
+    })
+    .expect("cap the iterations");
+
+    let report = Runner::new()
+        .threads(1)
+        .run(
+            &[Candidate::new("foce", foce), Candidate::new("focei", focei)],
+            &p.population,
+            &RunOptions {
+                criterion: Criterion::Ofv,
+                strictness: Strictness::none(),
+                n_starts: 1,
+                resume: false,
+                fit_options: None,
+            },
+        )
+        .expect("run");
+
+    let method_of = |id: &str| {
+        report
+            .results
+            .iter()
+            .find(|r| r.id == id)
+            .and_then(|r| r.fit.as_ref())
+            .map(|f| format!("{:?}", f.method))
+            .unwrap_or_default()
+    };
+    assert_ne!(
+        method_of("foce"),
+        method_of("focei"),
+        "both candidates were fitted with the same method, so the file's \
+         `[fit_options]` were not read per candidate"
+    );
+}
+
+#[test]
+fn an_edit_that_changes_the_random_effects_changes_the_bic_it_is_ranked_on() {
+    // The runner's criterion is computed from the candidate's own fit, so an
+    // edit that removes a variance parameter must move the penalty — the
+    // property `iivsearch` will rank on.
+    let p = prepared();
+    let list = candidates();
+    let options = RunOptions {
+        criterion: Criterion::Bic(ferx_core::BicType::Iiv),
+        ..run_options(&p.parsed.fit_options)
+    };
+    let report = Runner::new()
+        .threads(1)
+        .run(&list, &p.population, &options)
+        .expect("run");
+
+    let base = &report.results[0];
+    let no_ka = &report.results[2];
+    assert!(base.criterion.is_finite() && no_ka.criterion.is_finite());
+    assert_ne!(base.criterion, no_ka.criterion);
+    assert_eq!(
+        report.best().map(|r| r.id.as_str()),
+        Some(if base.criterion <= no_ka.criterion {
+            "base"
+        } else {
+            "no-ka-iiv"
+        })
+    );
+}
+
+#[test]
+fn the_fixtures_exist() {
+    // A wrong relative path would turn every test above into a `prepare_run`
+    // failure that reads like an engine problem.
+    assert!(Path::new(MODEL).exists(), "missing {MODEL}");
+    assert!(Path::new(DATA).exists(), "missing {DATA}");
+}

--- a/src/edit/mod.rs
+++ b/src/edit/mod.rs
@@ -442,14 +442,34 @@ fn split_keeping_terminators(src: &str) -> Vec<String> {
 
 /// A line with its comment and surrounding whitespace removed — what the
 /// parser reads. `#` and `//` both start a comment, whichever comes first.
+///
+/// A marker **inside a quoted string is content, not a comment**. This is the
+/// same rule [`canonical::squeeze`] applies to whitespace, and it is here for
+/// the same reason: with a naive cut at the first `#` or `//`, the two `[data]`
+/// paths `"s3://bucket/a.csv"` and `"s3://bucket/b.csv"` both truncate to
+/// `path = "s3:` and hash alike, so a search would fit one candidate and report
+/// its criterion for the other. An unterminated quote never cuts, which errs
+/// towards keeping text: a hash that keeps too much costs a refit, one that
+/// keeps too little costs a wrong answer.
 pub(crate) fn code_of(line: &str) -> &str {
-    let cut = line
-        .find('#')
-        .into_iter()
-        .chain(line.find("//"))
-        .min()
-        .unwrap_or(line.len());
-    line[..cut].trim()
+    let bytes = line.as_bytes();
+    let mut quote: Option<u8> = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        match quote {
+            Some(q) => {
+                if b == q {
+                    quote = None;
+                }
+            }
+            None if b == b'"' || b == b'\'' => quote = Some(b),
+            // Both markers are ASCII, so `i` is always a char boundary.
+            None if b == b'#' || (b == b'/' && bytes.get(i + 1) == Some(&b'/')) => {
+                return line[..i].trim();
+            }
+            None => {}
+        }
+    }
+    line.trim()
 }
 
 /// The leading whitespace of a line, excluding its own terminator (a blank

--- a/src/edit/mod_tests.rs
+++ b/src/edit/mod_tests.rs
@@ -251,6 +251,42 @@ fn canonical_hash_keeps_the_bytes_inside_a_quoted_value() {
     assert_eq!(spaced.canonical_hash(), reflowed.canonical_hash());
 }
 
+#[test]
+fn canonical_hash_keeps_a_comment_marker_inside_a_quoted_value() {
+    // `squeeze` copies a quoted string byte for byte, but it never sees one
+    // that `code_of` already cut: a naive "cut at the first `#` or `//`" ends
+    // both of these at `path = "s3:`, and the search then fits one candidate
+    // and reports its criterion for the other under `duplicate_of`.
+    for (a, b) in [
+        ("\"s3://bucket/a.csv\"", "\"s3://bucket/b.csv\""),
+        ("\"cohort#A.csv\"", "\"cohort#B.csv\""),
+        ("'s3://bucket/a.csv'", "'s3://bucket/b.csv'"),
+    ] {
+        let one = ModelText::parse(&format!("[data]\n  path = {a}\n")).unwrap();
+        let two = ModelText::parse(&format!("[data]\n  path = {b}\n")).unwrap();
+        assert_ne!(
+            one.canonical_hash(),
+            two.canonical_hash(),
+            "`{a}` and `{b}` canonicalised alike:\n{}",
+            one.canonical_form()
+        );
+        // And the straddle the pair exists to test: the marker must actually be
+        // past the opening quote, or both spellings survive a naive cut too.
+        assert!(a.find("//").or_else(|| a.find('#')).unwrap() > 0);
+    }
+}
+
+#[test]
+fn code_of_still_strips_a_comment_that_follows_a_quoted_value() {
+    // The quote closes before the marker, so the marker is a comment again —
+    // otherwise the fix would trade a wrong hash for an uncommentable line.
+    let with = ModelText::parse("[data]\n  path = \"a.csv\"  # the cohort\n").unwrap();
+    let without = ModelText::parse("[data]\n  path = \"a.csv\"\n").unwrap();
+    assert_eq!(with.canonical_hash(), without.canonical_hash());
+    let slashes = ModelText::parse("[data]\n  path = \"a.csv\"  // the cohort\n").unwrap();
+    assert_eq!(slashes.canonical_hash(), without.canonical_hash());
+}
+
 // ── SetFitOption ───────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Why

Part of #1175 (P0 — prerequisites). Depends on #1115 (`PoolPlan`) and the `ferx-core::edit` layer (#1176), both merged.

Every search tool the epic plans — covsearch, modelsearch, iivsearch, ruvsearch — is *generate candidates → fit them → rank them*, and the middle verb is identical each time: fit N candidates in parallel, deduplicate the ones that are the same model, cache and journal the results so an interrupted overnight search resumes, and emit a per-candidate table. `bootstrap/` already contains all of that (`journal.rs`, `manifest.rs`, `output.rs`) for one specific shape — resampled datasets rather than edited models. Writing it a second time per tool would be four copies of the same orchestration, each with its own resume bug.

## What changed

A new `ferx_tools::search` module — `Runner`, plus the types it consumes and produces. `ferx-core` is untouched.

**Identity is the canonical hash.** `Candidate::hash()` is the hex `ModelText::canonical_hash`, so a model reached twice by two different step orders is fitted **once** — pyDarwin's "model uniqueness" for free — and that same key addresses the journal row and the cached fit. A duplicate is not dropped: it comes back in the results carrying the representative's criterion and verdict plus `duplicate_of`, because a candidate missing from a report cannot be told apart from one the generator never produced.

**Parallelism goes through `PoolPlan::from_budget`** (#1115) rather than a bare outer `par_iter`. `fit()` already `par_iter`s over subjects, so nesting naively makes the two levels compete for the same workers; the plan splits the budget explicitly and gives the outer pool `FIT_RAYON_STACK_SIZE` instead of Rayon's 2 MiB default, and `apply_to` pins the inner fit to what is left.

**Retries before the gate.** Each candidate is fitted with `RunOptions::n_starts` (default 3) and only then judged by `check_strictness`. A candidate that fails the gate, fails to compile or fails to fit is kept with its reasons and lands in `candidates.csv`.

**Journal and resume.** With a cache directory:

```
.ferx-search/
  search_run.json          # criterion / n_starts / strictness / dataset fingerprint
  search_journal.jsonl     # one JSON object per finished candidate, flushed per row
  fits/<hash>.json         # the FitResult, so a resumed run is not a degraded one
  candidates.csv           # the table, rewritten in candidate order at the end
```

The journal is rewritten from its intact rows on open (through a `.part` sibling renamed into place), so a line truncated by a hard kill costs exactly one refit and the next append lands on a line boundary. `search_run.json` refuses a resume whose criterion, starts, strictness or dataset differ, naming the field — reusing a row means trusting a number another process computed under one convention.

**Cancellation** checks between candidates (and before the journal is opened, so a cancelled run never truncates the previous run's recovery data), returning partial results with `RunReport::cancelled`.

```rust
let report = Runner::new()
    .threads(8)
    .cache_dir(".ferx-search")
    .run(&candidates, &population, &RunOptions::default())?;
report.best()   // lowest criterion among the candidates that passed the gate
```

## Alternatives considered

- **Journal as CSV, like `bootstrap/raw_results.csv`.** A candidate's outcome is a verdict with a variable-length list of reasons, which is not a CSV row. Split instead: JSONL is the recovery log, CSV is the human-readable table.
- **Storing the `FitResult` inline in each journal row.** Keeps one file, but makes every line megabytes and the log ungreppable. The fit is a *cache* beside the log; a missing or corrupt `fits/<hash>.json` costs the reused candidate its `FitResult`, never its criterion and verdict.
- **Cloning the representative's `FitResult` into every duplicate.** One object per duplicate for a result the caller can already reach by id; `duplicate_of` says where it is.
- **Returning `Result<Vec<CandidateResult>, _>` as the issue sketched.** A cancelled run must return what finished, which an `Err(Cancelled)` cannot carry — hence `RunReport { results, cancelled, fitted, reused, deduped }`.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No `ferx-core` API change, so nothing for `ferx-r` to pick up.

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against: prior ferx commit (a direct `fit()` call), bit-for-bit

The Tier-2 oracle is **degenerate**: a candidate that is the base model unedited must give the OFV `fit()` gives on the same model and population, to the bit —

```rust
assert_eq!(base.ofv.to_bits(), direct.ofv.to_bits());
```

Anything the runner's own compile path drops — a covariate binding, the file's `[fit_options]`, the initial estimates — moves that number, and nothing else in the module would notice, since there is no second copy of the compile path to disagree with it. The other side of the oracle is asserted too: dropping `ETA_KA` must change both the hash *and* the objective, so an edit that never reached the engine fails rather than passing quietly.

This PR adds no numerical kernel — the criterion is `ferx_core::bic` / `FitResult::{ofv, aic}`, all validated in #1177 — so there is no new formula to anchor against NONMEM.

## Performance
- [x] No significant impact expected

New code, and its whole point is not to oversubscribe: `threads = 2` is asserted to never exceed 2 concurrent fits.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

**21 Tier-1 orchestration tests** drive a private `run_with_fitter` seam with an injected fitter. That is not a convenience: "two fits are in flight at once" is not observable from outside `fit()`, so the concurrency bound could not be *asserted* against real fits, only assumed — and every one of these tests would otherwise be a slow-tier convergence run. The one thing a fake fitter cannot fake is a `FitResult` (130-odd fields, no constructor), so the fixture is one genuine `outer_maxiter = 0` evaluation of `examples/warfarin.ferx`, memoized and cloned.

**8 Tier-2 tests** (`tests/search_runner_end_to_end.rs`) cover the real path — `ModelText` → `parse_full_model` → the data binders → `fit()` — with every fit an evaluation, so the file returns in 0.6 s.

**Three mutations were run to check the assertions can actually fail**, per the rule in CLAUDE.md:

| Mutation | Result |
|---|---|
| dedup disabled (`duplicate_of` never set) | `two_candidates_with_the_same_canonical_text_are_fitted_once` red — `left: ["first", "second"]` |
| thread budget ignored (`from_budget(0, …)`) | `the_thread_budget_bounds_concurrent_fits` red |
| resume filter removed | `a_resumed_run_refits_nothing_already_journalled` red — `left: ["a", "bb", "ccc"]` |

The middle one **passed the first time**, and fixing that is the most interesting part of the diff. The gauge originally left as soon as a second caller appeared, so every worker spent microseconds inside it and even an unbounded pool rarely had three fits in flight at once — `max <= 2` held under a deliberately broken budget. The gauge now holds a fixed dwell, which is what makes a wider pool actually reach a wider `max`; the reason is written into its doc comment so it cannot be "simplified" back.

A second finding, in the fixtures rather than the product: a Rayon worker blocked on a nested `install` keeps stealing work, so it re-entered `OnceLock::get_or_init` *in the middle of its own initialisation* and deadlocked. Observed as a hung test, not theorised. The fixture now initialises on a joined `std::thread`, which is not a Rayon latch, so the waiting worker steals nothing. `compile_and_fit` has no such lock, so this is a test-only hazard — but it is the kind that comes back, hence the comment.

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

No CLI flag, no `.ferx` syntax, no new `FitResult` field — this is the library layer the actual search tools will sit on.

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No user-visible change

Deliberately no `docs/` page: there is nothing a user can run yet. The `docs/tools/` page lands with the first search tool that has a CLI, alongside the `*.ferxsearch` configuration the epic specifies.

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), rustdoc, docs lint, public-API baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable — N/A, no gradient-reachable code touched
- [x] `Cargo.toml` version bump — N/A, additive

`cargo test -p ferx-tools`: 242 pass, 0 fail.

## Docs & examples

### ferx-site / ferx-book
No new DSL syntax, `[fit_options]` key, example `.ferx` or data file — nothing to mirror.

### Example execution
- [x] No example execution step needed (internal / no user-visible change)

## Reviewer hints

Worth the attention:

- **`runner.rs`, the assembly loop after the parallel section.** Results are emitted in submission order, and three cases have to come out right: a representative that was fitted, one that was reused from the journal, and a duplicate that points at either. A candidate whose representative was skipped by cancellation is omitted rather than emitted half-filled.
- **`journal.rs`, `CandidateRecord::{criterion, ofv}` being `Option<f64>`.** JSON has no `NaN`: `serde_json` writes a non-finite float as `null` and then refuses to read it back as `f64`, so a failed candidate stored as a bare `f64` would be a row that cannot be resumed from.
- **`SearchManifest::check_compatible`** — is the set of fields it guards the right one? The claim is that criterion, starts, strictness and dataset are exactly what a journalled row's meaning depends on.
- **`compile_and_fit` clones the `Population` per candidate**, because `bind_theta_levels` takes `&mut Population` to synthesize the level-index column (#1064). Cheap next to a fit, and a shared mutable population across concurrent candidates would be a data race by construction — but flag it if there is a better shape.

Skimmable: `output.rs` (a CSV writer), `candidate.rs` (data types and builders).

## Open questions

1. **`fit_options: Option<FitOptions>` in `RunOptions`.** `None` lets each candidate carry its own `[fit_options]`, which is what a search over models edited from one base file wants. `Some` replaces them wholesale, for a caller that needs one configuration across a space whose members disagree. Is wholesale replacement the right semantics, or should it be a merge?
2. **`RunOptions::n_starts` defaults to 3**, per the epic's "every candidate gets `n_starts ≥ 3`, non-negotiable". That is 3× the cost of a naive search by default. Keep it, or default to 1 and let the search tools set it?
3. **`journal` is a `pub mod`** so a search tool can read a finished run's rows without re-running it. If that is more surface than wanted, it can drop to `pub(crate)` with `read_records` re-exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REh3nwZwzixaoboE7rFvXz
