### PR TITLE
fix(ci): isolate the nn slow fits, and make a timeout fail red (part of #1239)

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -69,9 +69,20 @@ env:
 
 jobs:
   slow-tests:
-    name: Slow regression tests
+    name: Slow regression tests (${{ matrix.leg }})
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      # A failing leg must NOT cancel the other -- see the `fail-fast` note below.
+      fail-fast: false
+      matrix:
+        include:
+          - leg: core
+            cache: ci-slow
+            features: ferx-core/ci,ferx-core/survival,ferx-core/slow-tests,ferx-tools/slow-tests
+          - leg: nn
+            cache: ci-slow-nn
+            features: ferx-core/ci,ferx-core/survival,ferx-core/nn,ferx-core/slow-tests,ferx-tools/slow-tests
     steps:
       - uses: actions/checkout@v7
       - name: Install nightly toolchain
@@ -79,7 +90,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-slow
+          shared-key: ${{ matrix.cache }}
       - name: cargo test (ci-test profile + slow-tests)
         # `--profile ci-test` (defined in Cargo.toml) keeps release-level
         # optimisation so the heavy fits run fast, but drops fat LTO — the
@@ -115,63 +126,42 @@ jobs:
         # exactly what keeping it dependency-free was for (#969). The guard reads this
         # `--exclude` list, so adding or dropping one moves the path filter with it.
         #
-        # `ferx-core/nn`: the covariate-NN Tier-3 fits (`tests/nn_fit_smoke.rs`,
-        # `tests/nn_fit_convergence.rs`, `nn::regularizer_fit_tests`) are gated on BOTH
-        # `nn` and `slow-tests`. Without `nn` here those files compile to empty
-        # binaries and the `src/` bodies are `#[cfg]`ed out, so the only fits that
-        # exercise the DCM regularizers end to end would run in no CI job at all
-        # (the per-PR job that passes `nn` has no `slow-tests`, by design).
+        # `ferx-core/nn` is the second matrix leg, not part of the base list. #1215 added it
+        # to the single job that existed then, which switched on `tests/vi_dcm_omega_recovery.rs`
+        # (`#![cfg(feature = "nn")]`, 5 DCM VI/FOCEI fits) in CI for the first time. Those fits
+        # consumed the whole 120-minute budget, so the ~165 binaries ordered after them never
+        # ran -- five nightlies in a row covered less than they appeared to, and the NN fits are
+        # still gated on BOTH `nn` and `slow-tests`, so dropping the leg entirely would leave
+        # them running in no job at all (the per-PR job that passes `nn` has no `slow-tests`,
+        # by design). Separate legs keep both properties: the NN fits run, and an over-budget
+        # NN fit costs its own leg and nothing else.
         #
-        # `ferx-core/nn` is NOT here — it moved to the `slow-tests-nn` job below. It was
-        # added to this job by #1215, which switched on `tests/vi_dcm_omega_recovery.rs`
-        # (`#![cfg(feature = "nn")]`, 5 DCM VI/FOCEI fits) in CI for the first time. Those
-        # fits consumed the whole 120-minute budget, so the other ~165 test binaries after
-        # them never ran — five nightlies in a row covered less than they appeared to.
-        # Splitting the feature into its own job means an over-budget NN fit costs the NN
-        # job and nothing else.
+        # `fail-fast: false` above is load-bearing, not stylistic. A matrix leg failing cancels
+        # its siblings by default, which would put the base leg right back to being killed by
+        # the NN leg -- the bug this split exists to fix.
         #
-        # `timeout` is what makes that visible. A job killed by `timeout-minutes` is
-        # reported by GitHub as **`cancelled`, not `failure`** — it does not read as a red
-        # test, which is why the five timed-out nightlies looked like infra blips. Exceeding
-        # the inner budget here exits 124 and fails the step loudly instead.
+        # `timeout` is what makes an overrun visible. A job killed by `timeout-minutes` is
+        # reported by GitHub as **`cancelled`, not `failure`** -- it does not read as a red test,
+        # which is why the five timed-out nightlies looked like infra blips. Exceeding the inner
+        # budget exits 124 and fails the step loudly instead.
+        #
+        # 100m is derived, not picked: the suite ran in 43m on a fast runner, and the measured
+        # spread across `ubuntu-latest` draws is 1.7x (same commit, same features -- see #1239),
+        # giving ~74m worst case. 100m leaves headroom over that while staying clear of the 120m
+        # job ceiling, which must also absorb checkout, toolchain install and cache restore.
+        #
+        # KNOWN: the `nn` leg is expected to stay RED until #1239 sizes those fits -- it was
+        # unfinished after 13 minutes at ~7 cores locally, and this runner gives it 2 cores with
+        # `RAYON_NUM_THREADS: 1`. That is deliberate: a red leg is the honest signal, and it no
+        # longer costs the base leg. If it is still red long enough to become background noise,
+        # fix #1239 rather than muting it here.
         run: |
           timeout --signal=INT --kill-after=2m 100m \
             cargo test --workspace --exclude docs-lint --no-default-features \
-              --features ferx-core/ci,ferx-core/survival,ferx-core/slow-tests,ferx-tools/slow-tests \
+              --features ${{ matrix.features }} \
               --profile ci-test --no-fail-fast \
             || { code=$?; \
                  if [ "$code" -eq 124 ]; then \
-                   echo "::error::slow-tests exceeded its 100m budget - a test is hanging or the suite outgrew the runner"; \
-                 fi; \
-                 exit "$code"; }
-
-  # The `nn`-gated Tier-3 fits, isolated so they cannot spend the main suite's budget.
-  #
-  # Same command and same `--exclude` list as above (the `slow_test_path_filter` guard reads
-  # both), plus `ferx-core/nn`. Kept as a full `--workspace` run rather than an enumerated
-  # list of NN test targets on purpose: a new `#![cfg(feature = "nn")]` test file would be
-  # silently uncovered by a list, which is the failure mode #949 already cost this repo once.
-  # The duplicated non-NN work is the price, and it is a nightly.
-  slow-tests-nn:
-    name: Slow regression tests (nn)
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install nightly toolchain
-        run: rustup toolchain install nightly --profile minimal
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ci-slow-nn
-      - name: cargo test (ci-test profile + slow-tests + nn)
-        run: |
-          timeout --signal=INT --kill-after=2m 100m \
-            cargo test --workspace --exclude docs-lint --no-default-features \
-              --features ferx-core/ci,ferx-core/survival,ferx-core/nn,ferx-core/slow-tests,ferx-tools/slow-tests \
-              --profile ci-test --no-fail-fast \
-            || { code=$?; \
-                 if [ "$code" -eq 124 ]; then \
-                   echo "::error::slow-tests (nn) exceeded its 100m budget - see FeRx-NLME/ferx-core#1239"; \
+                   echo "::error::slow-tests (${{ matrix.leg }}) exceeded its 100m budget - a test is hanging or the suite outgrew the runner; see FeRx-NLME/ferx-core#1239"; \
                  fi; \
                  exit "$code"; }

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -121,7 +121,57 @@ jobs:
         # binaries and the `src/` bodies are `#[cfg]`ed out, so the only fits that
         # exercise the DCM regularizers end to end would run in no CI job at all
         # (the per-PR job that passes `nn` has no `slow-tests`, by design).
+        #
+        # `ferx-core/nn` is NOT here — it moved to the `slow-tests-nn` job below. It was
+        # added to this job by #1215, which switched on `tests/vi_dcm_omega_recovery.rs`
+        # (`#![cfg(feature = "nn")]`, 5 DCM VI/FOCEI fits) in CI for the first time. Those
+        # fits consumed the whole 120-minute budget, so the other ~165 test binaries after
+        # them never ran — five nightlies in a row covered less than they appeared to.
+        # Splitting the feature into its own job means an over-budget NN fit costs the NN
+        # job and nothing else.
+        #
+        # `timeout` is what makes that visible. A job killed by `timeout-minutes` is
+        # reported by GitHub as **`cancelled`, not `failure`** — it does not read as a red
+        # test, which is why the five timed-out nightlies looked like infra blips. Exceeding
+        # the inner budget here exits 124 and fails the step loudly instead.
         run: |
-          cargo test --workspace --exclude docs-lint --no-default-features \
-            --features ferx-core/ci,ferx-core/survival,ferx-core/nn,ferx-core/slow-tests,ferx-tools/slow-tests \
-            --profile ci-test --no-fail-fast
+          timeout --signal=INT --kill-after=2m 100m \
+            cargo test --workspace --exclude docs-lint --no-default-features \
+              --features ferx-core/ci,ferx-core/survival,ferx-core/slow-tests,ferx-tools/slow-tests \
+              --profile ci-test --no-fail-fast \
+            || { code=$?; \
+                 if [ "$code" -eq 124 ]; then \
+                   echo "::error::slow-tests exceeded its 100m budget - a test is hanging or the suite outgrew the runner"; \
+                 fi; \
+                 exit "$code"; }
+
+  # The `nn`-gated Tier-3 fits, isolated so they cannot spend the main suite's budget.
+  #
+  # Same command and same `--exclude` list as above (the `slow_test_path_filter` guard reads
+  # both), plus `ferx-core/nn`. Kept as a full `--workspace` run rather than an enumerated
+  # list of NN test targets on purpose: a new `#![cfg(feature = "nn")]` test file would be
+  # silently uncovered by a list, which is the failure mode #949 already cost this repo once.
+  # The duplicated non-NN work is the price, and it is a nightly.
+  slow-tests-nn:
+    name: Slow regression tests (nn)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install nightly toolchain
+        run: rustup toolchain install nightly --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-slow-nn
+      - name: cargo test (ci-test profile + slow-tests + nn)
+        run: |
+          timeout --signal=INT --kill-after=2m 100m \
+            cargo test --workspace --exclude docs-lint --no-default-features \
+              --features ferx-core/ci,ferx-core/survival,ferx-core/nn,ferx-core/slow-tests,ferx-tools/slow-tests \
+              --profile ci-test --no-fail-fast \
+            || { code=$?; \
+                 if [ "$code" -eq 124 ]; then \
+                   echo "::error::slow-tests (nn) exceeded its 100m budget - see FeRx-NLME/ferx-core#1239"; \
+                 fi; \
+                 exit "$code"; }


### PR DESCRIPTION
## Why

`Slow tests` has been killed at its 120-minute timeout on **every run since #1215 merged**, and it
did not look like a failure: a `timeout-minutes` kill is reported by GitHub as **`cancelled`, not
`failure`**. Five nightlies in a row read as infra blips while the suite was silently covering
~20 fewer test binaries than it appeared to.

Full diagnosis in #1239. In short:

#1215 added `ferx-core/nn` to this job so the new DCM regularizer fits would run somewhere — a
reasonable call. It also switched on every *other* `nn`-gated Tier-3 file, and
`tests/vi_dcm_omega_recovery.rs` (`#![cfg(feature = "nn")]`, 5 DCM VI/FOCEI fits) had **never run
in CI**. Both timed-out runs die identically:

| run | last output | killed | silence |
|---|---|---|---|
| [33914230476](https://github.com/FeRx-NLME/ferx-core/actions/runs/33914230476) | 20:38:52 `Running tests/vi_dcm_omega_recovery.rs` | 22:02:55 | **84 min** |
| [33917510422](https://github.com/FeRx-NLME/ferx-core/actions/runs/33917510422) | 21:18:08 | 22:42:09 | **84 min** |

**It is compute, not a deadlock.** Locally that binary sits at 590–790% CPU (~7 cores) and is
still unfinished after 13 minutes. This job pins `RAYON_NUM_THREADS: 1` on a 2-core runner while
libtest runs 4 of the 5 tests concurrently — four heavy fits contending for two cores.

## What changed

Two changes, neither touching the fits:

1. **`ferx-core/nn` moves to its own `slow-tests-nn` job.** An over-budget NN fit now costs that
   job and nothing else, instead of taking ~165 unrelated binaries down with it.
2. **Both jobs run under `timeout 100m`**, so exceeding the budget exits 124 and fails the step
   loudly with an `::error::` annotation, rather than being reported as `cancelled`.

## Alternatives considered

- **Just raise `timeout-minutes`.** Rejected: it does not fix the silent-coverage-loss half, and
  the NN fits would still be able to consume the whole budget.
- **Enumerate the NN test targets in job 2** instead of a full `--workspace` run. Rejected: a new
  `#![cfg(feature = "nn")]` file would go silently uncovered — exactly the stale-list failure mode
  #949 already cost this repo. The duplicated non-NN work is the price, and this is a nightly.
- **Relax `RAYON_NUM_THREADS: 1` or use a larger runner for the NN job.** Plausibly the right
  answer, but it changes fit reproducibility and is a call for whoever owns the DCM work — #1239.

## Breaking changes
- [x] None. CI only.

## Numerical validation
- [x] Not applicable (CI only)

## Tests
- [x] No new tests needed

`tests/slow_test_path_filter.rs` is the guard that pins this workflow, and it passes **11/11**. It
collects `--exclude` tokens from the whole file, so the second job's identical `--exclude
docs-lint` leaves its expectations unchanged. The workflow also parses as valid YAML with both
jobs present.

## Docs
- [x] No user-visible change — no CHANGELOG entry (CI only)

## Reviewer hints

The duplication in job 2 is deliberate and is the main thing to push back on if you disagree — see
Alternatives. Everything else is mechanical.

Worth knowing for the future regardless of this PR: **a `timeout-minutes` kill is `cancelled`, not
`failure`.** Any job that can outgrow its budget can go quiet this way, and the `timeout` wrapper
here is the general remedy.

## Open questions

This unblocks the nightly; it does **not** make the fits affordable — the NN job will likely still
hit its budget until the fits are sized. That is #1239 and I have not attempted it, since it is a
judgement call about what those 5 fits are meant to prove.

Separately, and noted in #1239 rather than fixed here: compiling `ferx-core --features nn
--profile ci-test` took **2h20m** in a single `rustc` locally, versus ~15 min both without `nn` and
with `nn` at `19fdbb04`. That may share a root cause with the runtime cost.

**Partially addresses #1239 — deliberately does NOT close it.** This stops one over-budget
binary from taking down the whole nightly and makes an overrun visible. The substantive half of
#1239 is untouched: the 5 DCM fits are still unaffordable under `RAYON_NUM_THREADS: 1` on a
2-core runner, and the 2h20m `nn` compile is unexplained. #1239 stays open for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

