### PR TITLE
feat(api): make the unsupported-keys warning model-aware for the ODE solver keys [closes #518]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,12 @@ section of the SDLC for the versioning policy).
   bundled data by the bundled model too, so a reloaded joint fit keeps its event records.
 
 ### Changed
+- **The unused-fit-option warning is model-aware for the ODE solver keys (#518).** Setting
+  `ode_reltol` / `ode_abstol` / `ode_max_steps` / `ode_method` / `ode_stiff_abort_after` /
+  `ode_auto_switch` on a model that never integrates — analytical PK with no `[odes]` block and
+  no closed-form absorption ODE twin — now warns that the key has no effect, instead of being
+  dropped silently. Models that do integrate (including a closed-form transit / inverse-Gaussian
+  model reaching its twin) still never warn on these keys, as of #517.
 - **FREM prep refuses a model with a non-Gaussian endpoint (#1199).** `prepare_frem()` /
   `transform_dataset_for_frem()` return `E_FREM_NON_GAUSSIAN_ENDPOINT` instead of writing
   a dataset from the Gaussian rows alone; run the FREM step on the PK model without the

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -94,6 +94,8 @@ The post-fit covariance step. See [Covariance Step](../estimation/foce.qmd#covar
 
 Accuracy and step budget for `[odes]` models, and for the auto-generated ODE twin that closed-form transit / inverse-Gaussian absorption models carry. See [ODE Models](ode-models.qmd#solver-details).
 
+#### Where the value comes from {#ode-tolerance-precedence}
+
 These six keys (and the two stepper keys below) can also arrive from a caller, and precedence is **per key** either way: a key the caller sets wins over the model file for that fit, a key the caller does not set keeps the file's value. What counts as "set" differs between the two front ends, so check which one you are on.
 
 From **R**, `ferx_fit(settings = list(ode_reltol = 1e-9))` merges your settings onto the model file's own `[fit_options]` and stamps the result on the model. Every key you name wins — *including* one you name with its default value, so `settings = list(ode_reltol = 1e-4)` does pull a file that pinned `1e-10` back to `1e-4`. Keys you leave out keep whatever the file said.
@@ -101,6 +103,10 @@ From **R**, `ferx_fit(settings = list(ode_reltol = 1e-9))` merges your settings 
 From **Rust**, `fit(&model, &pop, &params, &options)` — and equally `run_covariance()`, `run_sir()` and `run_sir_core()`, which integrate the same way — compares your `FitOptions` field by field against `FitOptions::default()` and carries only the moved fields for the duration of that call, so a hand-built settings struct cannot silently loosen a model that pinned `ode_reltol = 1e-10`. The consequence is the mirror image of the R rule: asking explicitly for a default value (`ode_reltol = 1e-4`) reads the same as not asking, and the model file still wins. That override also lasts exactly one `fit()` — a later `predict()` on the same `&CompiledModel` integrates at the model file's values, so a fit's IPREDs and a subsequent `predict()` can come from different tolerances. Call `model.sync_ode_solver_opts(&options)` on an owned model when both paths must match (that is what the R front end does).
 
 Put the key in `[fit_options]` when a model needs a specific accuracy regardless of who runs it.
+
+Set one of these on a model that never integrates — an analytical PK model with no `[odes]` block and no closed-form absorption twin — and the fit warns that the key has no effect (#518), instead of dropping it silently. A model that *does* integrate, including a closed-form transit / inverse-Gaussian model reaching its twin, never draws that warning.
+
+#### The keys {#ode-tolerance-keys}
 
 | Key | Values | Default | Description |
 |-----|--------|---------|-------------|

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -931,7 +931,10 @@ fn fit_inner(
     // Compute up-front so we can both surface the warnings before the fit
     // starts (a long-running fit shouldn't bury a "this option is unused"
     // notice at the end) and carry them through into FitResult.warnings.
-    let mut pre_run_warnings = options.unsupported_keys_warnings();
+    // Model-aware: the `ode_*` solver knobs are framework-level for every *method*
+    // but conditional on the *model* (#518) — on a model that never integrates they
+    // are silently dropped, so say so rather than staying quiet.
+    let mut pre_run_warnings = options.unsupported_keys_warnings_with_model(model);
     // Surface a "no method specified, defaulting to FOCEI" notice through the
     // same channel so it reaches both stderr and FitResult.warnings.
     if let Some(w) = options.method_default_warning() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -7773,7 +7773,9 @@ impl FitOptions {
                 continue;
             }
             warnings.push(format!(
-                "fit option `{key}` configures the ODE integrator, but this model has no                  `[odes]` block (and no closed-form absorption ODE twin), so it has no effect."
+                "fit option `{key}` configures the ODE integrator, but this model has \
+                 no `[odes]` block (and no closed-form absorption ODE twin), so it \
+                 has no effect."
             ));
         }
         warnings

--- a/src/types.rs
+++ b/src/types.rs
@@ -3834,6 +3834,20 @@ impl CompiledModel {
         self.ode_spec.is_some()
     }
 
+    /// Returns true when the `ode_*` solver knobs actually reach an integrator for
+    /// this model — i.e. when [`CompiledModel::sync_ode_solver_opts`] has something to
+    /// stamp them onto.
+    ///
+    /// Not the same predicate as [`Self::is_ode_based`]. A **closed-form**
+    /// transit/IG model is analytic, yet carries an absorption ODE twin
+    /// (`absorption_ode_equivalent`, #814) that its TV-covariate / `TIME` / IOV
+    /// subjects integrate on — and `sync_ode_solver_opts` stamps the tolerances onto
+    /// that twin too. So the keys are live there even though `ode_spec` is `None`,
+    /// and warning "this model has no `[odes]` block" would be wrong.
+    pub(crate) fn honors_ode_solver_opts(&self) -> bool {
+        self.ode_spec.is_some() || self.absorption_ode_equivalent.is_some()
+    }
+
     /// Returns true for a **compartment-free** (`$PRED`-equivalent) model — one
     /// whose `[structural_model]` declares its prediction as an equation with no
     /// compartments underneath (issue #811).
@@ -7730,6 +7744,41 @@ impl FitOptions {
         warnings
     }
 
+    /// [`Self::unsupported_keys_warnings`] plus the **model-conditional** notices.
+    ///
+    /// A handful of `framework_keys()` entries are framework-level with respect to the
+    /// *method* — every estimator honours them — but conditional on the *model*. The
+    /// `ode_*` solver knobs are the case in point: `sync_ode_solver_opts` applies them
+    /// on any model that integrates, and is a silent no-op on one that does not. Since
+    /// [`Self::unsupported_keys_warnings`] only sees `FitOptions`, listing them in
+    /// `framework_keys()` (#517) suppressed the false positive on ODE models at the
+    /// price of a false *negative* on analytical ones (#518). This variant takes the
+    /// model, so it can say which it is.
+    ///
+    /// The method-level warnings are unchanged; this only appends notices.
+    pub(crate) fn unsupported_keys_warnings_with_model(
+        &self,
+        model: &CompiledModel,
+    ) -> Vec<String> {
+        let mut warnings = self.unsupported_keys_warnings();
+        if model.honors_ode_solver_opts() {
+            return warnings;
+        }
+        let mut seen = std::collections::HashSet::new();
+        for key in &self.user_set_keys {
+            if !ode_solver_keys().contains(&key.as_str()) {
+                continue;
+            }
+            if !seen.insert(key.clone()) {
+                continue;
+            }
+            warnings.push(format!(
+                "fit option `{key}` configures the ODE integrator, but this model has no                  `[odes]` block (and no closed-form absorption ODE twin), so it has no effect."
+            ));
+        }
+        warnings
+    }
+
     /// Warn when no estimation method was set anywhere — neither in the model
     /// file's `[fit_options]` nor by the caller (CLI / R / Python wrapper).
     /// In that case `method` carries its `FOCEI` default, and the user may not
@@ -7749,6 +7798,24 @@ impl FitOptions {
             self.method.label()
         ))
     }
+}
+
+/// The `ode_*` subset of [`framework_keys`]: knobs that only ever reach the ODE
+/// integrator, via [`CompiledModel::sync_ode_solver_opts`].
+///
+/// Kept as its own list so [`FitOptions::unsupported_keys_warnings_with_model`] can
+/// treat exactly these as model-conditional. `framework_keys` still carries them, so
+/// they never draw the method-level "not used by method" warning; a unit test pins the
+/// subset relation so the two lists cannot drift.
+pub(crate) fn ode_solver_keys() -> &'static [&'static str] {
+    &[
+        "ode_reltol",
+        "ode_abstol",
+        "ode_max_steps",
+        "ode_method",
+        "ode_stiff_abort_after",
+        "ode_auto_switch",
+    ]
 }
 
 /// Framework-level fit-option keys: consumed by every method and typically

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -2754,3 +2754,141 @@ mod theta_block_scale_guards {
         assert!(compact_theta_blocks(&names).is_empty());
     }
 }
+
+// ---------------------------------------------------------------------------
+// #518: the unsupported-keys warning is model-aware for the `ode_*` knobs.
+//
+// #517 fixed a false positive by adding the ODE-solver keys to `framework_keys()`,
+// which suppresses the "not used by method" warning *unconditionally* — including on
+// an analytical model, where `sync_ode_solver_opts` is a no-op and the keys really do
+// nothing. `unsupported_keys_warnings_with_model` restores that diagnostic without
+// bringing the false positive back.
+// ---------------------------------------------------------------------------
+
+/// Build a `FitOptions` whose `user_set_keys` names exactly `keys` (the field the
+/// warning layer reads); the values themselves are irrelevant to the warning.
+fn opts_with_user_set_keys(keys: &[&str]) -> FitOptions {
+    FitOptions {
+        user_set_keys: keys.iter().map(|k| k.to_string()).collect(),
+        ..FitOptions::default()
+    }
+}
+
+#[test]
+fn ode_solver_keys_are_a_subset_of_framework_keys() {
+    // The two lists are separate on purpose — `framework_keys` suppresses the
+    // *method*-level warning, `ode_solver_keys` selects the *model*-conditional
+    // notice — but an `ode_*` key missing from the former would draw the old
+    // spurious "not used by method FOCEI" warning again (#516/#517). Pin the
+    // subset relation so the lists cannot drift apart.
+    let fw = framework_keys();
+    for k in ode_solver_keys() {
+        assert!(
+            fw.contains(k),
+            "`{k}` is in ode_solver_keys() but not framework_keys() — it would \
+             spuriously warn as method-unsupported"
+        );
+    }
+}
+
+#[test]
+fn analytical_model_warns_that_ode_solver_keys_have_no_effect() {
+    let model = test_helpers::analytical_model(GradientMethod::Auto);
+    assert!(!model.honors_ode_solver_opts());
+
+    let opts = opts_with_user_set_keys(&["ode_reltol"]);
+    let w = opts.unsupported_keys_warnings_with_model(&model);
+
+    assert_eq!(w.len(), 1, "expected exactly one warning, got: {w:?}");
+    assert!(w[0].contains("ode_reltol"), "got: {}", w[0]);
+    assert!(w[0].contains("`[odes]` block"), "got: {}", w[0]);
+    // The method-level phrasing would be the wrong diagnosis here: the key is
+    // fine for FOCEI, it is the *model* that never integrates.
+    assert!(!w[0].contains("is not used by method"), "got: {}", w[0]);
+}
+
+#[test]
+fn analytical_model_warns_once_per_distinct_ode_solver_key() {
+    let model = test_helpers::analytical_model(GradientMethod::Auto);
+    // Every key in the list must be covered, and a duplicate must not double up.
+    let mut keys: Vec<&str> = ode_solver_keys().to_vec();
+    keys.push("ode_reltol");
+    let opts = opts_with_user_set_keys(&keys);
+
+    let w = opts.unsupported_keys_warnings_with_model(&model);
+    assert_eq!(
+        w.len(),
+        ode_solver_keys().len(),
+        "one notice per distinct key, got: {w:?}"
+    );
+    for k in ode_solver_keys() {
+        assert!(
+            w.iter().any(|m| m.contains(k)),
+            "no notice named `{k}`: {w:?}"
+        );
+    }
+}
+
+#[test]
+fn ode_model_does_not_warn_on_ode_solver_keys() {
+    // The #517 regression guard, at the model tier: `sync_ode_solver_opts` does
+    // apply these here, so neither the method-level nor the model-level layer
+    // may say a word.
+    let model = test_helpers::ode_model(GradientMethod::Auto);
+    assert!(model.honors_ode_solver_opts());
+
+    let opts = opts_with_user_set_keys(ode_solver_keys());
+    assert!(
+        opts.unsupported_keys_warnings_with_model(&model).is_empty(),
+        "ODE model warned on solver keys: {:?}",
+        opts.unsupported_keys_warnings_with_model(&model)
+    );
+}
+
+#[test]
+fn closed_form_absorption_twin_suppresses_the_ode_solver_key_notice() {
+    // The predicate is *not* `is_ode_based()`. A closed-form transit primary is
+    // analytic (`ode_spec == None`) but carries an absorption ODE twin (#814) that
+    // `sync_ode_solver_opts` also stamps, so the keys are live and "this model has
+    // no `[odes]` block" would be a false positive of the kind #517 removed.
+    use crate::parser::model_parser::parse_model_string;
+    let model = parse_model_string(TRANSIT_IOV_TOL_SRC).expect("parse transit+IOV");
+    assert!(!model.is_ode_based(), "the transit primary is analytic");
+    assert!(
+        model.absorption_ode_equivalent.is_some(),
+        "it carries a twin"
+    );
+    assert!(model.honors_ode_solver_opts());
+
+    let opts = opts_with_user_set_keys(ode_solver_keys());
+    assert!(
+        opts.unsupported_keys_warnings_with_model(&model).is_empty(),
+        "twin-carrying analytic model warned: {:?}",
+        opts.unsupported_keys_warnings_with_model(&model)
+    );
+}
+
+#[test]
+fn model_aware_warnings_keep_the_method_level_ones() {
+    // The model layer only *appends*: a genuinely method-unsupported key must still
+    // produce its own warning alongside the ODE notice.
+    let model = test_helpers::analytical_model(GradientMethod::Auto);
+    let opts = opts_with_user_set_keys(&["n_convergence", "ode_abstol"]);
+
+    let w = opts.unsupported_keys_warnings_with_model(&model);
+    assert_eq!(w.len(), 2, "got: {w:?}");
+    assert!(
+        w.iter()
+            .any(|m| m.contains("n_convergence") && m.contains("is not used by method")),
+        "lost the method-level warning: {w:?}"
+    );
+    assert!(
+        w.iter().any(|m| m.contains("ode_abstol")),
+        "lost the model-level notice: {w:?}"
+    );
+    // The model-agnostic entry point is unchanged — it still sees only the
+    // method-level miss, which is what keeps the public API's contract stable.
+    let base = opts.unsupported_keys_warnings();
+    assert_eq!(base.len(), 1, "got: {base:?}");
+    assert!(base[0].contains("n_convergence"), "got: {}", base[0]);
+}

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -2800,8 +2800,16 @@ fn analytical_model_warns_that_ode_solver_keys_have_no_effect() {
     let w = opts.unsupported_keys_warnings_with_model(&model);
 
     assert_eq!(w.len(), 1, "expected exactly one warning, got: {w:?}");
-    assert!(w[0].contains("ode_reltol"), "got: {}", w[0]);
-    assert!(w[0].contains("`[odes]` block"), "got: {}", w[0]);
+    // Pinned in full, not by `contains`. This string is user-facing — it reaches the
+    // CLI and the fit YAML verbatim — and a `\`-continuation in the source silently
+    // keeps the next line's indentation unless the escape is exactly right, which is
+    // how a run of 18 spaces shipped in review. A substring check cannot see that.
+    assert_eq!(
+        w[0],
+        "fit option `ode_reltol` configures the ODE integrator, but this model has \
+         no `[odes]` block (and no closed-form absorption ODE twin), so it has no \
+         effect."
+    );
     // The method-level phrasing would be the wrong diagnosis here: the key is
     // fine for FOCEI, it is the *model* that never integrates.
     assert!(!w[0].contains("is not used by method"), "got: {}", w[0]);
@@ -2825,6 +2833,14 @@ fn analytical_model_warns_once_per_distinct_ode_solver_key() {
         assert!(
             w.iter().any(|m| m.contains(k)),
             "no notice named `{k}`: {w:?}"
+        );
+    }
+    // No notice may carry a run of whitespace. The exact-message assertion above
+    // pins one key's text; this covers the other five, and any key added later.
+    for m in &w {
+        assert!(
+            !m.contains("  "),
+            "notice contains a run of spaces — check the `\\` line continuations: {m:?}"
         );
     }
 }


### PR DESCRIPTION
## Why

Closes #518. Follow-up to #517 / #516.

#517 fixed a false positive: `ode_reltol` / `ode_abstol` / `ode_max_steps` were flagged *"not used by method `<M>` and will be ignored"* on ODE models even though `CompiledModel::sync_ode_solver_opts` applies them. The fix added the keys to `framework_keys()`, which suppresses the warning **unconditionally**.

`framework_keys()` is method- *and* model-agnostic — `FitOptions::unsupported_keys_warnings()` only ever sees `FitOptions`, never the `CompiledModel`. So the keys now never warn, including on an **analytical** model where `sync_ode_solver_opts` is a no-op and they genuinely do nothing. A false positive on ODE models was traded for a silent false negative on analytical ones.

This does not change whether the options *work*; they already work on every model that integrates. It is a diagnostics fix.

## What changed

- **`FitOptions::unsupported_keys_warnings_with_model(&self, model: &CompiledModel)`** (`src/types.rs`) — delegates to the existing `unsupported_keys_warnings()` for the method-level warnings, then **appends** one tailored notice per user-set `ode_*` key when the model never integrates:

  > ``fit option `ode_reltol` configures the ODE integrator, but this model has no `[odes]` block (and no closed-form absorption ODE twin), so it has no effect.``

- **`CompiledModel::honors_ode_solver_opts()`** — `ode_spec.is_some() || absorption_ode_equivalent.is_some()`.

- **`ode_solver_keys()`** — the `ode_*` subset of `framework_keys()`, as its own list so the model-conditional treatment names exactly those keys.

- **`src/api/fit.rs`** — `fit_inner` calls the model-aware variant; `model: &CompiledModel` was already in scope, so there is no plumbing.

Two things worth flagging:

**The predicate is deliberately not `is_ode_based()`.** A closed-form transit / inverse-Gaussian model is analytic (`ode_spec == None`) but carries an absorption ODE twin (#814) that `sync_ode_solver_opts` also stamps — its TV-covariate / `TIME` / IOV subjects integrate on it. Gating on `is_ode_based()` would tell those users "this model has no `[odes]` block" while the keys were in fact live, i.e. it would reintroduce exactly the class of false positive #517 removed.

**All six `ode_*` keys, not just the three the issue names.** `ode_method`, `ode_stiff_abort_after` and `ode_auto_switch` are stamped by the same function and are equally inert on a non-integrating model; warning on three of six would be arbitrary.

The optional generalisation in the issue (`frem_*` → needs FREM, `iov_column` → needs IOV) is **not** included — those want their own model predicates and their own tests, and the issue itself flags them as a possible follow-up.

## Alternatives considered

- **Change the signature of the public `unsupported_keys_warnings`** (to take `Option<&CompiledModel>`, as the issue's first bullet suggests). Rejected: it breaks a public-API item for a low-priority diagnostic and churns ~40 existing call sites in tests, for no gain — the only production caller is `fit_inner`, which is in-crate.
- **Add the model-aware entry point as `pub`.** Rejected: nothing outside the crate calls it (ferx-r does not use this API at all), so widening the surface would fail the "which tool needs this item" test in CLAUDE.md. Everything added here is `pub(crate)`; the committed baseline is unchanged.
- **Drop the keys back out of `framework_keys()`** and rely solely on the model layer. Rejected: they would then draw the method-level "not used by method FOCEI" warning again on ODE models — the #516 bug. A unit test now pins `ode_solver_keys() ⊆ framework_keys()` so this cannot regress by accident.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-API change, and `ferx-r` does not call this API.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [x] **None** — every new item is `pub(crate)`; `tools/update-public-api.sh --check` reports *"public API matches the committed baseline"*.

## Numerical validation
- [x] **Not applicable** (diagnostics only). No estimator, objective, gradient or output value is touched: the change adds strings to `FitResult.warnings` and nothing else. `sync_ode_solver_opts` is untouched, so which models honour the keys is exactly as before.

## Performance
- [x] No significant impact expected — one `Vec<String>` scan over `user_set_keys`, once per fit, guarded by an early return on models that integrate.

## Tests
- [x] Unit tests added (Tier 1, `src/types_tests.rs`) — `cargo test --lib --features ci`: **4041 passed, 0 failed**.
- [x] Regression test that fails without this fix — `analytical_model_warns_that_ode_solver_keys_have_no_effect` returns an empty vec on `main`.

Six tests, and what each exists to catch:

| Test | Catches |
|---|---|
| `analytical_model_warns_that_ode_solver_keys_have_no_effect` | the #518 false negative; also asserts the message is *not* the method-level phrasing, which would be the wrong diagnosis |
| `ode_model_does_not_warn_on_ode_solver_keys` | the #516/#517 false positive, now at the model tier |
| `closed_form_absorption_twin_suppresses_the_ode_solver_key_notice` | a naive `is_ode_based()` predicate — this model is `ode_spec == None` **and** must stay silent |
| `analytical_model_warns_once_per_distinct_ode_solver_key` | a key dropped from the notice, and a duplicate `user_set_keys` entry doubling up |
| `model_aware_warnings_keep_the_method_level_ones` | the model layer swallowing or replacing the method-level warnings; also pins the model-agnostic entry point's behaviour as unchanged |
| `ode_solver_keys_are_a_subset_of_framework_keys` | the two lists drifting — an `ode_*` key in one and not the other resurrects #516 |

Per the "a green test is not evidence that it can fail" rule in CLAUDE.md: the analytical and ODE tests **straddle** the predicate (same keys, opposite branch), each asserting `honors_ode_solver_opts()` explicitly, so neither can silently start taking the same arm as the other. There is no `is_empty()` fast path in front of the filter — the loop runs on any non-empty `user_set_keys` — so the mutation "filter the wrong key set" is reachable from these fixtures.

## Example

```toml
[structural_model]
  pk one_cpt_iv(cl=CL, v=V)   # analytical: no [odes] block, no absorption twin

[fit_options]
  method     = focei
  ode_reltol = 1e-9
```

Before: silent. After, in `FitResult.warnings` and on the CLI:

```
fit option `ode_reltol` configures the ODE integrator, but this model has no `[odes]`
block (and no closed-form absorption ODE twin), so it has no effect.
```

An `[odes]` model — or a `one_cpt_transit` / `two_cpt_ig` model reaching its twin — with the same keys emits nothing.

## Docs
- [x] `docs/model-file/fit-options.qmd` — a paragraph under *ODE solver tolerances* stating when the keys warn.
- [x] `CHANGELOG.md` `[Unreleased] → Changed` entry.
- [ ] New pages linked in `docs/_quarto.yml` — no new page.

Note: the added paragraph pushed *ODE solver tolerances* to 5,075 characters and R1 (the 5,000-char terminal-section rule) went red. It is split under two `####` subheadings — `Where the value comes from {#ode-tolerance-precedence}` and `The keys {#ode-tolerance-keys}` — rather than added to `docs/.lint-baseline`, per the ratchet rule. The `#ode-solver-tolerances` anchor is unchanged, so existing links still resolve.

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy `--all-targets`, rustdoc, docs lint, public-API baseline.
- [x] Nothing on the `Dual2` sensitivity path is touched.
- [ ] `Cargo.toml` version bump — not needed (non-breaking).

## Docs & examples

### ferx-site / ferx-book
- [x] No new DSL syntax, no new `[fit_options]` key, no new example file or data file — the six keys already exist and are already documented. Only their diagnostics changed.

### Example execution
- [x] No example execution step needed — no user-visible change to any example's *results*; the only change is an extra warning line on a model that sets an `ode_*` key it cannot use, which no committed example does.

## Reviewer hints

The one line worth arguing about is the predicate in `honors_ode_solver_opts()` (`src/types.rs`). Everything else follows from it. `closed_form_absorption_twin_suppresses_the_ode_solver_key_notice` is the test that would go red if it were narrowed to `is_ode_based()`.

Skimmable: the tests, the changelog, the docs split.

## Open questions

Should the follow-up generalisation (`frem_*` → needs FREM, `iov_column` → needs IOV) be its own issue? The mechanism here is deliberately shaped so those slot in as extra key-lists plus predicates, but each needs a model predicate that does not exist yet, so I left them out rather than guess at the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cq3rZMmYAA7dSZsQAMhE1j
