### PR TITLE
docs: five measured testing rules that CLAUDE.md did not yet carry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,46 @@ that no fixture could see.
 When an anchor does fail, vary **one input at a time** — the pair that differs by a
 single number is what localises the defect (`nonmem_anchor/tvcov_lag_saltation*`).
 
+**The oracle has to be more accurate than the difference you are about to call a defect.**
+An oracle outside that regime measures itself, not the thing under test — and an ODE twin at
+default tolerances is not automatically an oracle. `verify_against_ode_twin`
+(`pk/modified_release.rs`) compared the MR closed form against `ode_predictions` at
+`verify_tol = (500·reltol).max(1e-4)`, derived from `reltol` alone; but Dormand–Prince
+controls local error as `abstol + reltol·|y|`, so the twin's own
+relative accuracy is `abstol/|y| + reltol` and a state decayed to the order of `abstol` has no
+significant digits left. Measured on #1124/#1130: `central` fell to 1.3e-6 against that spec's
+`abstol = 1e-6`, the twin said 29.484, the closed form said 24.574829 — and the exact Bateman
+superposition is 24.574829, so the *twin* was 20% high and the check aborted a correct fit in
+debug. Gate the comparison on the condition for the oracle to outrank the disagreement, and
+when you cannot tell an oracle artifact from a real defect, **compute the quantity a third
+way, outside both engines** — a 30-line Bateman sum in Python settled that one after two
+wrong hypotheses reasoned from the code. Swapping oracles is changing the experiment, too:
+moving that twin to `ode_predictions_with_states` silently adopted a *wrong* reference, because
+at the time it dropped a lagged `zero_order` input rate that `ode_predictions` applied — a real
+public-API defect the swap surfaced, since fixed (#1171).
+
+**Measure the tolerance; never justify it with a story.** Run the comparison, print the worst
+realised error, put that number in the comment, and pick the bound from it with stated
+headroom. On PR #1174 a NONMEM POSTHOC sdtab anchor was set at `3e-2` with the explanation
+that the two inner optimizers "stop at slightly different η̂"; the realised error was
+**4.736e-5** — 630× tighter — and ferx's η̂ matches NONMEM's `.phi` to ~6 significant figures,
+so the stated mechanism was not conservative but wrong. A bound that loose is not safe, it is
+a test that has quietly stopped testing: at `3e-2` a regression delivering 99% of the absorbed
+mass passes green, and that was the only end-to-end `fit()` → sdtab check against an external
+reference. If the realised error surprises you, chase it — that is information.
+
+**When the bug report is "two implementations disagree", the fix is one implementation.**
+#1223's first fix re-wrote the dense engine's pre-start fill inline in the #570 shared solve
+~3600 lines away, with its own `- 1e-12` and its own `break_times.first()` guard, under a
+comment calling it "the exact twin of" — restoring by prose exactly the configuration that
+produced the defect. Extracting `fill_prestart_states` and calling it from both sites closed
+the drift class in the compiler instead, and the payoff is a test property: **one mutation of
+the helper now reddens both engines**, where the dedicated-engine control previously needed a
+separate dense-side mutation to fail. Before writing a second copy, check whether the callers
+can share a function; if they genuinely cannot, record the specific asymmetry at the call site
+(here: the share's `chz_times` is sorted-unique by contract but `ode_dense_solve_states` is
+`pub` with no such guarantee, so the helper keeps a full scan rather than a `take_while`).
+
 **A green test is not evidence that it can fail.** The rule above is about a fixture that
 cannot expose the defect; these are three ways the *assertion* cannot observe it, all three
 found on #1166 in tests that had been written, run green and believed:
@@ -297,12 +337,43 @@ found on #1166 in tests that had been written, run green and believed:
   `is_finite()` before folding. That anchor's one *direct* `(total - want).abs() < tol` was
   already safe, since any comparison against `NaN` is `false`; only the fold hides it.
   `filter_map(…ok())` and `unwrap_or(0.0)` absorb failures the same way.
+- **Two redundant gates cover for each other.** A #1229 check filtered on the coordinate's
+  *kind* inside the loop and on a second, derived per-coordinate table right after — both
+  correct, both excluding exactly the same inputs. Deleting either left the whole suite green,
+  so the test pinning that the check excludes Σ could not fail. When a
+  predicate has two conditions that reject the same inputs that is a test hole, not
+  belt-and-braces: collapse to one gate and re-run the mutation. Reading the code missed this
+  twice; only mutation found it.
+- **`is_finite()` cannot see a sentinel.** It is the right assertion for a *diverged* solve
+  (`NaN`/`inf`) and the wrong one for a subject that was **repelled**: `tte_nll_from_curves`
+  maps a `NaN` `H` to `1e20`, a perfectly finite `f64`, and #1223 measured an objective of
+  `2e20` coming back green under the mutation the test existed to catch. A test whose failure
+  mode is "the subject got repelled" must bound the magnitude instead — grep the sentinel's
+  actual value (`1e20` in `crate::survival`) and state both distances in the comment, to the
+  sentinel and to the real objective, so the bound is measured rather than picked.
 
 For each new assertion, name the regression it exists to catch and check that regression can
 actually reach it. For a regression test that means mutation; for an anchor, feeding it the
-failure it exists to catch.
+failure it exists to catch. Two things that "I mutation-tested it" does **not** cover:
 
-**Every change to an analytic sensitivity, gradient, marginal, or likelihood path requires a `Dual2`-vs-FD parity test.** The closed-form PK solutions and event-driven propagators are written once as generic `*_g<T: PkNum>` functions; instantiating `T = Dual2<M>` yields the exact `∂f/∂η` / `∂f/∂θ` that FOCE/FOCEI/HMC consume (`sens/`). A wrong sensitivity compiles and runs silently — there is no second copy of the formula to disagree with it — so when you add or modify one of these kernels, or the provider that assembles them, assert it against central finite differences of the `T = f64` production predictor, to tolerance, in a Tier-1 unit test. That parity pins the *derivative* against the value path, not the value path itself — when both share a wrong convention it passes against the exact derivative of the wrong function, which is how #1079 survived. It is an oracle for the gradient only; see the non-degeneracy rule above for what it cannot see. Follow the existing pattern: per-kernel `*_g_dual_matches_fd` checks (`sens/propagate.rs`, `sens/dual2.rs`) and the end-to-end `check_full_provider_vs_fd` harness (`sens/provider_tests.rs`). If a model is outside the analytic scope it must route to FD via the support predicates (`sens_supported` / `analytic_inner_grad_supported_model`); unit-test that routing so a scope gap fails loudly to FD instead of silently returning a wrong gradient. (This is the post-Enzyme successor to the retired `AD↔FD` parity rule — see #285 / #281.)
+- **Mutating your own fix is not enough — ask what the *smallest* edit that removes it is, and
+  which test dies.** On #1171 / PR #1174 sixteen tests across three tiers each died correctly
+  when the fix was toggled off, and the suite was called verified. A reviewer's *different*
+  minimal edit — drop both `push_route_lag_break_times` calls and have
+  `push_zero_order_break_times` emit `[w_start, w_end]` — passed the entire suite at identical
+  margins, because every fixture used `zero_order`, the one kind where the route onset
+  coincides exactly with the window start. The tests pinned a strictly weaker property than
+  the fix. If the honest answer to "which test dies" is "none", the fixture set is degenerate
+  however green it is.
+- **Mutate each side of a twin separately.** On #1223 deleting the *share* fill reddened the
+  parity test as designed, and deleting the *dense* fill left it green — the fixture never
+  reached the dense fill, because each engine folds its own horizon into `break_times` and the
+  dense builder's `saveat` was the `chz_times` themselves. A twin whose second leg is computed
+  by an unexercised path is an assertion against a constant. Require each mutation to name its
+  own side in the failure message; if one side stays green, find the fast path supplying the
+  answer and change the fixture until it does not.
+
+**Every change to an analytic sensitivity, gradient, marginal, or likelihood path requires a `Dual2`-vs-FD parity test.** The closed-form PK solutions and event-driven propagators are written once as generic `*_g<T: PkNum>` functions; instantiating `T = Dual2<M>` yields the exact `∂f/∂η` / `∂f/∂θ` that FOCE/FOCEI/HMC consume (`sens/`). A wrong sensitivity compiles and runs silently — there is no second copy of the formula to disagree with it — so when you add or modify one of these kernels, or the provider that assembles them, assert it against central finite differences of the `T = f64` production predictor, to tolerance, in a Tier-1 unit test. That parity pins the *derivative* against the value path, not the value path itself — when both share a wrong convention it passes against the exact derivative of the wrong function, which is how #1079 survived. It is an oracle for the gradient only; see the non-degeneracy rule above for what it cannot see. Follow the existing pattern: per-kernel `*_g_dual_matches_fd` checks (`sens/propagate.rs`, `sens/dual2.rs`) and the end-to-end `check_full_provider_vs_fd` harness (`sens/provider_tests.rs`). If a model is outside the analytic scope it must route to FD via the support predicates (`sens_supported` / `analytic_inner_grad_supported_model`); unit-test that routing so a scope gap fails loudly to FD instead of silently returning a wrong gradient. (This is the post-Enzyme successor to the retired `AD↔FD` parity rule — see #285 / #281.) **Before believing such a fix is complete, ask which engine each fixture actually ran on**: a fixture that routes to FD cannot observe the dual path at all, so a green anchor on it says nothing about the gradient side. Read the `FitResult` FD-fallback warning — on #1210 all seven `nonmem_anchor/ss_chz_*` arms reported "1 of 1 subjects use finite-difference inner gradients", so a green `--lib` suite and green CI never touched `sens/ode_provider.rs`'s dual SS equilibration, and only a Tier-3 convergence fit on a 300-subject joint PK-TTE population reached it. If every fixture says FD, the dual twin is untested.
 
 **Coverage is gated per PR.** A PR's changed lines must carry their own tests — the Codecov `patch` status enforces ≥90% coverage on the diff, and a 90% project floor is enforced on the weekly `main` run (see `codecov.yml`). This is the automated backstop to the rules above; slow-tests never run on PRs, so unit / Tier-2 tests are what register coverage. When excluding code from coverage, **scope `ignore`s by role, not by coverage %**: leave code out for *what it is* — dev-only tooling (e.g. `src/bin/generate_data.rs`), generated code (`build.rs`), or test scaffolding (`tests/`) — never because it reads red. (Feature-gated code that the coverage build doesn't compile reads as "missed" but is a measurement gap, not an ignore target — see #293.)
 


### PR DESCRIPTION
## Why

Seven testing rules were living in my per-session memory instead of in the repo. Each one cost a real defect or a suite that was green and false, and each was found by probing rather than by reading — but as private notes they bind one contributor's sessions rather than everyone working here. CLAUDE.md already carries the closest neighbours (the non-degenerate-oracle rule and the three "a green test is not evidence that it can fail" shapes, #1211), so these belong beside them.

Two of the seven turned out to be **already covered** by CLAUDE.md and are not in this PR. The five below are the genuine gap.

## What changed

`CLAUDE.md` only — no Rust, no `docs/`.

**Two new bullets on the existing "a green test is not evidence that it can fail" list:**

| | |
|---|---|
| Two redundant gates cover for each other | #1229 filtered on `coordinate_kinds(i) == OmegaDiagonal` *and* on `decls[i] == None → continue`. Both correct, both rejecting the same inputs — deleting either left all 15 tests green, so the Σ scope pin could not fail. Reading the code missed it twice. |
| `is_finite()` cannot see a sentinel | `tte_nll_from_curves` maps a `NaN` `H` to `1e20`. On #1223 the objective came back `2e20` — finite — under the exact mutation the assertion existed to catch. Bound the magnitude instead, and state both distances (to the sentinel, to the real objective). |

**Two limits on "I mutation-tested it", appended to the paragraph that asks for mutation:**

- **Mutating your own fix is not enough.** On #1171 / PR #1174, 16 tests across three tiers each died correctly when the fix was toggled — and a reviewer's *different* minimal edit passed the whole suite at identical margins, because every fixture used `zero_order`, the one kind where route onset coincides exactly with the window start. Ask what the smallest edit that removes the fix is, and which test dies.
- **Mutate each side of a twin separately.** On #1223 deleting the share fill reddened the parity test; deleting the dense fill left it green, because the fixture never reached the dense fill. A twin whose second leg runs on an unexercised path is an assertion against a constant.

**Three rules next to the non-degenerate-oracle rule they complement:**

- **The oracle must outrank the disagreement.** `verify_mr_twin` derived its tolerance from `reltol` alone, but Dormand–Prince controls `abstol + reltol·|y|`, so a state decayed to the order of `abstol` has no significant digits left. Measured on #1124/#1130: the twin said 29.484, the closed form 24.574829, and the exact Bateman superposition is **24.574829** — the twin was 20% high and the check aborted a correct fit in debug. Includes the corollary that swapping oracles is changing the experiment (`ode_predictions_with_states` drops a lagged `zero_order` rate — #1171).
- **Measure the tolerance, never justify it with a story.** PR #1174 set a NONMEM POSTHOC sdtab anchor at `3e-2` on the reasoning that the inner optimizers "stop at slightly different η̂". Realised error: **4.736e-5**, 630× tighter, and η̂ matches NONMEM's `.phi` to ~6 significant figures — the stated mechanism was wrong, not conservative. At `3e-2` a regression delivering 99% of the absorbed mass passes green, and that was the only end-to-end `fit()` → sdtab check against an external reference.
- **When the bug is "two implementations disagree", the fix is one implementation.** #1223's first fix re-wrote the dense engine's pre-start fill inline in the #570 shared solve ~3600 lines away, under a comment calling it "the exact twin of" — restoring by prose the configuration that produced the defect. Extracting `fill_prestart_states` means one mutation of the helper now reddens both engines.

**One sentence on the `Dual2`-vs-FD parity rule:** ask which engine each fixture actually ran on. On #1210 all seven `nonmem_anchor/ss_chz_*` arms reported "1 of 1 subjects use finite-difference inner gradients", so a green `--lib` suite and green CI never touched `sens/ode_provider.rs`'s dual SS equilibration.

## Alternatives considered

**Leave them in per-session memory.** That is the status quo and the reason for this PR: private notes do not reach Ron or Hidde, and they go stale silently because nothing loads them next to the code they describe.

**Add all seven.** Two were already in CLAUDE.md and are deliberately excluded — the three "cannot fail" shapes (#1211 put them there) and the non-degenerate-anchor rule. I found this by grepping for the wrong string first (`"cannot fail"` where the doc says `"can fail"`) and had to re-derive the delta against the actual text.

**A separate `docs/development/testing-rules.qmd` page.** Rejected: these are instructions to whoever is editing the code, and CLAUDE.md is what gets loaded at that moment. A Quarto page would also pull `docs-lint` into scope for prose that is deliberately long-form.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: CLAUDE.md is not compiled or linted — `docs-lint` scopes to `docs/**/*.qmd`, and no Rust source changed)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] No user-visible change

