### PR TITLE
docs: fold the one-implementation rule into a cross-reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,17 +302,13 @@ a test that has quietly stopped testing: at `3e-2` a regression delivering 99% o
 mass passes green, and that was the only end-to-end `fit()` → sdtab check against an external
 reference. If the realised error surprises you, chase it — that is information.
 
-**When the bug report is "two implementations disagree", the fix is one implementation.**
-#1223's first fix re-wrote the dense engine's pre-start fill inline in the #570 shared solve
-~3600 lines away, with its own `- 1e-12` and its own `break_times.first()` guard, under a
-comment calling it "the exact twin of" — restoring by prose exactly the configuration that
-produced the defect. Extracting `fill_prestart_states` and calling it from both sites closed
-the drift class in the compiler instead, and the payoff is a test property: **one mutation of
-the helper now reddens both engines**, where the dedicated-engine control previously needed a
-separate dense-side mutation to fail. Before writing a second copy, check whether the callers
-can share a function; if they genuinely cannot, record the specific asymmetry at the call site
-(here: the share's `chz_times` is sorted-unique by contract but `ode_dense_solve_states` is
-`pub` with no such guarantee, so the helper keeps a full scan rather than a `take_while`).
+**When the bug report is "two implementations disagree", the fix is one implementation.** This
+is the `*_g<T: PkNum>` rule in *Analytic Sensitivities* below, generalised past `sens/` to any
+two engines, and it buys a *test* property: after #1223 extracted `fill_prestart_states`, one
+mutation of the helper reddens both the dense and the shared solve, where the dedicated-engine
+control had needed its own. A comment calling a second copy "the exact twin of" restores by
+prose exactly the configuration that produced the defect. If two callers genuinely cannot
+share, record the asymmetry at the call site.
 
 **A green test is not evidence that it can fail.** The rule above is about a fixture that
 cannot expose the defect; these are three ways the *assertion* cannot observe it, all three


### PR DESCRIPTION
## Why

Follow-up to #1249. I flagged one of the five rules it added — "when the bug report is *two implementations disagree*, the fix is one implementation" — as the weakest of the set, and said so on the PR before merging. Asked to settle it, I checked instead of arguing from taste, and the answer was sharper than my original hunch.

CLAUDE.md **already states that principle twice**, both scoped to `sens/`:

- line 305 (the `Dual2`-vs-FD parity rule) — "A wrong sensitivity compiles and runs silently — *there is no second copy of the formula to disagree with it*"
- *Analytic Sensitivities* — "written **once** as generic `*_g<T: PkNum>` functions … *There is no second copy of any formula to keep in sync — edit the generic version.*"

So the paragraph #1249 added was the file's **third** pass over the same idea. My earlier framing — "a design rule wearing a testing rule's clothes" — was vague and, I think, wrong: it is a fine testing rule. The real defect is that it re-argues a principle the file has already established twice, rather than pointing at it.

CLAUDE.md loads into every session on this repo, so a restatement that adds no instruction is a recurring cost.

## What changed

`CLAUDE.md` only — 11 lines to 6, no rule removed.

Kept the two things that were genuinely new and not derivable from the existing statements:

1. **the rule generalises past `sens/`** to any two engines — the existing statements are both about the `*_g<T: PkNum>` kernels
2. **the test property extraction buys** — after #1223 extracted `fill_prestart_states`, one mutation of the helper reddens *both* the dense and the shared solve, where the dedicated-engine control had previously needed its own separate mutation

Cross-referenced the rest, and kept the two-sentence warning that carries the actual teeth (a comment calling a second copy "the exact twin of" restores by prose exactly the configuration that produced the defect; record the asymmetry at the call site when two callers genuinely cannot share).

Dropped, as restatement or as detail that belongs in the code rather than in the instructions: the `~3600 lines away` distance, the `- 1e-12` and `break_times.first()` specifics, and the `chz_times` sorted-unique-vs-`pub` asymmetry — that last one is recorded at the call site in `ode/predictions.rs`, which is exactly where the rule tells you to put it.

## Alternatives considered

**Cut the rule entirely.** That was my first instinct and I now think it is wrong — the generalisation past `sens/` and the mutation payoff are real, and neither is reachable from the two existing statements.

**Leave it as merged.** Defensible; nothing is incorrect. But the cost is paid on every session and the fix is six lines.

**Merge it into the Analytic Sensitivities statement instead.** Rejected: that section is about the `sens/` kernels specifically, and burying a general testing rule ~190 lines below the testing section is where it would stop being read.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: CLAUDE.md is not compiled or linted — `docs-lint` scopes to `docs/**/*.qmd`, and no Rust source changed)

## Example (user-facing features only)
- [x] Not applicable

## Docs
- [x] No user-visible change

`CHANGELOG.md` untouched: contributor instructions are not user-facing.

## Checklist
- [x] `tools/preflight.sh` green — `fmt` group run; the other groups are unaffected (no Rust, no `docs/**/*.qmd`)
- [x] `Dual2` path — N/A, no code touched
- [x] `Cargo.toml` version bump — N/A

## Docs & examples
- [x] No new DSL syntax, fit option, example, data file or estimator — nothing to mirror to ferx-site / ferx-book
- [x] No example execution step needed

## Reviewer hints

The claim to check is the premise, not the prose: that CLAUDE.md already says this twice. `grep -n "no second copy" CLAUDE.md` returns both. If you read those two and disagree that they cover the principle, this PR should be closed rather than merged — the trim only makes sense if the cross-reference is honest.

All three identifiers in the new text (`fill_prestart_states`, `ode_dense_solve_states`, `PkNum`) verified to resolve in `src/`.

## Open questions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
