### PR TITLE
ci: run the suite with debug-assertions enabled [refs #344]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
   # would be a no-op again — silently, with every test green — if a
   # `[profile.dev] debug-assertions = false` or a
   # `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` ever appeared. So the group's
-  # commands arm `debug_assertion_canary` (`src/lib.rs`) via
+  # commands arm `debug_assertion_canary` (`src/lib_tests.rs`) via
   # `env FERX_REQUIRE_DEBUG_ASSERTIONS=1`, and that canary fails the run if
   # `debug_assert!` turns out to compile to nothing. Do NOT set that variable at
   # the workflow or job level: every other job legitimately runs with the guards

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,16 @@ jobs:
   # and the CI gate cannot drift. It is the one group that is opt-in locally: it
   # runs a suite rather than a compile, so a no-argument `tools/preflight.sh`
   # stays a pre-push habit and this job is where it has to be green.
+  #
+  # Note that "no `--profile` flag" is an invariant held by ABSENCE, and this job
+  # would be a no-op again — silently, with every test green — if a
+  # `[profile.dev] debug-assertions = false` or a
+  # `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` ever appeared. So the group's
+  # commands arm `debug_assertion_canary` (`src/lib.rs`) via
+  # `env FERX_REQUIRE_DEBUG_ASSERTIONS=1`, and that canary fails the run if
+  # `debug_assert!` turns out to compile to nothing. Do NOT set that variable at
+  # the workflow or job level: every other job legitimately runs with the guards
+  # off, and arming it there would fail them for doing the right thing.
   debug-assertions:
     name: Tests (debug-assertions)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,54 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # #344. Every other test job in this file builds with `--profile ci-test` or
+  # `--profile ci-fast`, and both `inherits = "release"` — so `debug-assertions`
+  # is OFF and all 177 `debug_assert!` guards in the crate compile to nothing.
+  # They are invariant checks that CI was not running.
+  #
+  # That was not theoretical. An off-by-one in `compute_max_stack`
+  # (`src/parser/model_parser.rs`) tripped its own `debug_assert!` for any
+  # expression containing an `if`, and four lib tests panicked under the dev
+  # profile while CI stayed green through the whole thing (fixed in #342; this
+  # job closes the blind spot that hid it).
+  #
+  # Deliberately a SEPARATE job rather than flipping `ci-test`: that profile
+  # exists so the population-fit tests run at release speed, and this repo is
+  # compile-bound (93% LLVM, #969/#971), so the cheap way to get the guards
+  # executed is one extra UNOPTIMISED build — not a second optimised one.
+  # Measured locally on the dev profile: 80s of tests for `--features ci` (4035
+  # tests) and 198s for `--features ci,markov,nn` (4366), all green — turning the
+  # guards on surfaced no latent failure, so this job starts green.
+  #
+  # The commands live in `tools/preflight.sh` (group `debug-assertions`) for the
+  # same reason as `Check`/`Clippy`/`Format` (#1157) — one list, so the local gate
+  # and the CI gate cannot drift. It is the one group that is opt-in locally: it
+  # runs a suite rather than a compile, so a no-argument `tools/preflight.sh`
+  # stays a pre-push habit and this job is where it has to be green.
+  debug-assertions:
+    name: Tests (debug-assertions)
+    runs-on: ubuntu-latest
+    # Stable, not the workflow-level nightly: `--features ci,markov,nn` has no
+    # nightly-only code, and stable's rustc holds for ~6 weeks against nightly's
+    # daily bump — `rust-cache` keys on `rustc -vV`, so nightly here would cold-
+    # rebuild the dep graph every day for no gate. Same reasoning as the coverage
+    # jobs. `tools/preflight.sh` honours an inherited `RUSTUP_TOOLCHAIN`.
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install stable toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Own key: the dev profile shares no artifacts with the `ci` (check /
+          # clippy) caches or with the instrumented coverage ones.
+          shared-key: ci-debug-assertions
+
+      - name: cargo test --lib with debug-assertions on (via tools/preflight.sh)
+        run: tools/preflight.sh debug-assertions
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -265,13 +265,32 @@ after each major feature) and not yet on GitHub — a known gap to formalize.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented — runs the Tier-1/2 suite *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Clippy`, `Format`, `Public API baseline` (diffs `api/ferx-core-public-api.txt`); **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
+| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented — runs the Tier-1/2 suite *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Tests (debug-assertions)` (`--lib` on the **dev** profile, so `debug_assert!` guards actually run — see below), `Clippy`, `Format`, `Public API baseline` (diffs `api/ferx-core-public-api.txt`); **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
 | `slow-tests.yml` | nightly 06:00 UTC, manual, push to `main` touching estimation paths | Tier-3 fits to convergence (`--features ci,slow-tests --release`, `--no-fail-fast`) |
 | `docs.yml` | push to `main` touching `docs/**` | `quarto render` → deploy to `gh-pages` |
 | `release.yml` | tag `v*` or manual | GitHub release with generated notes |
 
 > Note: `RAYON_NUM_THREADS=1` is pinned in CI so cargo owns the test
 > parallelism on 2-core runners. Don't remove it.
+
+**Why a separate `Tests (debug-assertions)` job.** Every other test job builds
+with `--profile ci-test` or `--profile ci-fast`, and both `inherits = "release"`
+— so `debug-assertions` is off and each of the ~180 `debug_assert!` guards in the
+crate compiles to nothing. They were invariant checks CI never ran: an
+off-by-one in `compute_max_stack` tripped its own `debug_assert!` for any
+expression containing an `if`, and four lib tests panicked under the dev profile
+while CI stayed green (fixed in #342; the blind spot in #344). The fix is a
+separate job, not a flipped profile — `ci-test` exists so the fits run at release
+speed. Its commands live in `tools/preflight.sh` under the `debug-assertions`
+group; run them locally with
+
+```bash
+tools/preflight.sh debug-assertions
+```
+
+That group is the one `tools/preflight.sh` skips when you pass no arguments: it
+runs a test suite rather than a compile, so it is minutes rather than seconds.
+Name it when you want it.
 
 ### 8.3 CI workflows (ferx-r)
 
@@ -331,7 +350,8 @@ FOCE/FOCEI and HMC gradients come from hand-rolled analytic `Dual2` sensitivitie
 (`sens/`), and models outside the provider's scope fall back to finite differences.
 
 In fact there is no nightly-only code left, which is why the three coverage jobs
-in `ci.yml` override `RUSTUP_TOOLCHAIN` to **stable**: stable's rustc version
+in `ci.yml` — and `Tests (debug-assertions)` — override `RUSTUP_TOOLCHAIN` to
+**stable**: stable's rustc version
 holds for ~6 weeks against nightly's daily bump, keeping their instrumented build
 cache warm. `rust-toolchain.toml` still pins nightly as the default, and `Check` /
 `Clippy` / `Format` run on it.

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -292,6 +292,18 @@ That group is the one `tools/preflight.sh` skips when you pass no arguments: it
 runs a test suite rather than a compile, so it is minutes rather than seconds.
 Name it when you want it.
 
+Its commands carry `env FERX_REQUIRE_DEBUG_ASSERTIONS=1`, which arms a canary
+(`debug_assertion_canary` in `src/lib.rs`) that fails the run if `debug_assert!`
+turns out to compile to nothing after all. Without it the gate would rest on the
+*absence* of a `--profile` flag, and a `[profile.dev] debug-assertions = false`
+or a `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment would neuter the
+whole job with every test still green. Do not set that variable anywhere else:
+every other job legitimately runs with the guards off.
+
+What this does **not** fix: `debug_assert!` condition lines are still permanently
+zero-hit regions in the Codecov reports, because every coverage job uses a
+release-derived profile. See #1248.
+
 ### 8.3 CI workflows (ferx-r)
 
 `R-CMD-check.yaml` and `test-coverage.yaml`. **ferx-r CI builds ferx-core from

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -293,7 +293,7 @@ runs a test suite rather than a compile, so it is minutes rather than seconds.
 Name it when you want it.
 
 Its commands carry `env FERX_REQUIRE_DEBUG_ASSERTIONS=1`, which arms a canary
-(`debug_assertion_canary` in `src/lib.rs`) that fails the run if `debug_assert!`
+(`debug_assertion_canary` in `src/lib_tests.rs`) that fails the run if `debug_assert!`
 turns out to compile to nothing after all. Without it the gate would rest on the
 *absence* of a `--profile` flag, and a `[profile.dev] debug-assertions = false`
 or a `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment would neuter the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,3 +70,72 @@ pub use types::*;
 
 #[cfg(feature = "survival")]
 pub use api::{predict_categorical, predict_survival, SurvivalPredictionResult};
+
+/// Positive proof that the `debug_assert!` guards in this crate are LIVE (#344).
+///
+/// Every other test job builds with `ci-test`/`ci-fast`, both of which
+/// `inherits = "release"`, so all ~180 `debug_assert!`s compile to nothing. The
+/// `Tests (debug-assertions)` job exists to run them, and it does that by simply
+/// omitting `--profile` — the dev default has them on.
+///
+/// That is an invariant held by *absence*, which is the fragile kind. Nothing in
+/// the command string distinguishes a build with the guards live from one without:
+/// a `[profile.dev] debug-assertions = false` in `Cargo.toml`, or a
+/// `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` in the workflow environment, would
+/// neuter the whole job while all 4366 tests, all nine preflight-contract tests and
+/// both `cargo test` commands stayed green. The gate would then be exactly the
+/// no-op it was filed to replace.
+///
+/// So the group arms this canary through its own argument vector
+/// (`env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test …`, visible in
+/// `tools/preflight.sh --list` and asserted by
+/// `tests/preflight_owns_the_fast_gates.rs`), and the canary fails the run when the
+/// guards turn out to be dead.
+#[cfg(test)]
+mod debug_assertion_canary {
+    /// The env var `tools/preflight.sh`'s `debug-assertions` group sets. Deliberately
+    /// opt-*in*: every other job legitimately runs with the guards off, so an
+    /// unconditional assertion here would fail `Tests + coverage (core)` and both
+    /// coverage jobs for doing exactly what they are supposed to do.
+    const DEMAND: &str = "FERX_REQUIRE_DEBUG_ASSERTIONS";
+
+    #[test]
+    fn debug_assert_guards_run_when_the_gate_demands_them() {
+        let demanded = std::env::var_os(DEMAND).is_some();
+
+        // Observe the MACRO, not `cfg!(debug_assertions)`. The property the job exists
+        // to establish is "the condition of a `debug_assert!` is evaluated"; reading
+        // the cfg flag is one indirection away from it.
+        //
+        // `Cell` rather than `let mut`: with the guards off the assignment is compiled
+        // away, and a `mut` binding that is then never mutated warns.
+        let evaluated = std::cell::Cell::new(false);
+        debug_assert!({
+            evaluated.set(true);
+            true
+        });
+        let evaluated = evaluated.get();
+
+        assert_eq!(
+            evaluated,
+            cfg!(debug_assertions),
+            "`debug_assert!` and `cfg!(debug_assertions)` disagree, which should be \
+             impossible — the macro is defined in terms of that cfg. Read this as the \
+             canary itself being broken rather than the profile being wrong."
+        );
+
+        // The gate. Note the shape: `!demanded || evaluated`, so the only run this can
+        // fail is one that asked for the guards and did not get them. A single
+        // expression rather than an `if`, so both profiles execute every line here and
+        // the canary cannot read as uncovered on the patch gate.
+        assert!(
+            !demanded || evaluated,
+            "{DEMAND} is set — this run came from `tools/preflight.sh debug-assertions` \
+             or the `Tests (debug-assertions)` CI job — but `debug_assert!` compiled to \
+             nothing, so every guard in the crate is dead and the job is green for no \
+             reason. Something switched debug-assertions off for the dev profile: a \
+             `[profile.dev] debug-assertions = false` in Cargo.toml, or a \
+             `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment (#344)."
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,13 +78,13 @@ pub use api::{predict_categorical, predict_survival, SurvivalPredictionResult};
 /// `Tests (debug-assertions)` job exists to run them, and it does that by simply
 /// omitting `--profile` — the dev default has them on.
 ///
-/// That is an invariant held by *absence*, which is the fragile kind. Nothing in
-/// the command string distinguishes a build with the guards live from one without:
-/// a `[profile.dev] debug-assertions = false` in `Cargo.toml`, or a
+/// That is an invariant held by *absence*, which is the fragile kind. Nothing in the
+/// command string distinguishes a build with the guards live from one without: a
+/// `[profile.dev] debug-assertions = false` in `Cargo.toml`, or a
 /// `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` in the workflow environment, would
 /// neuter the whole job while all 4366 tests, all nine preflight-contract tests and
-/// both `cargo test` commands stayed green. The gate would then be exactly the
-/// no-op it was filed to replace.
+/// both `cargo test` commands stayed green. The gate would then be exactly the no-op
+/// it was filed to replace.
 ///
 /// So the group arms this canary through its own argument vector
 /// (`env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test …`, visible in
@@ -92,50 +92,5 @@ pub use api::{predict_categorical, predict_survival, SurvivalPredictionResult};
 /// `tests/preflight_owns_the_fast_gates.rs`), and the canary fails the run when the
 /// guards turn out to be dead.
 #[cfg(test)]
-mod debug_assertion_canary {
-    /// The env var `tools/preflight.sh`'s `debug-assertions` group sets. Deliberately
-    /// opt-*in*: every other job legitimately runs with the guards off, so an
-    /// unconditional assertion here would fail `Tests + coverage (core)` and both
-    /// coverage jobs for doing exactly what they are supposed to do.
-    const DEMAND: &str = "FERX_REQUIRE_DEBUG_ASSERTIONS";
-
-    #[test]
-    fn debug_assert_guards_run_when_the_gate_demands_them() {
-        let demanded = std::env::var_os(DEMAND).is_some();
-
-        // Observe the MACRO, not `cfg!(debug_assertions)`. The property the job exists
-        // to establish is "the condition of a `debug_assert!` is evaluated"; reading
-        // the cfg flag is one indirection away from it.
-        //
-        // `Cell` rather than `let mut`: with the guards off the assignment is compiled
-        // away, and a `mut` binding that is then never mutated warns.
-        let evaluated = std::cell::Cell::new(false);
-        debug_assert!({
-            evaluated.set(true);
-            true
-        });
-        let evaluated = evaluated.get();
-
-        assert_eq!(
-            evaluated,
-            cfg!(debug_assertions),
-            "`debug_assert!` and `cfg!(debug_assertions)` disagree, which should be \
-             impossible — the macro is defined in terms of that cfg. Read this as the \
-             canary itself being broken rather than the profile being wrong."
-        );
-
-        // The gate. Note the shape: `!demanded || evaluated`, so the only run this can
-        // fail is one that asked for the guards and did not get them. A single
-        // expression rather than an `if`, so both profiles execute every line here and
-        // the canary cannot read as uncovered on the patch gate.
-        assert!(
-            !demanded || evaluated,
-            "{DEMAND} is set — this run came from `tools/preflight.sh debug-assertions` \
-             or the `Tests (debug-assertions)` CI job — but `debug_assert!` compiled to \
-             nothing, so every guard in the crate is dead and the job is green for no \
-             reason. Something switched debug-assertions off for the dev profile: a \
-             `[profile.dev] debug-assertions = false` in Cargo.toml, or a \
-             `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment (#344)."
-        );
-    }
-}
+#[path = "lib_tests.rs"]
+mod debug_assertion_canary;

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -1,0 +1,55 @@
+//! Positive proof that the `debug_assert!` guards in this crate are LIVE (#344).
+//!
+//! Sibling test file rather than an inline `#[cfg(test)] mod`, for the ordinary
+//! reason (`CLAUDE.md`'s sibling-`*_tests.rs` pattern) and for one specific to what
+//! this module does: the interior of a `debug_assert!` is, by construction,
+//! unreachable under a release-derived profile. Inline in `src/lib.rs` those two
+//! lines are permanently-missed patch lines in every Codecov job — the exact defect
+//! filed as #1248 — and they took this PR's own patch gate to 9/11 = 81.81%. No
+//! test can cover them; they are a measurement artefact, not a coverage gap. Here
+//! they are simply not measured, which is how the other 53 `*_tests.rs` files in
+//! this repo are already treated.
+
+/// The env var `tools/preflight.sh`'s `debug-assertions` group sets. Deliberately
+/// opt-*in*: every other job legitimately runs with the guards off, so an
+/// unconditional assertion here would fail `Tests + coverage (core)` and both
+/// coverage jobs for doing exactly what they are supposed to do.
+const DEMAND: &str = "FERX_REQUIRE_DEBUG_ASSERTIONS";
+
+#[test]
+fn debug_assert_guards_run_when_the_gate_demands_them() {
+    let demanded = std::env::var_os(DEMAND).is_some();
+
+    // Observe the MACRO, not `cfg!(debug_assertions)`. The property the job exists
+    // to establish is "the condition of a `debug_assert!` is evaluated"; reading the
+    // cfg flag is one indirection away from it.
+    //
+    // `Cell` rather than `let mut`: with the guards off the assignment is compiled
+    // away, and a `mut` binding that is then never mutated warns.
+    let evaluated = std::cell::Cell::new(false);
+    debug_assert!({
+        evaluated.set(true);
+        true
+    });
+    let evaluated = evaluated.get();
+
+    assert_eq!(
+        evaluated,
+        cfg!(debug_assertions),
+        "`debug_assert!` and `cfg!(debug_assertions)` disagree, which should be \
+         impossible — the macro is defined in terms of that cfg. Read this as the \
+         canary itself being broken rather than the profile being wrong."
+    );
+
+    // The gate. Note the shape: `!demanded || evaluated`, so the only run this can
+    // fail is one that asked for the guards and did not get them.
+    assert!(
+        !demanded || evaluated,
+        "{DEMAND} is set — this run came from `tools/preflight.sh debug-assertions` \
+         or the `Tests (debug-assertions)` CI job — but `debug_assert!` compiled to \
+         nothing, so every guard in the crate is dead and the job is green for no \
+         reason. Something switched debug-assertions off for the dev profile: a \
+         `[profile.dev] debug-assertions = false` in Cargo.toml, or a \
+         `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment (#344)."
+    );
+}

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -590,7 +590,7 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
         // this group's two commands intact, run all 4366 tests, and keep every
         // assertion in this file green while the job verified nothing —
         // an invariant held by absence is exactly what #344 was filed about.
-        // `debug_assertion_canary` in `src/lib.rs` closes that, but only when armed,
+        // `debug_assertion_canary` (`src/lib_tests.rs`) closes that, but only when armed,
         // so the arming has to be pinned as tightly as the flags are.
         //
         // `starts_with`, not `contains`: it must be the argv-leading `env` form, so
@@ -600,7 +600,7 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
             "`{cmd}` does not arm the debug-assertions canary. Prefix it with \
              `env FERX_REQUIRE_DEBUG_ASSERTIONS=1` (in the argument vector, so \
              `--list` shows it): without that, `debug_assertion_canary` in \
-             src/lib.rs passes vacuously and nothing in this group ever verifies \
+             src/lib_tests.rs passes vacuously and nothing in this group ever verifies \
              that `debug_assert!` is actually live (#344)."
         );
     }

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -575,10 +575,33 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
              green (#344). Drop the flag; the dev default is the gate."
         );
         assert!(
-            cmd.starts_with("cargo test "),
+            cmd.contains("cargo test "),
             "`{cmd}` is in the `debug-assertions` group but does not RUN anything. \
              A `cargo check`/`clippy` line compiles the assertions and never \
              evaluates them, which is the blind spot, not the fix (#344)."
+        );
+
+        // The POSITIVE half, and the one the flag check above cannot supply.
+        // Rejecting `--profile` only rules out the ways of turning the guards off
+        // that are VISIBLE in the command string. Two are not: `[profile.dev]
+        // debug-assertions = false` in Cargo.toml, and a
+        // `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` in the workflow environment.
+        // Either would leave
+        // this group's two commands intact, run all 4366 tests, and keep every
+        // assertion in this file green while the job verified nothing —
+        // an invariant held by absence is exactly what #344 was filed about.
+        // `debug_assertion_canary` in `src/lib.rs` closes that, but only when armed,
+        // so the arming has to be pinned as tightly as the flags are.
+        //
+        // `starts_with`, not `contains`: it must be the argv-leading `env` form, so
+        // `run` echoes it and `--list` tells the truth about what will run.
+        assert!(
+            cmd.starts_with("env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo "),
+            "`{cmd}` does not arm the debug-assertions canary. Prefix it with \
+             `env FERX_REQUIRE_DEBUG_ASSERTIONS=1` (in the argument vector, so \
+             `--list` shows it): without that, `debug_assertion_canary` in \
+             src/lib.rs passes vacuously and nothing in this group ever verifies \
+             that `debug_assert!` is actually live (#344)."
         );
     }
 
@@ -782,16 +805,23 @@ fn the_default_run_is_every_group_that_is_not_opt_in_and_ci_runs_the_rest() {
          to ALL_GROUPS and to neither list's intent."
     );
 
-    // The other half: each opt-in group is invoked by name in ci.yml. Searched over
-    // the whole file rather than one job body, so moving it between jobs is fine —
-    // what must not happen is it running nowhere.
+    // The other half: each opt-in group is invoked by name in ci.yml — read from the
+    // file's parsed `run:` steps, NOT from its raw text. A YAML *comment* that merely
+    // mentions `tools/preflight.sh <group>` would satisfy a `contains` check while
+    // nothing executed the group, and this workflow is full of comments that name
+    // exactly these commands, so that check would have been self-satisfying. Applied
+    // to the whole document rather than one job body on purpose: moving the group
+    // between jobs is fine, running it nowhere is not.
     let yml = ci_yml();
+    let executed = run_commands(&yml);
     for g in &opt_in {
         let want = format!("tools/preflight.sh {g}");
         assert!(
-            yml.contains(&want),
-            "group `{g}` is opt-in locally and no job in ci.yml runs `{want}`, so it \
-             is a gate that nothing executes"
+            executed.iter().any(|c| c == &want),
+            "group `{g}` is opt-in locally and no job in ci.yml RUNS `{want}`, so it \
+             is a gate that nothing executes. Naming it in a comment does not count — \
+             this reads the `run:` steps.\nrun steps found:\n  {}",
+            executed.join("\n  ")
         );
     }
 }

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -1,6 +1,6 @@
-//! Guard: the `Check`, `Clippy` and `Format` jobs in `.github/workflows/ci.yml` must run
-//! their cargo commands **through `tools/preflight.sh`**, and that script must actually
-//! fail when a gate fails (#1157).
+//! Guard: the `Check`, `Clippy`, `Format`, `Rustdoc` and `Tests (debug-assertions)` jobs
+//! in `.github/workflows/ci.yml` must run their cargo commands **through
+//! `tools/preflight.sh`**, and that script must actually fail when a gate fails (#1157).
 //!
 //! The point of the script is not documentation — it is that CI executes the same list a
 //! developer runs before pushing, so "green locally" and "green in CI" cannot mean
@@ -11,14 +11,18 @@
 //! `--features ci,nn,slow-tests` had been failing to compile for an entire commit,
 //! because the local run and the CI run were not the same set.
 //!
-//! Three invariants:
+//! Four invariants:
 //!
-//!  1. Those three jobs contain **no inline `run: cargo …` step**, and neither skip
+//!  1. Those jobs contain **no inline `run: cargo …` step**, and neither skip
 //!     themselves (`if:`) nor tolerate failure (`continue-on-error`). Each is a way for
 //!     the two lists to diverge, or for a red gate to report green.
 //!  2. Each of them **does** invoke `tools/preflight.sh <group>` with its own group.
 //!  3. A failing command makes the script exit non-zero **from every position in the
 //!     list**, not just the last one.
+//!  4. A no-argument run is `ALL_GROUPS` minus `OPT_IN_GROUPS`, and every opt-in group
+//!     is named by a job in `ci.yml` (#344). An opt-in group exists because it runs a
+//!     test suite rather than a compile — `debug-assertions` is the only one — and the
+//!     failure it invites is a gate that runs in neither place.
 //!
 //! (3) is not hypothetical. The first version of the script returned a status from `run`
 //! and propagated it through a group function and a `case … esac || { …; exit 1; }` —
@@ -52,6 +56,40 @@ fn repo_root() -> PathBuf {
 
 fn preflight() -> PathBuf {
     repo_root().join("tools").join("preflight.sh")
+}
+
+/// One `NAME=(a b c)` array literal out of `tools/preflight.sh`.
+///
+/// The script is the single owner of the group list, so these tests read the list
+/// FROM it rather than keeping a second copy. A group added to `ALL_GROUPS` is
+/// therefore covered by every assertion below the moment it is added — including
+/// the count tripwire, which is the one place a literal remains (deliberately: it
+/// is a tripwire against silent shrinkage, not a copy of the commands).
+fn script_array(name: &str) -> Vec<String> {
+    let src = std::fs::read_to_string(preflight()).expect("read tools/preflight.sh");
+    let needle = format!("\n{name}=(");
+    let start = src
+        .find(&needle)
+        .unwrap_or_else(|| panic!("`{name}=(` not found in tools/preflight.sh"))
+        + needle.len();
+    let rest = &src[start..];
+    let end = rest
+        .find(')')
+        .unwrap_or_else(|| panic!("unterminated `{name}=(` in tools/preflight.sh"));
+    rest[..end].split_whitespace().map(str::to_string).collect()
+}
+
+/// Every group the script knows about, opt-in ones included.
+fn all_groups() -> Vec<String> {
+    let groups = script_array("ALL_GROUPS");
+    assert!(!groups.is_empty(), "ALL_GROUPS parsed empty");
+    groups
+}
+
+/// The groups a no-argument run deliberately SKIPS (#344): they run a test suite
+/// rather than a compile, so they are named explicitly or run by CI.
+fn opt_in_groups() -> Vec<String> {
+    script_array("OPT_IN_GROUPS")
 }
 
 fn ci_yml() -> String {
@@ -171,6 +209,12 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
         ("clippy", "clippy"),
         ("fmt", "fmt"),
         ("rustdoc", "rustdoc"),
+        // #344. This one is a TEST job, not a compile/lint gate, and it is the
+        // only group a no-argument `tools/preflight.sh` skips — so the workflow
+        // is the only place it is guaranteed to run. That makes delegation
+        // matter more here, not less: an inline `cargo test` in the job would be
+        // a command no developer can reproduce with a documented local call.
+        ("debug-assertions", "debug-assertions"),
     ] {
         let body = job_body(&yml, job);
         let cmds = run_commands(&body);
@@ -244,7 +288,7 @@ fn a_failing_gate_fails_the_script_from_every_position() {
     // Every group whose commands are `cargo` invocations, so the fake below intercepts
     // them. `public-api` shells out to `tools/update-public-api.sh` instead and is covered
     // by `the_failure_diagnostic_names_the_group_that_actually_failed`.
-    for group in ["fmt", "check", "clippy", "rustdoc"] {
+    for group in ["fmt", "check", "clippy", "rustdoc", "debug-assertions"] {
         let listed = listed_commands(group);
         assert!(
             !listed.is_empty(),
@@ -509,6 +553,46 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
         docs.join("\n  ")
     );
 
+    // The `debug-assertions` group is a gate ONLY because it builds on the default
+    // dev profile (#344). Every named profile in this repo — `release`, `ci-test`,
+    // `ci-fast` — has `debug-assertions` off, `ci-test`/`ci-fast` by inheriting
+    // `release`, so a `--profile`/`--release` flag added to one of these commands
+    // would leave two `cargo test` lines in the list, still run 4000-odd tests,
+    // still take minutes, and compile every `debug_assert!` in the crate back down
+    // to nothing. That is the exact shape of the neutered gate this test exists for:
+    // the command list cannot show it, only its flags can.
+    let dbg = listed_commands("debug-assertions");
+    assert!(
+        !dbg.is_empty(),
+        "the `debug-assertions` group lists no commands"
+    );
+    for cmd in &dbg {
+        assert!(
+            !cmd.contains("--profile") && !cmd.contains("--release"),
+            "`{cmd}` selects an explicit profile. Every named profile in this repo \
+             inherits `release`, where `debug-assertions = false`, so the guards this \
+             group exists to execute would compile to nothing while the job stayed \
+             green (#344). Drop the flag; the dev default is the gate."
+        );
+        assert!(
+            cmd.starts_with("cargo test "),
+            "`{cmd}` is in the `debug-assertions` group but does not RUN anything. \
+             A `cargo check`/`clippy` line compiles the assertions and never \
+             evaluates them, which is the blind spot, not the fix (#344)."
+        );
+    }
+
+    // Same non-nesting trap as `check`: `--features ci` compiles neither
+    // `src/survival`, `src/markov`, `src/categorical` nor `src/nn`, and all four
+    // carry `debug_assert!`s.
+    assert!(
+        dbg.iter().any(|c| c.contains("ci,markov,nn")),
+        "no `debug-assertions` command builds `ci,markov,nn`, so every guard in the \
+         feature-gated endpoint and NN code is as dead here as in the release-profile \
+         jobs:\n  {}",
+        dbg.join("\n  ")
+    );
+
     // Union of every `--features` value in the check group.
     let check = listed_commands("check");
     let mut features: Vec<String> = Vec::new();
@@ -553,9 +637,15 @@ fn preflight_is_executable_and_lists_every_group() {
         );
     }
 
+    // Every group by name, not a bare `--list`: since #344 a no-argument run is
+    // `ALL_GROUPS` minus `OPT_IN_GROUPS`, so a bare `--list` would walk past the
+    // opt-in group and it would get no count tripwire at all — exactly the
+    // silent-shrinkage hole this test exists to close. The names come from the
+    // script's own array, so there is still no second copy of the group list.
     let out = Command::new("bash")
         .arg(&script)
         .arg("--list")
+        .args(all_groups())
         .current_dir(repo_root())
         .output()
         .expect("run tools/preflight.sh --list");
@@ -578,13 +668,19 @@ fn preflight_is_executable_and_lists_every_group() {
     // commands are actually *enforced* is
     // `a_failing_gate_fails_the_script_from_every_position`; `--list` executes nothing and
     // can never show it.
-    let expected: [(&str, usize); 6] = [
+    let expected: [(&str, usize); 7] = [
         ("fmt", 1),        // cargo fmt --all -- --check
         ("check", 5),      // ci · ci,survival,slow-tests · ci,markov · ci,nn,slow-tests · members
         ("clippy", 2),     // ferx-core --all-targets · members
         ("rustdoc", 2),    // ferx-core rustdoc · members
         ("docs", 2),       // cargo test -p docs-lint · cargo clippy -p docs-lint
         ("public-api", 1), // tools/update-public-api.sh --check
+        // #344: `--features ci` · `--features ci,markov,nn`. The second line is
+        // not padding — `ci` compiles neither `src/survival`, `src/markov`,
+        // `src/categorical` nor `src/nn`, and all four carry `debug_assert!`s, so
+        // dropping it would leave those guards exactly as dead as they are in
+        // every release-profile job.
+        ("debug-assertions", 2),
     ];
 
     // Every group `--list` actually walks must have an entry above. The loop below
@@ -629,12 +725,75 @@ fn preflight_is_executable_and_lists_every_group() {
              group's dispatch or one of its `run` lines is silently doing nothing.\n{stdout}"
         );
     }
-    // The default run is the full set; a subset would silently under-check a developer
-    // who typed no arguments.
     assert!(
         stdout.contains("nothing was executed"),
         "`--list` should execute nothing:\n{stdout}"
     );
+}
+
+/// A no-argument run is **every group except the declared opt-in ones** — and an
+/// opt-in group is only legitimate because CI runs it.
+///
+/// Both halves matter and they fail in opposite directions. Drop a group from the
+/// default set without declaring it opt-in and a developer who types no arguments
+/// silently under-checks; declare one opt-in without a CI job that names it and
+/// the gate runs *nowhere*, which is strictly worse than the blind spot #344 was
+/// filed about — there the guards were at least compiled out honestly.
+#[test]
+fn the_default_run_is_every_group_that_is_not_opt_in_and_ci_runs_the_rest() {
+    let all = all_groups();
+    let opt_in = opt_in_groups();
+
+    for g in &opt_in {
+        assert!(
+            all.contains(g),
+            "`{g}` is in OPT_IN_GROUPS but not in ALL_GROUPS, so naming it is an \
+             argument error and nothing can ever run it"
+        );
+    }
+
+    let out = Command::new("bash")
+        .arg(preflight())
+        .arg("--list")
+        .current_dir(repo_root())
+        .output()
+        .expect("run tools/preflight.sh --list");
+    assert!(
+        out.status.success(),
+        "`--list` exited {:?}",
+        out.status.code()
+    );
+    let walked: Vec<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|l| l.trim().strip_prefix("══ "))
+        .filter_map(|l| l.split_whitespace().next())
+        .map(str::to_string)
+        .collect();
+
+    let want: Vec<String> = all
+        .iter()
+        .filter(|g| !opt_in.contains(g))
+        .cloned()
+        .collect();
+    assert_eq!(
+        walked, want,
+        "a no-argument run walks {walked:?} but ALL_GROUPS minus OPT_IN_GROUPS is \
+         {want:?}. Either a gate silently left the default run, or a group was added \
+         to ALL_GROUPS and to neither list's intent."
+    );
+
+    // The other half: each opt-in group is invoked by name in ci.yml. Searched over
+    // the whole file rather than one job body, so moving it between jobs is fine —
+    // what must not happen is it running nowhere.
+    let yml = ci_yml();
+    for g in &opt_in {
+        let want = format!("tools/preflight.sh {g}");
+        assert!(
+            yml.contains(&want),
+            "group `{g}` is opt-in locally and no job in ci.yml runs `{want}`, so it \
+             is a gate that nothing executes"
+        );
+    }
 }
 
 /// `--help` is the only place a developer learns which groups exist, so it must not be
@@ -671,22 +830,13 @@ fn preflight_help_lists_every_group_and_works_from_any_cwd() {
         );
     }
 
-    // Every group the script will actually dispatch has to be documented. Naming them
-    // from the `--list` banners rather than from a literal here means a new group cannot
-    // be added without `--help` growing it too.
-    let full = Command::new("bash")
-        .arg(preflight())
-        .arg("--list")
-        .current_dir(repo_root())
-        .output()
-        .expect("run tools/preflight.sh --list");
-    let groups: Vec<String> = String::from_utf8_lossy(&full.stdout)
-        .lines()
-        .filter_map(|l| l.trim().strip_prefix("══ "))
-        .filter_map(|l| l.split_whitespace().next())
-        .map(str::to_string)
-        .collect();
-    assert!(!groups.is_empty(), "no group banners in `--list` output");
+    // Every group the script will actually dispatch has to be documented. Read from
+    // the script's own `ALL_GROUPS` rather than from a literal here, so a new group
+    // cannot be added without `--help` growing it too — and `ALL_GROUPS` rather than
+    // the `--list` banners of a no-argument run, because since #344 that run walks
+    // only the default set and an opt-in group is precisely the one a developer
+    // will never discover any other way (#344).
+    let groups = all_groups();
     for g in &groups {
         assert!(
             stdout.contains(g.as_str()),

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -389,7 +389,20 @@ group_debug_assertions() {
   # `Tests + coverage (core)`, and compiling 120-odd of them again under a second
   # profile is the cost this group is shaped to avoid. Tier-1 is also where the
   # guards live — `debug_assert!` sits next to the invariant, in `src/`.
-  run cargo test --lib --no-default-features --features ci
+  # `env FERX_REQUIRE_DEBUG_ASSERTIONS=1` in the ARGUMENT VECTOR, not as a shell
+  # assignment prefix and not an `export` up in this function. Both of those would
+  # reach the child just the same, but `run` echoes `$*`, so only this form appears
+  # in `--list` — and what `--list` prints is what the guard test can assert and
+  # what a developer can copy. Same reasoning as `RUSTDOCFLAGS` in `group_rustdoc`.
+  #
+  # It arms `debug_assertion_canary` in `src/lib.rs`, which fails the run if
+  # `debug_assert!` turns out to compile to nothing. Without it this whole group is
+  # an invariant held by ABSENCE — nothing in `cargo test --lib --features ci`
+  # distinguishes a build with the guards live from one without, so a
+  # `[profile.dev] debug-assertions = false` or a `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS`
+  # in the environment would neuter it with every test still green. The canary is
+  # opt-in precisely because every OTHER job legitimately runs with the guards off.
+  run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --no-default-features --features ci
 
   # The feature-gated surface, for the same non-nesting reason `check` is a matrix
   # rather than one line: `--features ci` compiles neither `src/survival`,
@@ -398,7 +411,8 @@ group_debug_assertions() {
   # as they are in every other one. `markov` implies `survival`, so
   # `ci,markov,nn` is the union of the production cfgs — the same set `clippy` and
   # `rustdoc` take, and for the same reason.
-  run cargo test --lib --no-default-features --features ci,markov,nn
+  run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --no-default-features \
+    --features ci,markov,nn
 }
 
 # ── Drive ───────────────────────────────────────────────────────────────────

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -395,7 +395,7 @@ group_debug_assertions() {
   # in `--list` — and what `--list` prints is what the guard test can assert and
   # what a developer can copy. Same reasoning as `RUSTDOCFLAGS` in `group_rustdoc`.
   #
-  # It arms `debug_assertion_canary` in `src/lib.rs`, which fails the run if
+  # It arms `debug_assertion_canary` (`src/lib_tests.rs`), which fails the run if
   # `debug_assert!` turns out to compile to nothing. Without it this whole group is
   # an invariant held by ABSENCE — nothing in `cargo test --lib --features ci`
   # distinguishes a build with the guards live from one without, so a

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -60,7 +60,44 @@ export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly}"
 # current user's numeric group IDs, and it wins. The first draft used it and
 # every group name silently became a GID — `unknown group 'check' — expected one
 # of: 20 12 61 ...`.
-ALL_GROUPS=(fmt check clippy rustdoc docs public-api)
+ALL_GROUPS=(fmt check clippy rustdoc docs public-api debug-assertions)
+
+# Groups that are NOT in the default selection.
+#
+# Every other group is a compile or a lint — seconds on a warm `target/`, which
+# is what makes a no-argument run something you do before every push. A group
+# that RUNS the unit suite is a different order of cost (its own profile hash,
+# so its own full build, and then the tests), and folding it into the default
+# would turn `tools/preflight.sh` from a pre-push habit into a coffee break. So
+# it is opt-in by name — `tools/preflight.sh debug-assertions` — and CI runs it
+# as its own job, which is where it has to be green.
+#
+# `--help` and `--list` still enumerate it, and
+# `tests/preflight_owns_the_fast_gates.rs` pins both this array and the fact that
+# the corresponding CI job delegates here, so an opt-in group cannot quietly
+# become a group that nothing ever runs.
+OPT_IN_GROUPS=(debug-assertions)
+
+is_opt_in() {
+  local candidate="$1" g
+  for g in "${OPT_IN_GROUPS[@]}"; do
+    if [ "$g" = "$candidate" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# `ALL_GROUPS` minus `OPT_IN_GROUPS`, in `ALL_GROUPS` order. Derived rather than
+# written out a second time: a group added to one list and forgotten in the other
+# is the failure mode this whole script exists to avoid.
+DEFAULT_GROUPS=()
+for g in "${ALL_GROUPS[@]}"; do
+  if ! is_opt_in "$g"; then
+    DEFAULT_GROUPS+=("$g")
+  fi
+done
+
 
 usage() {
   cat <<EOF
@@ -71,12 +108,21 @@ Run the fast CI gates locally, so "green on my machine" means what CI means.
   tools/preflight.sh fmt clippy   any subset, in the order you name them
   tools/preflight.sh --list       print the commands without running them
 
-Groups: ${ALL_GROUPS[*]}  (default: all of them, in that order)
+Groups: ${ALL_GROUPS[*]}
+Default: ${DEFAULT_GROUPS[*]}  (in that order)
 
-NOT covered: the test jobs. \`cargo check --tests\` COMPILES the test targets
-but runs nothing, so \`Tests + coverage (core)\` can still go red after a green
-preflight. This gates compilation and lint, not behaviour. (The one exception is
-\`docs\`, whose gate IS its test run — a filesystem walk over \`docs/\`, not a fit.)
+Opt-in, i.e. NOT in a no-argument run: ${OPT_IN_GROUPS[*]}. \`debug-assertions\`
+RUNS the Tier-1 suite on the default \`dev\` profile (#344). Every other test job
+builds with \`ci-test\`/\`ci-fast\`, which \`inherits = "release"\` — so every
+\`debug_assert!\` in the crate is compiled to nothing and its invariant goes
+unchecked. It is a build plus a test run rather than seconds of compile, so you
+name it when you want it; CI runs it on every PR.
+
+NOT covered by the DEFAULT set: the test jobs. \`cargo check --tests\` COMPILES
+the test targets but runs nothing, so \`Tests + coverage (core)\` can still go red
+after a green preflight. The default set gates compilation and lint, not
+behaviour. Two exceptions: \`docs\`, whose gate IS its test run (a filesystem walk
+over \`docs/\`, not a fit), and the opt-in \`debug-assertions\` above.
 EOF
 }
 
@@ -120,7 +166,7 @@ done
 # Cheapest first, so a formatting slip fails in seconds rather than after a
 # full compile. CI calls one group per job, so this order only affects local runs.
 if [ ${#SELECTED[@]} -eq 0 ]; then
-  SELECTED=("${ALL_GROUPS[@]}")
+  SELECTED=("${DEFAULT_GROUPS[@]}")
 fi
 
 # ── Plumbing ────────────────────────────────────────────────────────────────
@@ -313,6 +359,48 @@ group_public_api() {
   run tools/update-public-api.sh --check
 }
 
+group_debug_assertions() {
+  CI_JOB="Tests (debug-assertions)"
+  # #344. Every OTHER test job in this repo builds with `--profile ci-test` or
+  # `--profile ci-fast`, both of which `inherits = "release"` — so
+  # `debug-assertions` is OFF and all 177 `debug_assert!` guards in the crate are
+  # compiled to nothing. They are invariant checks that CI was not running.
+  #
+  # That is not theoretical: a real off-by-one in `compute_max_stack`
+  # (`src/parser/model_parser.rs`) tripped its own `debug_assert!` on any
+  # expression containing an `if`, and four lib tests panicked under the dev
+  # profile while CI stayed green through the whole thing. It was fixed in #342;
+  # the CI blind spot that hid it is what this group closes.
+  #
+  # The DEFAULT (dev) profile, deliberately — no `--profile` flag:
+  #
+  #  * it is the profile the bug actually reproduced under, so this gate is the
+  #    literal repro rather than an approximation of it;
+  #  * it also turns on `overflow-checks`, which `release` leaves off, so integer
+  #    overflow panics instead of wrapping silently — a second class of guard the
+  #    other jobs cannot see;
+  #  * a `ci-test`-with-debug-assertions profile would be a distinct profile hash
+  #    and therefore a whole extra OPTIMISED build of the lib, which in this
+  #    compile-bound repo (93% of the build is LLVM, #969/#971) costs far more
+  #    than the unoptimised tests do. Measured here on the dev profile: 80s of
+  #    tests for `ci` (4035) and 198s for `ci,markov,nn` (4366), all green.
+  #
+  # `--lib` only: Tier-1 unit tests. The `tests/` binaries are run by
+  # `Tests + coverage (core)`, and compiling 120-odd of them again under a second
+  # profile is the cost this group is shaped to avoid. Tier-1 is also where the
+  # guards live — `debug_assert!` sits next to the invariant, in `src/`.
+  run cargo test --lib --no-default-features --features ci
+
+  # The feature-gated surface, for the same non-nesting reason `check` is a matrix
+  # rather than one line: `--features ci` compiles neither `src/survival`,
+  # `src/markov`, `src/categorical` nor `src/nn`, and all four carry
+  # `debug_assert!`s. Without this line their guards would be as dead in this job
+  # as they are in every other one. `markov` implies `survival`, so
+  # `ci,markov,nn` is the union of the production cfgs — the same set `clippy` and
+  # `rustdoc` take, and for the same reason.
+  run cargo test --lib --no-default-features --features ci,markov,nn
+}
+
 # ── Drive ───────────────────────────────────────────────────────────────────
 
 # A group named in `ALL_GROUPS` with no `group_<name>` function would print its
@@ -347,7 +435,7 @@ if [ "$LIST_ONLY" -eq 1 ]; then
   echo "(--list: nothing was executed)"
 else
   echo "preflight OK — ${SELECTED[*]}"
-  if [ ${#SELECTED[@]} -lt ${#ALL_GROUPS[@]} ]; then
+  if [ ${#SELECTED[@]} -lt ${#DEFAULT_GROUPS[@]} ]; then
     echo "note: this was a SUBSET. A full run is 'tools/preflight.sh' with no arguments."
   fi
 fi


### PR DESCRIPTION
## Why

Every test job in `ci.yml` builds with `--profile ci-test` or `--profile ci-fast`, and both `inherits = "release"` — so `debug-assertions` is **off** and all **177 `debug_assert!`** guards in the crate compile to nothing. They are invariant checks CI has never executed.

That is not theoretical. An off-by-one in `compute_max_stack` (`src/parser/model_parser.rs`) tripped its own `debug_assert!` for any expression containing an `if`/ternary, and four lib tests panicked under the dev profile while CI stayed green through the whole thing:

- `parser::model_parser::tests::bytecode_matches_ast_on_conditional_and_logic`
- `parser::model_parser::tests::test_inline_if_in_parameter_assignment`
- `parser::model_parser::tests::test_ode_rhs_defined_names_ok`
- `parser::model_parser::tests::test_parse_all_example_ferx_files`

The bug was fixed in #342. The *class* of problem — any future invariant violation guarded by `debug_assert!` being invisible to CI — is what this addresses.

## What changed

**A new `Tests (debug-assertions)` job**, not a flipped profile. `ci-test` exists so the population fits run at release speed (`Cargo.toml`'s comment says so); flipping it would slow every other test job.

The job builds on the **default `dev` profile** — no `--profile` flag — deliberately:

- it is the profile the #342 bug actually reproduced under, so the gate is the literal repro rather than an approximation of it;
- it also turns on `overflow-checks`, which `release` leaves off, so integer overflow panics instead of wrapping silently — a second class of guard no other job can see;
- a `ci-test`-with-`debug-assertions` profile would be a distinct profile hash and therefore a whole extra **optimised** build of the lib. This repo is compile-bound (93% LLVM, #969/#971), so one extra *unoptimised* build is much cheaper than a second optimised one.

**Two feature sets**, for the same non-nesting reason `check` is a matrix rather than one line: `--features ci` compiles neither `src/survival`, `src/markov`, `src/categorical` nor `src/nn`, and all four carry `debug_assert!`s. `markov` implies `survival`, so `ci,markov,nn` is the union of the production cfgs (same set `clippy` and `rustdoc` take).

`--lib` only: Tier-1 is where the guards live (`debug_assert!` sits next to the invariant, in `src/`), and the `tests/` binaries are already run by `Tests + coverage (core)`.

**Wired through `tools/preflight.sh`** (#1157) as the `debug-assertions` group, so the local gate and the CI gate stay one list. It is the **first opt-in group**: it runs a test suite rather than a compile, so folding it into a no-argument run would turn `tools/preflight.sh` from a seconds-long pre-push habit into a coffee break. The default selection is now derived as `ALL_GROUPS` minus `OPT_IN_GROUPS`, so the two lists cannot drift.

```bash
tools/preflight.sh debug-assertions   # what the new CI job runs
```

**A canary, because "no `--profile` flag" is an invariant held by absence.** Nothing in `cargo test --lib --features ci` distinguishes a build with the guards live from one without, so a `[profile.dev] debug-assertions = false` in `Cargo.toml` or a `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` in the workflow environment would neuter the entire job with every test still green — the gate back to being the no-op it was filed to replace. `debug_assertion_canary` (`src/lib.rs`) closes that: it records whether a `debug_assert!` actually **evaluated its condition** (the macro, not `cfg!(debug_assertions)` — one indirection closer to the property that matters) and fails the run when the guards turn out to be dead.

It is armed opt-in, via `env FERX_REQUIRE_DEBUG_ASSERTIONS=1` in the group's own argument vector — the `env` form so `run` echoes it and `--list` tells the truth, the same reasoning `group_rustdoc` uses for `RUSTDOCFLAGS`. Opt-in because every *other* job legitimately runs with the guards off; an unconditional assertion would fail `Tests + coverage (core)` and both coverage jobs for doing exactly what they are supposed to do.

**Triage (the issue's caveat).** Turning the guards on surfaced **no latent failure**. Measured locally on the dev profile:

| feature set | tests | result | wall clock |
|---|---|---|---|
| `ci` | 4035 | **ok**, 0 failed, 23 ignored | 80s |
| `ci,markov,nn` | 4366 | **ok**, 0 failed, 23 ignored | 198s |

So the job starts green; nothing needed fixing or documenting as a known failure.

## Alternatives considered

- **Flip `debug-assertions = true` on `ci-test`.** Rejected by the issue and on the merits: that profile exists for fit speed, and every job that uses it would pay.
- **A `ci-test`-like profile with `debug-assertions = true`** (the issue's second option). It gives fast tests, at the price of a second full **optimised** lib build under its own profile hash. The dev profile wins because it **fits inside the wall-clock envelope the existing test jobs already set**, and it gets `overflow-checks` for free.

  > **Corrected after the first CI run.** This bullet originally argued the dev profile wins because "the tests are the cheap side in a compile-bound repo". On a 2-core runner that is backwards. From the job log: `finished in 396.49s` (`ci`) and `finished in 1223.02s` (`ci,markov,nn`) — **27 minutes of tests** against roughly 3 minutes of compile, the reverse of the local measurement (80s + 198s on a warm 10-core machine). I should have labelled those numbers local-only rather than generalising from them.
  >
  > The decision stands, for a different reason than the one first given: at 29m57s the job runs in parallel with `Tests + coverage (core)` (28m26s) and `Tests + coverage (TTE/CTMM endpoints)` (24m32s), so it does not extend total CI wall clock. And the `ci-fast`-plus-assertions variant trades ~24 min of unoptimised tests for an optimised lib build those same jobs show costs ~20 min — close to a wash, while giving up `overflow-checks` and the literal-repro property.
  >
  > **Consequence for review:** this job is now roughly the critical path rather than comfortably inside it. If the Tier-1 suite grows much, it is the first job to push total CI time up, and the `ci-fast`-plus-assertions variant becomes the better trade at that point. The 29m57s is also a cold-cache figure, and only the ~3 min compile half is cacheable.
- **Fold the group into the default `preflight.sh` run.** Rejected: the script's contract is seconds of compile/lint, and a multi-minute suite in the default set is how a pre-push gate stops being run at all.
- **`--tests` instead of `--lib`.** Rejected: compiling ~120 more binaries under a second profile for guards that overwhelmingly live in `src/`.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

CI-only; no `pub` surface, no `.ferx` format, no `FitResult` change.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [x] None

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):
- [x] Not applicable (docs / refactor / CI only)

No numerical path is touched — this changes which compiler flags the existing tests run under.

## Performance
- [x] No significant impact expected

No change to any shipped profile. CI gains one job: **29m57s** cold cache on this PR's first run, **21m59s** warm on the latest — against `Tests + coverage (core)` at 17m25s and `Tests + coverage (TTE/CTMM endpoints)` at 16m34s on that same warm run. It runs in parallel with them, so it does not extend total CI wall clock, but it is now the longest single job. See the correction under *Alternatives considered*.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

`tests/preflight_owns_the_fast_gates.rs` — the file that already pins the preflight/CI contract — grows to cover the new group. It reads the group list **out of the script** (`script_array("ALL_GROUPS")` / `("OPT_IN_GROUPS")`) rather than keeping a second copy, so a future group is covered the moment it is added:

1. the new job must delegate to `tools/preflight.sh debug-assertions`, run no inline `cargo`, and neither skip itself (`if:`) nor tolerate failure (`continue-on-error`);
2. the script must exit non-zero when either of the group's two commands fails (the existing fake-`cargo` position sweep now includes it);
3. **new test** — a no-argument run must equal `ALL_GROUPS` minus `OPT_IN_GROUPS`, *and* every opt-in group must be named by a job in `ci.yml`. Both halves matter and fail in opposite directions: drop a group from the default set without declaring it opt-in and a developer silently under-checks; declare one opt-in with no CI job and the gate runs **nowhere** — strictly worse than the blind spot #344 is about, where the guards were at least compiled out honestly;
4. **new** — no command in the group may pass `--profile`/`--release`, and each must be a `cargo test`. Every named profile in this repo inherits `release`, so such a flag would leave two commands in the list, still run 4000-odd tests, still take minutes, and compile every `debug_assert!` back down to nothing. That is a neutered gate the command list cannot see, only its flags can;
5. **new** — every command in the group must **arm the canary** (`env FERX_REQUIRE_DEBUG_ASSERTIONS=1` leading the argv). This is the positive half that (4) cannot supply: (4) only rules out the ways of disabling the guards that are *visible in the command string*, and the two most likely ones are not.

Per the "a green test is not evidence that it can fail" rule, each assertion was **mutation-checked**, and all four mutations turn the guard red:

| mutation | test that failed |
|---|---|
| delete `run: tools/preflight.sh debug-assertions` from `ci.yml` | `the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo` **and** `the_default_run_is_every_group_that_is_not_opt_in_and_ci_runs_the_rest` |
| drop the `ci,markov,nn` line from the group | `preflight_is_executable_and_lists_every_group` (count tripwire) |
| add `--profile ci-test` to a group command | `load_bearing_flags_and_feature_coverage_survive_in_the_command_list` |
| fail either command position behind a fake `cargo` | `a_failing_gate_fails_the_script_from_every_position` |
| `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false`, armed | `debug_assertion_canary` — and it passes **unarmed** under the same setting, which is what keeps the three release-profile jobs green |
| drop the `env` arming from a group command | `load_bearing_flags_and_feature_coverage_survive_in_the_command_list` |
| replace the `run:` line with a comment naming the same command | the opt-in check — and the **previous** `yml.contains` version passed it, which is how finding 3 was confirmed rather than assumed |

The opt-in check (3) reads the workflow's parsed `run:` steps, not its raw text. An earlier revision used `yml.contains`, which a YAML *comment* naming the command would satisfy while nothing executed the group — and this workflow is full of comments that name exactly these commands, so the check was one edit away from being self-satisfying. Demonstrated, not assumed: with the `run:` line replaced by a comment carrying the same string, the `contains` version passes and the parsed version fails.

One further trap worth naming: the count tripwire and the `--help` coverage test both used to enumerate groups from a bare `--list`. Since a no-argument run now walks only the default set, that would have walked straight past the new group and left it gated by nothing — the exact silent-shrinkage hole those tests exist to close. Both now read `ALL_GROUPS` from the script.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [ ] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [x] No user-visible change

`docs/development/sdlc.qmd` §8.2: the new job is added to the `ci.yml` row, with a short "Why a separate `Tests (debug-assertions)` job" note, the local command, how the canary is armed, and an explicit statement of what this does **not** fix (the Codecov ceiling, #1248); §8.6's "the three coverage jobs override `RUSTUP_TOOLCHAIN` to stable" now also names this job. No new page, so no `_quarto.yml` entry. No `CHANGELOG.md` entry — CI-only, per `CLAUDE.md`. `cargo run -p docs-lint -- --check` is green.

## Checklist
- [x] `tools/preflight.sh` green — `preflight OK — fmt check clippy rustdoc docs public-api`, plus `tools/preflight.sh debug-assertions` green (4035 and 4366 tests)
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable — none touched
- [ ] `Cargo.toml` version bumped if breaking — not breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

None apply — no DSL, example or data change.

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

None apply.

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI
- [ ] All affected ferx-site example `.qmd` pages render cleanly
- [ ] All affected ferx-book chapters render cleanly
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

Focus on two judgment calls:

1. **The dev profile rather than a `ci-test`-with-assertions profile.** The trade is unoptimised tests (80s + 198s, measured) against a second optimised lib build. In a repo where 93% of the build is LLVM, the tests are the cheap side — and the dev profile throws in `overflow-checks`. If you would rather pay the compile for faster tests, that is the line to push back on.
2. **Making it opt-in locally.** This is the first group a no-argument `tools/preflight.sh` skips, which is a real (small) weakening of "one command reproduces CI". The mitigation is invariant (3): an opt-in group that no `ci.yml` job names is a test failure, so it cannot become a gate that runs nowhere. `--help` and `--list <group>` both document it.
3. **`refs #344` rather than `closes #344`.** The Codecov half of that issue is untouched here and is now #1248. If you would rather #344 be closed by this PR and the coverage work tracked purely as new scope, say so and I will flip the keyword — but the two halves are separable and the second one is not fixed.

The rest is mechanical: the guard test now reads the group list from the script instead of hard-coding it, so much of its diff is that substitution.

Skimmable: the comment blocks. They restate the rationale above.

## Open questions

- The job runs `--lib` only. Integration tests in `tests/` also reach `debug_assert!`s in `src/`, but adding `--tests` means compiling ~120 more binaries under a second profile. Worth it later if a guard is ever found that only a Tier-2 path trips?
- `slow-tests.yml` is still entirely release-profile, so Tier-3 fits never evaluate a guard either. Deliberately out of scope here (a nightly dev-profile convergence run would be very slow), but it is a remaining corner of the same blind spot.
- The canary proves `debug_assert!` is live. It does **not** prove `overflow-checks` is, which this PR also claims as a benefit of the dev profile — `cfg!(overflow_checks)` is still unstable (rust-lang/rust#111466, verified against this toolchain), and the runtime alternative is a `catch_unwind` around a deliberate overflow, which means swapping the global panic hook while other tests run concurrently. Judged not worth the hazard for a secondary claim; happy to add it if you disagree.

Refs #344 — **deliberately non-closing.** The issue's 2026-08-31 comment documents a second failure mode this PR does not touch: `debug_assert!` condition lines are permanently zero-hit regions in every Codecov job, because all of them use release-derived profiles, so the patch-coverage ceiling is unchanged by a job that uploads no coverage. Filed as #1248 with the measurements and the options. Closing #344 here would have buried a defect that remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRvJ1r8YxQ18UfcxrdKGhT