`CHANGELOG.md` deliberately untouched: contributor instructions are not a user-facing change.

## Checklist
- [x] `tools/preflight.sh` green — ran the `fmt` group; the `check`/`clippy`/`rustdoc`/`docs`/`public-API` groups are unaffected because no Rust and no `docs/**/*.qmd` changed
- [x] Functions on the `Dual2` sensitivity path stay differentiable — N/A, no code touched
- [x] `Cargo.toml` version bumped if breaking — N/A

## Docs & examples

### ferx-site / ferx-book
- [x] No new DSL syntax, `[fit_options]` key, example, data file, estimator or fit option — nothing to mirror

### Example execution
- [x] No example execution step needed (docs-only, no user-visible change)

## Reviewer hints

The substance is five rules, each anchored to a measured number from a specific issue — the numbers are the point, so check those rather than the prose. The two you can skim are the new bullets on the existing "can fail" list; they follow that list's established shape exactly.

Worth a real look: whether the oracle-precision rule and the measured-tolerance rule belong as separate paragraphs or read as one idea. They came from the same PR (#1174 / #1124) and both say "a number you did not measure is not evidence", but they fire at different moments — one when choosing what to compare against, one when choosing the bound.

CLAUDE.md grows by 72 lines here, which is not free: it loads into every session on this repo. I think each of these earns it, but that is the trade to push back on if you disagree — the weakest of the five is probably "one implementation, not two", which is a design rule wearing a testing rule's clothes.

## Open questions

Nothing blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
