### PR TITLE
feat(api): derive Default on UncertaintyMethod and SimulateUncertaintyOptions [refs #529]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ section of the SDLC for the versioning policy).
 - **`Default` on `UncertaintyMethod` and `SimulateUncertaintyOptions` (#529).** The
   uncertainty-simulation options can now be built with `..Default::default()`
   (`UncertaintyMethod::Asymptotic` is the default method), so wrapper code stays
-  source-compatible when a field is added. Every other `pub` options struct in
-  `ferx-core` and `ferx-tools` already implemented `Default`; a test now pins that
-  convention.
+  source-compatible when a field is added. Every other `*Options` type in
+  `ferx-core` and `ferx-tools` already implemented `Default`; a new inventory
+  guard (`tests/public_api_boundary.rs`, A4) now discovers every `*Options`
+  declaration under `src/` and `crates/` and fails on one that lacks it, so the
+  convention holds for options types added later.
 - **`.ferxsearch` search configuration and an MFL search-space parser in `ferx-tools` (#1179).**
   A TOML file (`base`, `data`, `[space] mfl`, `[rank]`, `[strictness]`, `[run]`) whose space is
   written in Pharmpy's Model Feature Language, with `@IIV` / `@PK` / `@CONTINUOUS` / … resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ section of the SDLC for the versioning policy).
 ## [Unreleased]
 
 ### Added
+- **`Default` on `UncertaintyMethod` and `SimulateUncertaintyOptions` (#529).** The
+  uncertainty-simulation options can now be built with `..Default::default()`
+  (`UncertaintyMethod::Asymptotic` is the default method), so wrapper code stays
+  source-compatible when a field is added. Every other `pub` options struct in
+  `ferx-core` and `ferx-tools` already implemented `Default`; a test now pins that
+  convention.
 - **`.ferxsearch` search configuration and an MFL search-space parser in `ferx-tools` (#1179).**
   A TOML file (`base`, `data`, `[space] mfl`, `[rank]`, `[strictness]`, `[run]`) whose space is
   written in Pharmpy's Model Feature Language, with `@IIV` / `@PK` / `@CONTINUOUS` / … resolved

--- a/crates/ferx-tools/src/lib.rs
+++ b/crates/ferx-tools/src/lib.rs
@@ -36,10 +36,17 @@ pub fn core_version() -> &'static str {
 mod tests {
     use super::core_version;
 
-    /// #529 convention guard, `ferx-tools` half: every `pub` options struct
-    /// this crate exposes must implement `Default` so a caller can build it
-    /// with `..Default::default()` and survive an added field. A new options
-    /// struct that forgets it fails to compile here.
+    /// #529, trait-level half for `ferx-tools`: this crate's options types
+    /// really do resolve `Default`, so a caller can build them with
+    /// `..Default::default()`.
+    ///
+    /// A **named spot check, not the inventory guard** — the list is
+    /// hand-written and a new options struct does not change it. Discovery for
+    /// the whole workspace (this crate included: the scan walks `crates/`) is
+    /// `every_public_options_type_implements_default` in `ferx-core`'s
+    /// `tests/public_api_boundary.rs` (A4). It lives there rather than here
+    /// because `ferx-core` must not depend on `ferx-tools`, and a source scan
+    /// needs no dependency in either direction.
     #[test]
     fn every_public_options_struct_implements_default() {
         fn assert_default<T: Default>() -> T {

--- a/crates/ferx-tools/src/lib.rs
+++ b/crates/ferx-tools/src/lib.rs
@@ -36,6 +36,20 @@ pub fn core_version() -> &'static str {
 mod tests {
     use super::core_version;
 
+    /// #529 convention guard, `ferx-tools` half: every `pub` options struct
+    /// this crate exposes must implement `Default` so a caller can build it
+    /// with `..Default::default()` and survive an added field. A new options
+    /// struct that forgets it fails to compile here.
+    #[test]
+    fn every_public_options_struct_implements_default() {
+        fn assert_default<T: Default>() -> T {
+            T::default()
+        }
+        let _ = assert_default::<crate::bootstrap::BootstrapOptions>();
+        let _ = assert_default::<crate::gam::GamOptions>();
+        let _ = assert_default::<crate::search::RunOptions>();
+    }
+
     #[test]
     fn core_version_is_reported_through_the_public_api() {
         let v = core_version();

--- a/src/api/simulate.rs
+++ b/src/api/simulate.rs
@@ -1010,11 +1010,19 @@ fn simulate_inner_with_draw<R: rand::Rng>(
 }
 
 /// Options controlling `simulate_with_uncertainty()`.
-#[derive(Debug, Clone)]
+///
+/// Derives `Default` so an out-of-crate caller (the R wrapper) can build one
+/// with `..Default::default()` and stay source-compatible when a field is
+/// added here (#529). Note that the two counts default to `0`, which draws
+/// nothing and returns an empty row set — a caller spreading the default is
+/// expected to set both explicitly.
+#[derive(Debug, Clone, Default)]
 pub struct SimulateUncertaintyOptions {
     /// Number of parameter sets to draw from the uncertainty distribution.
+    /// Defaults to `0`; set it explicitly when spreading `Default::default()`.
     pub n_uncertainty_draws: usize,
     /// Number of eta/eps replicates simulated *per* parameter draw.
+    /// Defaults to `0`; set it explicitly when spreading `Default::default()`.
     pub n_sim_per_draw: usize,
     /// How to draw the parameter sets — asymptotic MVN or SIR resamples.
     pub method: crate::estimation::uncertainty_samples::UncertaintyMethod,

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -1605,10 +1605,18 @@ fn spread_default_matches_exhaustive_literal() {
     }
 }
 
-/// #529 convention guard: every `pub` options struct `ferx-core` exposes at
-/// the R boundary must implement `Default`, so the wrapper can spread it and
-/// survive an added field. A new one that forgets the derive fails to compile
-/// here rather than breaking `ferx-r`'s build after the merge.
+/// #529, trait-level half: the options types `ferx-core` exposes at the R
+/// boundary really do resolve `Default`, so the wrapper can spread them.
+///
+/// This is a **named spot check, not the inventory guard** — the list is
+/// hand-written, so adding a new options struct does not change it and this
+/// test would stay green. Discovery is
+/// `every_public_options_type_implements_default` in
+/// `tests/public_api_boundary.rs` (A4), which scans `src/` and `crates/` for
+/// every `*Options` declaration and fails on one lacking `Default`. The two
+/// are complementary: the scan is textual and sees types nobody registered,
+/// this one is a real trait bound and would catch a `Default` that exists in
+/// source but does not apply to the type (a `cfg`-ed out impl, say).
 #[test]
 fn every_public_options_struct_implements_default() {
     fn assert_default<T: Default>() -> T {

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -1539,3 +1539,85 @@ fn asymptotic_errors_without_covariance_step() {
     let err = simulate_with_uncertainty(&model, &pop, &fit, &opts).unwrap_err();
     assert!(err.contains("covariance"));
 }
+
+// ---------------------------------------------------------------------------
+// #529 — `Default` at the R boundary
+// ---------------------------------------------------------------------------
+
+/// Pin every field of the derived `Default`. The R wrapper builds this struct
+/// with `..Default::default()`, so these values are the ones a field it does
+/// *not* name silently takes.
+#[test]
+fn simulate_uncertainty_options_default_values() {
+    let d = SimulateUncertaintyOptions::default();
+    assert_eq!(d.n_uncertainty_draws, 0);
+    assert_eq!(d.n_sim_per_draw, 0);
+    assert_eq!(d.method, UncertaintyMethod::Asymptotic);
+    assert_eq!(d.seed, None);
+}
+
+/// The point of #529: a spread construction that names only the fields the
+/// caller cares about must behave identically to the exhaustive literal it
+/// replaces. Run both through `simulate_with_uncertainty` with the same seed
+/// and require bit-identical predictions — an oracle that fails if a future
+/// field's default silently changes the simulation rather than merely
+/// compiling.
+#[test]
+fn spread_default_matches_exhaustive_literal() {
+    let model = tiny_model();
+    let pop = tiny_population();
+    let fit = synthetic_fit(&model.default_params);
+
+    let exhaustive = SimulateUncertaintyOptions {
+        n_uncertainty_draws: 3,
+        n_sim_per_draw: 2,
+        method: UncertaintyMethod::Asymptotic,
+        seed: Some(42),
+    };
+    let spread = SimulateUncertaintyOptions {
+        n_uncertainty_draws: 3,
+        n_sim_per_draw: 2,
+        seed: Some(42),
+        ..Default::default()
+    };
+
+    let a = simulate_with_uncertainty(&model, &pop, &fit, &exhaustive).unwrap();
+    let b = simulate_with_uncertainty(&model, &pop, &fit, &spread).unwrap();
+
+    // Non-degenerate: the comparison is worthless on an empty or all-zero run.
+    assert_eq!(a.len(), 3 * 2 * 2 * 3);
+    assert!(a
+        .iter()
+        .all(|r| r.ipred.is_finite() && r.outcome.continuous_value().is_finite()));
+    assert!(a.iter().any(|r| r.ipred != 0.0));
+
+    assert_eq!(a.len(), b.len());
+    for (x, y) in a.iter().zip(b.iter()) {
+        assert_eq!(x.id, y.id);
+        assert_eq!(x.time, y.time);
+        assert_eq!(x.draw, y.draw);
+        assert_eq!(x.sim, y.sim);
+        assert_eq!(x.ipred.to_bits(), y.ipred.to_bits());
+        assert_eq!(
+            x.outcome.continuous_value().to_bits(),
+            y.outcome.continuous_value().to_bits()
+        );
+    }
+}
+
+/// #529 convention guard: every `pub` options struct `ferx-core` exposes at
+/// the R boundary must implement `Default`, so the wrapper can spread it and
+/// survive an added field. A new one that forgets the derive fails to compile
+/// here rather than breaking `ferx-r`'s build after the merge.
+#[test]
+fn every_public_options_struct_implements_default() {
+    fn assert_default<T: Default>() -> T {
+        T::default()
+    }
+    let _ = assert_default::<crate::types::FitOptions>();
+    let _ = assert_default::<crate::io::fitrx::SaveFitOptions>();
+    let _ = assert_default::<crate::ode::solver::OdeSolverOptions>();
+    let _ = assert_default::<crate::api::simulate::SimulateOptions>();
+    let _ = assert_default::<SimulateUncertaintyOptions>();
+    let _ = assert_default::<crate::AdaptiveSimulateOptions>();
+}

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -23,10 +23,19 @@ use rand::{Rng, RngExt};
 use rand_distr::StandardNormal;
 
 /// How parameter-uncertainty draws are produced.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `Default` is [`UncertaintyMethod::Asymptotic`] — the standard MVN method,
+/// which needs only a successful covariance step. `Sir` additionally requires
+/// the SIR resample pool to have been retained at fit time, so it is not a
+/// safe default. Deriving `Default` here is what lets
+/// [`crate::SimulateUncertaintyOptions`] derive it too, so out-of-crate
+/// callers (the R wrapper) can construct it with `..Default::default()` and
+/// stay source-compatible when a field is added (#529).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum UncertaintyMethod {
     /// MVN in packed log-space using `FitResult.covariance_matrix`. Fast and
     /// parametric; requires a successful covariance step.
+    #[default]
     Asymptotic,
     /// Reuse the resampled parameter vectors retained from the SIR step.
     /// Requires `FitOptions.sir = true` AND `sir_keep_samples = true`.
@@ -309,6 +318,15 @@ fn draw_sir(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #529: `UncertaintyMethod` derives `Default` so
+    /// `SimulateUncertaintyOptions` can derive it too. Pin the variant — a
+    /// silent move of `#[default]` to `Sir` would make a spread-constructed
+    /// options value demand a SIR pool that most fits never retained.
+    #[test]
+    fn uncertainty_method_defaults_to_asymptotic() {
+        assert_eq!(UncertaintyMethod::default(), UncertaintyMethod::Asymptotic);
+    }
     use crate::types::{ErrorModel, OmegaMatrix, SigmaVector};
     use nalgebra::DMatrix;
     use rand::rngs::StdRng;

--- a/tests/public_api_boundary.rs
+++ b/tests/public_api_boundary.rs
@@ -361,3 +361,373 @@ fn toml_comments_are_stripped_but_string_hashes_survive() {
     let name = "name = \"ferx-core\"";
     assert_eq!(strip_toml_comment(name), name);
 }
+
+// ── A4 — every `pub *Options` type implements `Default` (#529) ───────────────
+
+/// One `pub … Options` type declaration found by the source scan.
+#[derive(Debug, PartialEq, Eq)]
+struct OptionsDecl {
+    name: String,
+    /// `Default` appears in a `#[derive(...)]` attached to the declaration.
+    derives_default: bool,
+    /// 1-indexed line of the `pub struct` / `pub enum` itself.
+    line: usize,
+}
+
+/// The attributes attached to the item declared at `decl_idx`, as one string.
+///
+/// Walks back to the nearest blank line — the block rustfmt keeps contiguous
+/// above an item — and keeps only genuine attribute lines. Doc comments are
+/// **dropped on purpose**: several of the types this guard covers explain their
+/// `Default` in prose ("Derives `Default` so the wrapper can spread it"), and a
+/// substring scan that read documentation would let a comment satisfy a check
+/// about code. Continuation lines of a multi-line attribute are kept via the
+/// paren depth, so a `#[derive(` split across lines is still seen whole.
+fn attribute_block_above(lines: &[&str], decl_idx: usize) -> String {
+    let mut start = decl_idx;
+    while start > 0 && !lines[start - 1].trim().is_empty() {
+        start -= 1;
+    }
+    let mut attrs = String::new();
+    let mut depth = 0usize;
+    for line in &lines[start..decl_idx] {
+        let trimmed = line.trim();
+        if depth == 0 && !trimmed.starts_with("#[") && !trimmed.starts_with("#![") {
+            continue;
+        }
+        attrs.push_str(trimmed);
+        attrs.push('\n');
+        depth += trimmed.matches('(').count();
+        depth = depth.saturating_sub(trimmed.matches(')').count());
+    }
+    attrs
+}
+
+/// Whether `attrs` contains a `#[derive(...)]` naming `Default` **as a whole
+/// trait**, not as a substring: a hypothetical `DefaultDisplay` derive must not
+/// satisfy the guard.
+fn derive_list_names_default(attrs: &str) -> bool {
+    let mut rest = attrs;
+    while let Some(at) = rest.find("derive(") {
+        let after = &rest[at + "derive(".len()..];
+        let mut depth = 1usize;
+        let mut end = after.len();
+        for (i, c) in after.char_indices() {
+            match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let inner = &after[..end];
+        if inner
+            .split(',')
+            .any(|t| matches!(t.trim(), "Default" | "core::default::Default"))
+        {
+            return true;
+        }
+        rest = &after[end.min(after.len())..];
+    }
+    false
+}
+
+/// Identifier starting at the front of `s`, or `None` if `s` does not start
+/// with one.
+fn leading_ident(s: &str) -> Option<&str> {
+    let end = s
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(s.len());
+    (end > 0).then(|| &s[..end])
+}
+
+/// Every `struct`/`enum` in `src` whose name ends in `Options`.
+///
+/// Deliberately name-driven rather than baseline-driven: `cargo public-api`
+/// omits *derived* impls, so `api/ferx-core-public-api.txt` shows no
+/// `impl Default` row for a type that derives it (only for the hand-written
+/// ones). The committed baseline therefore cannot see this convention at all,
+/// which is why it is scanned from source — the same argument that puts the
+/// `#[doc(hidden)]` ban in this file.
+fn scan_options_decls(src: &str) -> Vec<OptionsDecl> {
+    let lines: Vec<&str> = src.lines().collect();
+    let mut out = Vec::new();
+    for (idx, line) in lines.iter().enumerate() {
+        let trimmed = line.trim_start();
+        let after_kind = trimmed
+            .strip_prefix("pub struct ")
+            .or_else(|| trimmed.strip_prefix("pub enum "));
+        let Some(after_kind) = after_kind else {
+            continue;
+        };
+        let Some(name) = leading_ident(after_kind) else {
+            continue;
+        };
+        if !name.ends_with("Options") {
+            continue;
+        }
+        out.push(OptionsDecl {
+            name: name.to_string(),
+            derives_default: derive_list_names_default(&attribute_block_above(&lines, idx)),
+            line: idx + 1,
+        });
+    }
+    out
+}
+
+/// Type names carrying a hand-written `impl Default for …` in `src`.
+///
+/// Six of the options types in this workspace implement `Default` manually
+/// (`FitOptions`, `OdeSolverOptions`, `AdaptiveSimulateOptions`,
+/// `BootstrapOptions`, `GamOptions`, `RunOptions`), so a derive-only scan would
+/// report six false offenders.
+fn scan_manual_default_impls(src: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        for prefix in ["impl Default for ", "impl core::default::Default for "] {
+            let Some(after) = trimmed.strip_prefix(prefix) else {
+                continue;
+            };
+            // Take the last path segment so `impl Default for crate::a::B` and
+            // `impl Default for B` agree, and drop any generic argument list.
+            let head = after.split(['<', ' ', '{']).next().unwrap_or(after);
+            if let Some(name) = head.rsplit("::").next().and_then(leading_ident) {
+                out.push(name.to_string());
+            }
+        }
+    }
+    out
+}
+
+/// Rust sources under `dir`, skipping any `target/` build directory.
+fn rust_sources_skipping_target(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("readable directory") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            if path.file_name().and_then(|n| n.to_str()) == Some("target") {
+                continue;
+            }
+            rust_sources_skipping_target(&path, out);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// **A4 — every `pub *Options` type in the workspace implements `Default`
+/// (#529).**
+///
+/// `ferx-r` builds these structs with exhaustive literals, so a field added
+/// here breaks the wrapper's build with `error[E0063]: missing field`. The fix
+/// is for the wrapper to spread `..Default::default()`, which it can only do if
+/// the struct implements `Default` — so "options types implement `Default`" is
+/// a cross-repo contract, not a style preference.
+///
+/// This is an **inventory** check, not a list: it discovers every `struct` /
+/// `enum` named `*Options` under `src/` and `crates/`, so a newly added one
+/// that forgets the trait fails here without anyone remembering to register it.
+/// The scan is pinned by `options_scan_flags_a_new_struct_without_default`
+/// below, which feeds it exactly that mutation.
+#[test]
+fn every_public_options_type_implements_default() {
+    let root = repo_root();
+    let mut sources = Vec::new();
+    rust_sources_skipping_target(&root.join("src"), &mut sources);
+    rust_sources_skipping_target(&root.join("crates"), &mut sources);
+    assert!(
+        !sources.is_empty(),
+        "found no sources under src/ or crates/"
+    );
+
+    let mut decls: Vec<(PathBuf, OptionsDecl)> = Vec::new();
+    let mut manual_impls: Vec<String> = Vec::new();
+    for path in &sources {
+        let src = std::fs::read_to_string(path).expect("source file is valid UTF-8");
+        manual_impls.extend(scan_manual_default_impls(&src));
+        for decl in scan_options_decls(&src) {
+            decls.push((path.clone(), decl));
+        }
+    }
+
+    // Non-degeneracy: a scan that silently found nothing, or that classified
+    // every type the same way, would pass vacuously. Both spellings of the
+    // convention must be present and correctly told apart — `SimulateOptions`
+    // derives `Default`, `FitOptions` implements it by hand.
+    let found = |name: &str| decls.iter().any(|(_, d)| d.name == name);
+    for anchor in [
+        "FitOptions",
+        "SaveFitOptions",
+        "OdeSolverOptions",
+        "SimulateOptions",
+        "SimulateUncertaintyOptions",
+        "AdaptiveSimulateOptions",
+        "BootstrapOptions",
+        "GamOptions",
+        "RunOptions",
+    ] {
+        assert!(found(anchor), "the scan did not find `{anchor}`");
+    }
+    assert!(
+        decls
+            .iter()
+            .any(|(_, d)| d.name == "SimulateOptions" && d.derives_default),
+        "`SimulateOptions` derives `Default`; the derive arm of the scan is broken"
+    );
+    assert!(
+        decls
+            .iter()
+            .any(|(_, d)| d.name == "FitOptions" && !d.derives_default),
+        "`FitOptions` implements `Default` by hand, not by derive; \
+         the scan is reading a derive that is not there"
+    );
+    assert!(
+        manual_impls.iter().any(|n| n == "FitOptions"),
+        "the manual-`impl` arm of the scan is broken"
+    );
+
+    let offenders: Vec<String> = decls
+        .iter()
+        .filter(|(_, d)| !d.derives_default && !manual_impls.contains(&d.name))
+        .map(|(path, d)| {
+            format!(
+                "{}:{} ({})",
+                path.strip_prefix(&root).unwrap_or(path).display(),
+                d.line,
+                d.name
+            )
+        })
+        .collect();
+
+    assert!(
+        offenders.is_empty(),
+        "every `pub *Options` type must implement `Default` so a wrapper can \
+         build it with `..Default::default()` and survive an added field \
+         (#529). Add `Default` to the derive list, or write an `impl Default` \
+         with meaningful values. Missing at: {offenders:?}"
+    );
+}
+
+/// The mutation the A4 guard exists to catch, run against the scan itself:
+/// introducing a `pub *Options` type with no `Default` must be reported.
+///
+/// This is the check a hand-written `assert_default::<T>()` list cannot make —
+/// adding a type does not change a hard-coded list, so such a test stays green.
+/// Here the offender is the *only* thing that differs between the two fixtures,
+/// and the guard's verdict has to flip with it.
+#[test]
+fn options_scan_flags_a_new_struct_without_default() {
+    const FIXTURE: &str = r#"
+/// Derives `Default` in prose only — this documentation must not rescue the
+/// type below, which is the point of dropping doc comments from the scan.
+#[derive(Debug, Clone)]
+pub struct ForgottenOptions {
+    pub a: usize,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DerivedOptions {
+    pub b: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct ManualOptions {
+    pub c: usize,
+}
+
+impl Default for ManualOptions {
+    fn default() -> Self {
+        Self { c: 7 }
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Default,
+)]
+pub enum SplitDeriveOptions {
+    #[default]
+    One,
+}
+
+/// Not an options type, so not this guard's business.
+#[derive(Debug)]
+pub struct Something {
+    pub d: usize,
+}
+"#;
+
+    let decls = scan_options_decls(FIXTURE);
+    let names: Vec<&str> = decls.iter().map(|d| d.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec![
+            "ForgottenOptions",
+            "DerivedOptions",
+            "ManualOptions",
+            "SplitDeriveOptions"
+        ],
+        "the scan must find every `pub *Options` declaration and nothing else"
+    );
+
+    let manual = scan_manual_default_impls(FIXTURE);
+    assert_eq!(manual, vec!["ManualOptions".to_string()]);
+
+    let flagged: Vec<&str> = decls
+        .iter()
+        .filter(|d| !d.derives_default && !manual.contains(&d.name))
+        .map(|d| d.name.as_str())
+        .collect();
+    assert_eq!(
+        flagged,
+        vec!["ForgottenOptions"],
+        "exactly the type that forgot `Default` must be reported — a prose \
+         mention of the trait must not satisfy the guard, and a multi-line \
+         derive must not be missed"
+    );
+
+    // The straddle: the *same* fixture with the derive fixed must come back
+    // clean, so the guard's verdict tracks the code rather than always firing.
+    let fixed = FIXTURE.replace(
+        "#[derive(Debug, Clone)]\npub struct ForgottenOptions",
+        "#[derive(Debug, Clone, Default)]\npub struct ForgottenOptions",
+    );
+    assert_ne!(
+        fixed, FIXTURE,
+        "the mutation must actually change the source"
+    );
+    let manual_fixed = scan_manual_default_impls(&fixed);
+    let still_flagged: Vec<String> = scan_options_decls(&fixed)
+        .into_iter()
+        .filter(|d| !d.derives_default && !manual_fixed.contains(&d.name))
+        .map(|d| d.name)
+        .collect();
+    assert!(
+        still_flagged.is_empty(),
+        "adding the derive must clear the finding, got {still_flagged:?}"
+    );
+}
+
+/// `Default` must be matched as a derive entry, not as a substring, and a
+/// `derive(...)` must not be read out of an unrelated attribute.
+#[test]
+fn derive_list_matches_default_exactly() {
+    assert!(derive_list_names_default("#[derive(Debug, Default)]"));
+    assert!(derive_list_names_default(
+        "#[derive(Debug,\n Default,\n Clone)]"
+    ));
+    assert!(!derive_list_names_default("#[derive(Debug, Clone)]"));
+    // A trait whose name merely starts with `Default`.
+    assert!(!derive_list_names_default("#[derive(DefaultDisplay)]"));
+    // Nested parens inside an earlier attribute must not end the scan early.
+    assert!(derive_list_names_default(
+        "#[derive(Debug)]\n#[serde(rename_all(x))]\n#[derive(Default)]"
+    ));
+    assert!(!derive_list_names_default("#[non_exhaustive]"));
+}


### PR DESCRIPTION
## Why

`ferx-r` constructs ferx-core options structs with **exhaustive** struct literals (`SimulateUncertaintyOptions` at `ferx-r/src/rust/src/lib.rs:906` on `main`). When ferx-core adds a field, those literals break with `error[E0063]: missing field` — exactly the cross-repo trap the CLAUDE.md sibling-repo note warns about. We hit it for `SimulateOptions` (#522 → FeRx-NLME/ferx-r#200).

`SimulateOptions` already derives `Default`, so ferx-r can spread `..Default::default()` and be immune to additive field changes. `SimulateUncertaintyOptions` could **not** take that fix, because `UncertaintyMethod` had no `Default`.

This PR makes the resilient form *available*. It does not by itself make the wrapper resilient — see **Cross-repo dependency** for the sequencing, and note the deliberate `Refs #529` rather than `closes`.

## What changed

- **`UncertaintyMethod` derives `Default`** with `#[default] Asymptotic`. That is the right default rather than an arbitrary one: `Asymptotic` needs only a successful covariance step, while `Sir` additionally requires the SIR resample pool to have been retained at fit time (`sir = true` **and** `sir_keep_samples = true`), so a spread-constructed value defaulting to `Sir` would fail at run time for most fits.
- **`SimulateUncertaintyOptions` derives `Default`.** Its two counts default to `0`, which draws nothing and returns an empty row set; the struct and field doc comments say so explicitly, since a caller spreading the default is expected to set both.
- **An inventory guard for the convention** — A4 in `tests/public_api_boundary.rs`. It scans every `.rs` file under `src/` and `crates/`, collects every `struct`/`enum` named `*Options` together with every hand-written `impl Default for …`, and fails naming any declaration covered by neither. It is **discovery-based, not a list**: a `*Options` type added later that forgets the trait fails without anyone remembering to register it.
- **Audit result:** `FitOptions`, `SaveFitOptions`, `OdeSolverOptions`, `SimulateOptions`, `AdaptiveSimulateOptions` (core) and `BootstrapOptions`, `GamOptions`, `RunOptions` (`ferx-tools`) all already implement `Default`, derived or manual — so the two types above were the only gap. The guard now holds that line going forward.

## Alternatives considered

**For the default value:** a hand-written `impl Default for SimulateUncertaintyOptions` with non-zero counts (e.g. 100 draws × 1 sim), so a bare `Default::default()` would do something useful rather than return no rows. Rejected — those numbers would be invented, and the struct's purpose here is the `..Default::default()` **spread**, where the caller always names the counts. Documenting the `0` is honest; a magic 100 is a silent policy the R wrapper would inherit.

**For the guard:** centralizing the declarations behind an enforcing macro (the review's other suggestion) would give a compile-time bound instead of a text scan, but it would rewrite eight type declarations across two crates to enforce a one-line convention, and a new options struct could still simply not use the macro — the same discovery hole one level up. The scan has no such hole: it is keyed on the type's *name*, which is the thing the convention is about.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | tracked as FeRx-NLME/ferx-r#330 (issue, no PR yet) | open | after |

**Sequencing, explicitly.** `ferx-r/src/rust/Cargo.lock` pins ferx-core by commit *from the `main` branch* — currently `ebc13a1e`. A lock bump therefore cannot point at a rev that exists only on this feature branch, so the ferx-r work is blocked on this PR merging. The order is:

1. **this PR merges to ferx-core `main`** → the derives exist at a rev on `main`;
2. `tools/update-ferx-core-lock.sh` in ferx-r bumps `src/rust/Cargo.lock` to that rev;
3. `ferx-r/src/rust/src/lib.rs:906` switches to `..Default::default()`;
4. that ferx-r PR merges — **only now is the wrapper actually immune.**

Because step 4 is what closes the issue's intent, this PR says `Refs #529`, not `closes #529` (in the title, the body, and both commit messages — GitHub's squash-merge body concatenates commit messages, so leaving the keyword in one of them would have auto-closed the issue on merge). #529 stays open until the ferx-r side lands. FeRx-NLME/ferx-r#330 carries the exact diff, the lock-bump command, and this same sequencing note.

Nothing is broken in the meantime: `SimulateUncertaintyOptions` is unchanged by #522, so ferx-r's current exhaustive literal keeps compiling. This is pre-emptive hardening against the *next* added field, which is why the split across two merges is safe rather than a half-landed change.

## Breaking changes

- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [x] None

Additive only: two new trait impls, no signature or field changes. `tools/update-public-api.sh` was re-run and the committed baseline is **unchanged** — `cargo public-api` omits derived impls, which is why the already-derived `SimulateOptions` carries no `impl Default` row in the baseline either (`AdaptiveSimulateOptions` / `FitOptions` / `OdeSolverOptions`, whose `Default` is hand-written, do). `tools/update-public-api.sh --check` reports `public API matches the committed baseline.` That blind spot is precisely why the new convention guard is a source scan and lives next to the `#[doc(hidden)]` ban, which exists for the same reason.

<details>
<summary>Migration notes (if breaking)</summary>

Not breaking — no migration needed.

</details>

## Numerical validation

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):
- [x] Not applicable (docs / refactor / CI only)

No numerical path is touched: this adds trait impls and a test. The NONMEM-comparison rule does not bite because nothing here produces a new estimate, OFV, residual or diagnostic. What *is* asserted numerically is that the new construction path is a no-op — `spread_default_matches_exhaustive_literal` requires bit-identical `ipred` and outcome values (`to_bits()`) between an exhaustive literal and its `..Default::default()` spread at the same seed.

## Performance

- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

The new guard is a filesystem walk over `src/` and `crates/` with no compilation, and runs in the existing `public_api_boundary` binary: the whole file is 0.25 s.

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

| Test | Location | Pins |
|---|---|---|
| `uncertainty_method_defaults_to_asymptotic` | `src/estimation/uncertainty_samples.rs` | the `#[default]` variant — moving it to `Sir` would make spread-constructed options demand a SIR pool most fits never retained |
| `simulate_uncertainty_options_default_values` | `src/api/tests/simulate_with_uncertainty_tests.rs` | every default field value a caller silently inherits for a field it does not name |
| `spread_default_matches_exhaustive_literal` | same | the point of #529 — spread and exhaustive constructions must produce identical simulations |
| `every_public_options_type_implements_default` | `tests/public_api_boundary.rs` (A4) | **the convention, by discovery** — every `*Options` declaration under `src/` and `crates/` implements `Default` |
| `options_scan_flags_a_new_struct_without_default` | same | that the guard above can actually fail |
| `derive_list_matches_default_exactly` | same | the derive parser: whole-trait match, multi-line derives, no false hit from a nested-paren attribute |
| `every_public_options_struct_implements_default` | `src/api/tests/…` + `crates/ferx-tools/src/lib.rs` | named trait-level spot checks (see below) |

**On "a green test is not evidence it can fail":**

- The A4 guard was mutation-tested **on the real tree, both directions**. Appending `#[derive(Debug, Clone)] pub struct MutationProbeOptions { pub a: usize }` to `src/lib.rs` fails it with `Missing at: ["src/lib.rs:75 (MutationProbeOptions)"]`; adding `Default` to that derive turns it green again; the probe was then reverted (`git status` clean, trees verified identical). The same flip is pinned permanently by `options_scan_flags_a_new_struct_without_default`, whose fixture differs by exactly the offending derive and which asserts the straddle explicitly, so the guard cannot silently become a tautology.
- The fixture also contains a doc comment that says "Derives `Default`" in prose above the offending struct, and asserts it does **not** rescue it — the scan drops doc comments from the attribute block for exactly that reason, since several of the real types describe their `Default` in prose.
- `spread_default_matches_exhaustive_literal` can fail too: if `#[default]` moved to `Sir`, the spread arm would take the SIR path against a fit with no retained pool and `unwrap()` would panic. It guards against a degenerate comparison first — the run must be the expected 36 rows, all finite, and not identically zero — before any equality is checked.

Results: `cargo test --lib --features ci` → **4039 passed, 0 failed**; `cargo test --test public_api_boundary --features ci` → **8 passed, 0 failed**; `cargo test -p ferx-tools --lib` → **300 passed, 0 failed**.

## Example (user-facing features only)

- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

No `.ferx` DSL, `[fit_options]` key or output field changes — this is a Rust-API ergonomics change for wrapper authors. The usage it enables:

<details>
<summary>Example (if not a standalone file)</summary>

```rust
// Before: exhaustive — breaks with E0063 when ferx-core adds a field.
let opts = SimulateUncertaintyOptions {
    n_uncertainty_draws: 200,
    n_sim_per_draw: 1,
    method: UncertaintyMethod::Asymptotic,
    seed: Some(42),
};

// After: immune to additive field changes.
let opts = SimulateUncertaintyOptions {
    n_uncertainty_draws: 200,
    n_sim_per_draw: 1,
    seed: Some(42),
    ..Default::default()
};
```

</details>

## Docs

- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

Added under `[Unreleased] → Added`, and reworded in the second commit so it describes the inventory guard rather than claiming more than the first commit's hand-written lists delivered. No `docs/**/*.qmd` page changed: the Quarto site documents the `.ferx` model file and fit behaviour, and nothing there describes these Rust struct literals.

## Docs & examples

### ferx-site
- [x] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened — N/A, no DSL or fit-option change
- [x] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book — N/A, no new example
- [x] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book — N/A, no new data

### ferx-book
- [x] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened — N/A, none of those

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI
- [ ] All affected ferx-site example `.qmd` pages render cleanly
- [ ] All affected ferx-book chapters render cleanly
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

No `examples/*.ferx` is affected — no model file, CLI surface or numerical output changes.

## Checklist

- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), public-API baseline. A green `cargo test` is not a green build: the feature sets are not nested (#1133, #1157)
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code)
- [x] `Cargo.toml` version bumped if breaking

`preflight OK — fmt check clippy rustdoc docs public-api`. Nothing on the `Dual2` path is touched (two trait impls on options types and a test, no numeric kernel), and no version bump is needed since nothing breaks.

## Reviewer hints

Two judgement calls worth a look:

1. **`#[default] Asymptotic`.** `Sir` has a precondition (`sir_keep_samples` at fit time) a defaulted value cannot guarantee, so it would turn a spread construction into a run-time error. `uncertainty_method_defaults_to_asymptotic` pins it.
2. **Counts defaulting to `0`.** A bare `SimulateUncertaintyOptions::default()` draws nothing and returns an empty row set (`draw_parameter_samples` short-circuits at `n_draws == 0`). Documented on the struct and both fields, pinned by `simulate_uncertainty_options_default_values`. See *Alternatives considered* for why not a manual `impl` with invented counts.

The new A4 guard is where the real review value is: it is textual, so the things to check are the parser's edges — multi-line derives, doc-comment prose, `DefaultDisplay`-style near-misses — all of which have their own assertions in `derive_list_matches_default_exactly`.

The second commit is the response to review; the first is the original change. Reviewing them separately is easier than the combined diff.

## Open questions

None blocking. The one open thread is the ferx-r follow-up (FeRx-NLME/ferx-r#330), which cannot start until this merges — see **Cross-repo dependency** for why the lock bump has to come second.

Refs #529 — intentionally non-closing; the issue stays open until FeRx-NLME/ferx-r#330 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mk3MLZ59oLAZVx3uNLBLjz
