### PR TITLE
fix(ode): carry the model-time anchors into the EKF walk [closes #1131, closes #1259]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,29 @@ section of the SDLC for the versioning policy).
   The covariance step's non-finite-objective diagnostic asked for the eigenvalues of the
   0×0 OMEGA such a model has, which `nalgebra` rejects. It now reports the non-finite objective
   as the failure reason, which is what the diagnostic exists to say.
+- **An infusion under `F ≠ 1` no longer delivers zero drug on an SDE (`[diffusion]`) model
+  (#1263).** Bioavailability reshapes a `RATE`-defined infusion's *duration*, not its rate, and
+  the EKF path placed the window's segment boundary at the unscaled end. The infusion window
+  then failed its own membership test in every segment, so the dose delivered no mass at all and
+  every prediction read zero. The boundary is now `F`-scaled, matching the ODE path and NONMEM
+  (anchored against `nonmem_anchor/oral_central_inf_advan2_f06`).
+- **An SDE model whose records start after `t = 0` no longer inflates its observation variance
+  (#1263).** The EKF began integrating at a hard-coded `t = 0` rather than at the subject's first
+  record, so the covariance accumulated process noise across a segment that does not exist —
+  for a first dose at `t = 24`, thirteen times the correct value at the first observation. An
+  `init(state) = …` starting amount was decayed across the same phantom segment.
+- **Two observation records at the same time no longer read as zero on an SDE model (#1263).**
+  Inside a dose segment the EKF kept one record per observation time, so a second record at that
+  instant kept its initialised `0.0` prediction and variance and fed a plausible zero into the
+  likelihood. All records at one instant now share a single filter update, as they already did
+  at a dose boundary.
+- **Dosing features the EKF/SDE path does not implement now warn instead of returning a
+  plausible wrong answer (#1263, #1260).** An `SS=1` record is applied as a single dose rather
+  than equilibrated (`W_SDE_STEADY_STATE`), and an absorption `lagtime` / `ALAGn` is ignored
+  (`W_SDE_LAGTIME`) — joining the existing `W_SDE_RESET`. Neither gap is visible in `IPRED`, and
+  the steady-state one is large: a 1-cpt model with one `SS=1, II=12` record predicts `90.48`
+  where the equivalent explicit dose train predicts `200.27`. Expand the steady state into
+  explicit records, or fit without `[diffusion]`.
 
 ## [0.3.1] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -430,6 +430,20 @@ section of the SDLC for the versioning policy).
   `minimization_successful` fraction. Re-running a bootstrap of an unchanged model can therefore
   report slightly different CIs than before; `--summarize` over a stored `raw_results.csv`
   re-applies the criteria without refitting.
+- **An `[odes]` right-hand side that reads `TAD` / `TAFD` no longer destroys the objective on an
+  SDE (`[diffusion]`) model (#1131).** The extended-Kalman-filter path handed the compiled RHS a
+  bare PK parameter array, two slots shorter than the one the ODE predictors build, so both
+  model-time anchors read as missing and the RHS injected `NaN`. The state was then clamped back
+  to a plausible-looking number while the observation variance kept the `NaN`, so `ipred` looked
+  right and the fit silently reported the diverged-subject sentinel (`OFV` ≈ `2e20`) instead of a
+  real objective. The EKF now carries the same extended array and re-anchors `TAD` per dose
+  segment by the same rule as the two ODE predictors, so an SDE fit of a time-varying RHS agrees
+  with its zero-diffusion ODE twin. A model whose RHS reads neither builtin is bit-identical to
+  before.
+- **A model with no random effects no longer panics when its objective is non-finite (#1259).**
+  The covariance step's non-finite-objective diagnostic asked for the eigenvalues of the
+  0×0 OMEGA such a model has, which `nalgebra` rejects. It now reports the non-finite objective
+  as the failure reason, which is what the diagnostic exists to say.
 
 ## [0.3.1] - 2026-09-02
 

--- a/docs/model-file/diffusion.qmd
+++ b/docs/model-file/diffusion.qmd
@@ -140,6 +140,33 @@ the ODE alone explains the data; a large value suggests model misspecification.
 | State name not in `states = [...]` | Parse-time error |
 | Negative initial value | Parse-time error |
 
+## Model-time builtins in the RHS
+
+An `[odes]` right-hand side under `[diffusion]` may read the solver-injected builtins
+`TIME` / `T`, `TAFD` and `TAD`, with the same meaning as on the ordinary ODE path — see
+[TAD before the first dose arrives](ode-models.qmd#tad-before-the-first-dose-arrives) for
+what `TAD` reads in the window before an arrival, and for the dose-free case.
+
+```
+[odes]
+  d/dt(central) = -(CL/V) * central * (1.0 + KTAD * TAD)
+[diffusion]
+  central ~ 0.01
+```
+
+`TAD` is re-anchored at each dose segment by the same rule the two ODE predictors use, so
+an SDE fit of a time-varying right-hand side reduces to its ODE twin as the diffusion
+variance goes to zero. Measured on the model above (`CL = 1`, `V = 20`, `KTAD = 0.3`, doses
+at 0 and 12): `OFV = 14.7016` from the EKF at `central ~ 1e-14` and `14.7016` from the same
+model with the `[diffusion]` block removed.
+
+`TIME` / `T` is the integration variable itself and has always been readable here. `TAFD`
+and `TAD` are passed in two extra parameter slots, and until #1131 the EKF was handed an
+array two slots short, so both evaluated to `NaN` for the whole trajectory. That failure was
+easy to miss: `IPRED` is computed on the ordinary ODE path and stayed correct, while the
+objective — which is what the filter actually contributes — became the diverged-subject
+sentinel. A right-hand side reading neither builtin was never affected.
+
 ## ferx-r usage note
 
 When using ferx-core from R via the ferx-r package, the `[diffusion]` block is part

--- a/docs/model-file/diffusion.qmd
+++ b/docs/model-file/diffusion.qmd
@@ -171,6 +171,12 @@ equivalence:
 | `lagtime` / `ALAGn` | `W_SDE_LAGTIME` | every dose is applied at its record time |
 | `SS=1` steady-state dose | `W_SDE_STEADY_STATE` | the record is applied as a single dose, not equilibrated |
 
+These are **fitting** gaps, not prediction gaps. The filter runs only inside the objective, so
+`predict()` and `simulate()` on the same model go through the ordinary ODE path, which does
+equilibrate a steady-state dose and does apply a lag time. A model can therefore show a correct
+`IPRED` and a wrong objective at the same time — which is why the warnings are raised by `fit()`
+and `ferx check` rather than at prediction time.
+
 The steady-state gap is the one most likely to be mistaken for a converged answer: on a
 1-cpt model with `CL = 1`, `V = 20`, one `SS=1, II=12` record and an autonomous right-hand
 side, the EKF returns `90.48` where an explicit eleven-dose train returns `200.27`. The

--- a/docs/model-file/diffusion.qmd
+++ b/docs/model-file/diffusion.qmd
@@ -160,6 +160,25 @@ variance goes to zero. Measured on the model above (`CL = 1`, `V = 20`, `KTAD = 
 at 0 and 12): `OFV = 14.7016` from the EKF at `central ~ 1e-14` and `14.7016` from the same
 model with the `[diffusion]` block removed.
 
+That reduction holds for the dataset above. It is **not** unconditional, because the
+EKF/SDE path does not implement every dosing feature the ODE path does. Each gap below
+raises a warning rather than failing, so check the fit's warnings before relying on the
+equivalence:
+
+| Dataset feature | Code | What the SDE path does instead |
+|---|---|---|
+| `EVID=3`/`4` system reset | `W_SDE_RESET` | the reset is ignored; compartment amounts carry through |
+| `lagtime` / `ALAGn` | `W_SDE_LAGTIME` | every dose is applied at its record time |
+| `SS=1` steady-state dose | `W_SDE_STEADY_STATE` | the record is applied as a single dose, not equilibrated |
+
+The steady-state gap is the one most likely to be mistaken for a converged answer: on a
+1-cpt model with `CL = 1`, `V = 20`, one `SS=1, II=12` record and an autonomous right-hand
+side, the EKF returns `90.48` where an explicit eleven-dose train returns `200.27`. The
+`TAD` anchor is folded into `[0, II)` for that record as though the train existed, so a
+right-hand side reading `TAD` diverges further still — `45.60` against `36.74` at `t = 150`
+for an `SS=1` infusion whose end lands inside a dosing interval. Expand the steady state
+into explicit dose records, or fit the model without `[diffusion]`.
+
 `TIME` / `T` is the integration variable itself and has always been readable here. `TAFD`
 and `TAD` are passed in two extra parameter slots, and until #1131 the EKF was handed an
 array two slots short, so both evaluated to `NaN` for the whole trajectory. That failure was

--- a/src/api/tests/sde_integration.rs
+++ b/src/api/tests/sde_integration.rs
@@ -297,3 +297,168 @@ fn sde_emits_experimental_warning() {
         "non-SDE model should not emit W_EXPERIMENTAL_SDE"
     );
 }
+
+/// #1263: dosing features the EKF/SDE path silently drops must **warn**, mirroring the
+/// `W_SDE_RESET` precedent, rather than return a plausible wrong number.
+///
+/// `solve_ekf` applies an `SS=1` record as a single bolus with no equilibration, and
+/// never calls `DoseAttrMap::lagtime` at all. Neither gap fails, neither is visible in
+/// `IPRED` (the likelihood takes only `p_obs` from the filter), and both are large:
+/// measured on a 1-cpt autonomous model, one `SS=1, II=12` record gives `90.48` against
+/// `200.27` for the equivalent explicit train.
+///
+/// Each case is asserted against its **own** control — the same population without the
+/// feature — so a warning that fired unconditionally would fail here too.
+mod sde_unsupported_dosing_warnings {
+    use super::*;
+
+    /// The shared SDE model with a `lagtime` bound, so `model.has_lagtime()` is true.
+    const SDE_LAG_MODEL_SRC: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  theta TVLAG(0.5, 0.01, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma ADD ~ 1.0 FIX
+
+[individual_parameters]
+  CL      = TVCL * exp(ETA_CL)
+  V       = TVV
+  lagtime = TVLAG
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL/V) * central
+
+[diffusion]
+  central ~ 0.5
+
+[error_model]
+  DV ~ additive(ADD)
+
+[fit_options]
+  method = foce
+"#;
+
+    /// The same, without `[diffusion]` — the non-SDE control for the lag warning.
+    const ODE_LAG_MODEL_SRC: &str = r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 50.0)
+  theta TVV(50.0, 1.0, 500.0)
+  theta TVLAG(0.5, 0.01, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma ADD ~ 1.0 FIX
+
+[individual_parameters]
+  CL      = TVCL * exp(ETA_CL)
+  V       = TVV
+  lagtime = TVLAG
+
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+
+[odes]
+  d/dt(central) = -(CL/V) * central
+
+[error_model]
+  DV ~ additive(ADD)
+
+[fit_options]
+  method = foce
+"#;
+
+    fn codes(src: &str, pop: &Population) -> Vec<String> {
+        let parsed = parse_full_model(src).expect("model parses");
+        let m = &parsed.model;
+        super::super::check_model_data_warnings(m, pop, &m.default_params)
+            .iter()
+            .map(|d| d.code.clone())
+            .collect()
+    }
+
+    /// `make_sde_population` with every subject's dose flipped to `SS=1, II=12`.
+    fn ss_population() -> Population {
+        let mut pop = make_sde_population();
+        for s in &mut pop.subjects {
+            s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, true, 12.0)];
+        }
+        pop
+    }
+
+    #[test]
+    fn a_lagtime_under_diffusion_warns() {
+        let pop = make_sde_population();
+        assert!(
+            codes(SDE_LAG_MODEL_SRC, &pop).contains(&"W_SDE_LAGTIME".to_string()),
+            "a [diffusion] model declaring lagtime must raise W_SDE_LAGTIME"
+        );
+        // Control 1 — the same lagtime with no [diffusion] block. Isolates the SDE half
+        // of the predicate: without this the warning could be keyed on lagtime alone.
+        assert!(
+            !codes(ODE_LAG_MODEL_SRC, &pop).contains(&"W_SDE_LAGTIME".to_string()),
+            "an ODE model with a lagtime must NOT raise W_SDE_LAGTIME"
+        );
+        // Control 2 — [diffusion] with no lagtime. Isolates the other half.
+        assert!(
+            !codes(SDE_MODEL_SRC, &pop).contains(&"W_SDE_LAGTIME".to_string()),
+            "a [diffusion] model without a lagtime must NOT raise W_SDE_LAGTIME"
+        );
+    }
+
+    #[test]
+    fn a_steady_state_dose_under_diffusion_warns() {
+        let ss = ss_population();
+        let plain = make_sde_population();
+        assert!(
+            codes(SDE_MODEL_SRC, &ss).contains(&"W_SDE_STEADY_STATE".to_string()),
+            "a [diffusion] model with SS=1 records must raise W_SDE_STEADY_STATE"
+        );
+        // Control 1 — the same model, same subjects, doses not flagged SS.
+        assert!(
+            !codes(SDE_MODEL_SRC, &plain).contains(&"W_SDE_STEADY_STATE".to_string()),
+            "a [diffusion] model with no SS record must NOT raise W_SDE_STEADY_STATE"
+        );
+        // Control 2 — the same SS records with no [diffusion] block; the ODE path does
+        // equilibrate, so there is nothing to warn about.
+        assert!(
+            !codes(BASE_MODEL_SRC, &ss).contains(&"W_SDE_STEADY_STATE".to_string()),
+            "an ODE model with SS=1 records must NOT raise W_SDE_STEADY_STATE"
+        );
+    }
+
+    /// The message has to name the workaround, not just the gap — a warning that says
+    /// only "not supported" leaves the user with a silently wrong objective and no move.
+    #[test]
+    fn the_messages_say_what_to_do_instead() {
+        let parsed = parse_full_model(SDE_MODEL_SRC).expect("model parses");
+        let m = &parsed.model;
+        let diags = super::super::check_model_data_warnings(m, &ss_population(), &m.default_params);
+        let ss = diags
+            .iter()
+            .find(|d| d.code == "W_SDE_STEADY_STATE")
+            .expect("W_SDE_STEADY_STATE present");
+        assert_eq!(ss.severity, crate::diagnostics::Severity::Warning);
+        assert!(
+            ss.message.contains("explicit dose train"),
+            "the SS warning must point at the expansion workaround: {}",
+            ss.message
+        );
+
+        let parsed_lag = parse_full_model(SDE_LAG_MODEL_SRC).expect("model parses");
+        let ml = &parsed_lag.model;
+        let lag_diags =
+            super::super::check_model_data_warnings(ml, &make_sde_population(), &ml.default_params);
+        let lag = lag_diags
+            .iter()
+            .find(|d| d.code == "W_SDE_LAGTIME")
+            .expect("W_SDE_LAGTIME present");
+        assert_eq!(lag.severity, crate::diagnostics::Severity::Warning);
+        assert!(
+            lag.message.contains("record time"),
+            "the lag warning must say what happens instead: {}",
+            lag.message
+        );
+    }
+}

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -3971,6 +3971,51 @@ pub fn check_model_data_warnings(
         }
     }
 
+    // Absorption lag times are not applied on the EKF/SDE path. `solve_ekf` never calls
+    // `DoseAttrMap::lagtime`: the bolus lands at the raw `dose.time`, `active_infusions`
+    // is handed an empty lag slice, and the `TAD` anchor is computed at zero lag. Same
+    // silent-drop shape as `W_SDE_RESET` above (#1263 review).
+    if model.is_sde() && model.has_lagtime() {
+        diags.push(Diagnostic::warning(
+            "W_SDE_LAGTIME",
+            "This model declares an absorption lag time (`lagtime` / `ALAGn`) with a \
+             [diffusion] (SDE) model. Lag times are not yet honoured on the EKF/SDE \
+             path — every dose is applied at its record time and the lag is ignored. \
+             Use an ODE or analytical model if the lag matters."
+                .to_string(),
+        ));
+    }
+
+    // Steady-state doses are not equilibrated on the EKF/SDE path. `solve_ekf` applies an
+    // `SS=1` record as a single bolus and never runs the equilibration, so the state is
+    // the one-dose state while `tad_anchor_for`'s `ss` branch hands the RHS a `TAD`
+    // folded into `[0, II)` — an anchor describing a periodic pulse train that this
+    // engine did not build. Measured on #1263: 55% low against an explicit train on an
+    // autonomous model (90.48 vs 200.27), and a further 24.1% `ipred` divergence at
+    // t=150 for an `SS=1` infusion whose end break lands past a virtual pulse. Both are
+    // silent — hence a warning rather than a quiet wrong answer (#1260).
+    if model.is_sde() {
+        let n_ss_sde = population
+            .subjects
+            .iter()
+            .filter(|s| s.has_periodic_ss_dose())
+            .count();
+        if n_ss_sde > 0 {
+            diags.push(Diagnostic::warning(
+                "W_SDE_STEADY_STATE",
+                format!(
+                    "{} subject(s) have SS=1 dose records with a [diffusion] (SDE) \
+                     model. Steady-state doses are not yet equilibrated on the EKF/SDE \
+                     path — the record is applied as a single dose, so predictions and \
+                     the objective reflect a one-dose history rather than a steady \
+                     state. Use an ODE or analytical model, or expand the steady state \
+                     into an explicit dose train.",
+                    n_ss_sde
+                ),
+            ));
+        }
+    }
+
     // Negative typical-value lag time at the initial point (eta = 0).
     if model.has_lagtime() {
         if let Some(first_subj) = population.subjects.first() {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -45,6 +45,8 @@
 //! | `W_STEADY_STATE_II`       | SS=1 dose with missing / non-positive II |
 //! | `W_STEADY_STATE_INFUSION` | SS=1 infusion with `T_inf > II` (overlapping pulses) |
 //! | `W_SDE_RESET`             | EVID=3/4 resets under an SDE model are not honoured |
+//! | `W_SDE_LAGTIME`           | an absorption lag time under an SDE model is not honoured |
+//! | `W_SDE_STEADY_STATE`      | an `SS=1` dose under an SDE model is not equilibrated |
 //! | `W_EXPERIMENTAL_SDE`      | an SDE (`[diffusion]`) model uses an experimental feature (see Feature Maturity docs) |
 //! | `W_EXPERIMENTAL_NN`       | a neural-network (`[covariate_nn]`) model uses an experimental feature (see Feature Maturity docs) |
 //! | `W_NEGATIVE_LAGTIME`      | a lag time is negative at the initial estimates |

--- a/src/estimation/covariance.rs
+++ b/src/estimation/covariance.rs
@@ -177,8 +177,25 @@ fn fmt_eig(v: f64) -> String {
     }
 }
 
-/// Eigenvalues of `sym` sorted descending. Returns `None` if any eigenvalue is non-finite.
+/// Eigenvalues of `sym` sorted descending. Returns `None` if any eigenvalue is non-finite,
+/// or if `sym` is empty.
+///
+/// The empty case is reachable, not defensive: a model with **no random effects** has a
+/// 0×0 Omega, and the non-finite-objective diagnostic below asks this function to inspect
+/// it precisely when the fit has already gone wrong. `nalgebra`'s `SymmetricEigen::new`
+/// panics outright on a 0×0 input ("Unable to compute the symmetric tridiagonal
+/// decomposition of an empty matrix"), so an `n_eta = 0` fit whose objective went
+/// non-finite aborted with that message instead of reporting the objective — the diagnostic
+/// killed the run it was there to explain. `None` is the existing "cannot diagnose" signal
+/// and every caller already handles it.
+///
+/// One predicate, not `nrows() == 0 || ncols() == 0`: those two reject exactly the same
+/// inputs here, so either could be deleted with the guard still passing its own test —
+/// the redundant-gate hole from #1229 / #1255.
 pub(crate) fn extract_eigenvalues(sym: &DMatrix<f64>) -> Option<Vec<f64>> {
+    if sym.is_empty() {
+        return None;
+    }
     let eig = SymmetricEigen::new(sym.clone());
     if eig.eigenvalues.iter().any(|l| !l.is_finite()) {
         return None;

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -441,6 +441,25 @@ fn test_extract_eigenvalues_none_on_nan() {
     );
 }
 
+/// extract_eigenvalues returns None — rather than panicking — for a 0x0 matrix.
+///
+/// A model with no random effects has a 0x0 Omega, and the non-finite-objective diagnostic
+/// in `compute_covariance` inspects exactly that matrix when a fit has already gone wrong.
+/// `nalgebra`'s `SymmetricEigen::new` panics on an empty input, so before this guard an
+/// `n_eta = 0` fit whose objective went non-finite aborted with "Unable to compute the
+/// symmetric tridiagonal decomposition of an empty matrix" instead of reporting the
+/// objective. Both conjuncts are required to reach it — measured: `n_eta = 1` with a
+/// non-finite objective returns the `1e20` sentinel and does not panic, and `n_eta = 0`
+/// with a finite objective never enters this branch.
+#[test]
+fn test_extract_eigenvalues_none_on_empty_matrix() {
+    let h: DMatrix<f64> = DMatrix::zeros(0, 0);
+    assert!(
+        extract_eigenvalues(&h).is_none(),
+        "a 0x0 matrix must return None, not panic"
+    );
+}
+
 /// packed_param_label decodes the lower-triangular block-omega index correctly.
 /// Packing order (column-major lower triangle): (0,0), (1,0), (1,1).
 /// With n_theta=2, packed_idx=3 → omega_idx=1 → (row=1, col=0).

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -1126,7 +1126,15 @@ mod tests {
 
         for (i, &t) in obs_times.iter().enumerate() {
             let p_analytic = (sigma2_w / (2.0 * ke)) * (1.0 - (-2.0 * ke * t).exp());
-            // Euler covariance propagation introduces O(Δt²) error; 5% tolerance is adequate.
+            // 5% is a **discretisation floor, not a loose tolerance**: `propagate_covariance`
+            // steps the Riccati equation with forward Euler at `DT_MAX = 0.5`, so at `t = 1`
+            // it computes exactly `Q·0.5 + (Q − 2·ke·P₁)·0.5` — for this fixture
+            // `0.04·0.5 + (0.04 − 2·0.05·0.02)·0.5 = 0.039` — against a true `0.0380650`,
+            // i.e. 2.46% before any other source of error. The realised error falls with `t`
+            // as `P` approaches steady state (2.46% → 1.32% over t = 1…12), so this bound is
+            // set by the smallest `t` in the grid. Any oracle for this quantity inherits the
+            // same floor; see `ekf_covariance_matches_a_quadrature_oracle_on_a_time_varying_rate`
+            // (#1263), which measures it on a time-varying rate.
             assert_relative_eq!(ekf_pts[i].p_obs, p_analytic, max_relative = 0.05);
         }
     }

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -192,32 +192,69 @@ pub fn solve_ekf(
         pk_params_flat,
         crate::ode::predictions::earliest_dose_time(doses),
     );
-    // This path applies no lagtime (see `dose_f_bio` below and the `active_infusions`
-    // call), so the anchor rule is fed zero lags — the same values the rest of this
-    // function already assumes.
-    let no_lag: Vec<f64> = vec![0.0; doses.len()];
-
-    let obs_map: HashMap<u64, usize> = obs_times
-        .iter()
-        .enumerate()
-        .map(|(i, &t)| (t.to_bits(), i))
-        .collect();
-
-    // Build break times (same logic as ode_predictions)
-    let t_last = obs_times.iter().cloned().fold(0.0f64, f64::max);
-    let mut break_times: Vec<f64> = vec![0.0];
-    for dose in doses {
-        break_times.push(dose.time);
-        if is_real_infusion(dose) {
-            break_times.push(dose.time + dose.duration);
-        }
+    // Every observation index at a given time, not just the last one: multiple records
+    // can share a time (simultaneous PK/PD samples on different compartments), and a
+    // `HashMap<u64, usize>` keeps only one of them — the rest would keep the
+    // `EkfObsPoint { ipred: 0.0, p_obs: 0.0 }` prefill from above and feed a finite,
+    // plausible zero into the likelihood. The boundary-read path below was hardened for
+    // exactly this in #1226; the in-segment path was not, and measured on #1263
+    // `obs_times = [2.0, 2.0, 8.0]` returned `ipred = 0.0` for the first of the pair
+    // (#1263 review). Mirrors `predictions::build_obs_index_map`.
+    let mut obs_map: HashMap<u64, Vec<usize>> = HashMap::new();
+    for (i, &t) in obs_times.iter().enumerate() {
+        obs_map.entry(t.to_bits()).or_default().push(i);
     }
+
     // Bioavailability resolved per dose compartment (`Fn`; issue #369), falling
     // back to the bare `F` slot. (The EKF path does not apply lagtime.)
     let dose_f_bio: Vec<f64> = doses
         .iter()
         .map(|d| dose_attr_map.f_bio(d.cmt_raw(), pk_params_flat))
         .collect();
+
+    // Build break times (same logic as ode_predictions).
+    //
+    // The first break is the subject's own integration start, **not** a literal `0.0`:
+    // for a subject whose records begin at `t > 0` a leading `[0, t_first]` segment is
+    // pure fiction, and it is not free — `propagate_covariance` runs it, so `p_mat`
+    // reaches the first observation carrying `q · t_first` of process noise the ODE path
+    // never accumulates (measured 13× on #1263), and an `init(state)` mean decays across
+    // it before the twin has started. `doses`/`obs_times` are what this engine is given,
+    // so the start is the min over them rather than `subject_integration_start`'s wider
+    // event set — the caller (`ode_predictions_ekf_with_diffusion`) passes the subject's
+    // full dose and observation lists, and pk-only/reset rows are not honoured here at
+    // all (`W_SDE_RESET`).
+    let t_first = obs_times
+        .iter()
+        .chain(doses.iter().map(|d| &d.time))
+        .cloned()
+        .fold(f64::INFINITY, f64::min);
+    // `fold(0.0, max)` matches `ode_predictions` (`:3225`), then clamped up to `t_first`.
+    // Without the clamp a subject with **no observations** — `t_last` folds to `0.0`
+    // while `t_first` is its first dose — pushes a `0.0` back into `break_times` and
+    // restores the very phantom leading segment this seed removes. Nothing is scored for
+    // such a subject, so it costs only wasted integration, but it would make the code
+    // contradict the comment above.
+    let t_last = obs_times
+        .iter()
+        .cloned()
+        .fold(0.0f64, f64::max)
+        .max(if t_first.is_finite() { t_first } else { 0.0 });
+    // `subject_integration_start`'s own dose-free fallback, spelled here because this
+    // engine holds slices rather than a `&Subject`.
+    let mut break_times: Vec<f64> = vec![if t_first.is_finite() { t_first } else { 0.0 }];
+    for (k, dose) in doses.iter().enumerate() {
+        break_times.push(dose.time);
+        if is_real_infusion(dose) {
+            // `F`-reshaped window end, matching `active_infusions`' own membership test
+            // (`predictions.rs:1520-1531`) and `collect_dose_break_times`. An unscaled
+            // `dose.duration` puts the break past the true end, so the admission test
+            // `end >= t_end - EPS` fails and the infusion is never admitted in *any*
+            // segment — measured on #1263 as `ipred = 0.0` everywhere for `F = 0.5`.
+            let (_, dur_eff) = dose.bioavailable_infusion(dose_f_bio[k]);
+            break_times.push(dose.time + dur_eff);
+        }
+    }
     break_times.push(t_last);
     break_times.sort_by(|a, b| a.total_cmp(b));
     break_times.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
@@ -300,10 +337,10 @@ pub fn solve_ekf(
             let point = EkfObsPoint { ipred, p_obs };
             // Records sharing this exact time are one measurement instant: they take the
             // same `ipred`/`p_obs` from this single update rather than each running their
-            // own — the collapsing the old `obs_map.get(&t_start.to_bits())` did, since that
-            // map keeps one index per bit pattern. They are *filled* rather than dropped:
-            // the band excludes them from the segment `saveat` too, so a dropped index would
-            // keep its `EkfObsPoint { ipred: 0.0, p_obs: 0.0 }` prefill and feed a finite,
+            // own. The in-segment read below collapses them the same way. They are
+            // *filled* rather than dropped: the band excludes them from the segment
+            // `saveat` too, so a dropped index would keep its
+            // `EkfObsPoint { ipred: 0.0, p_obs: 0.0 }` prefill and feed a finite,
             // plausible zero into the likelihood.
             let bits = obs_times[obs_idx].to_bits();
             for &j in &boundary_obs {
@@ -332,8 +369,11 @@ pub fn solve_ekf(
         // Re-anchor TAD for this segment, *before* anything integrates with it — the
         // ODE predictors write this slot per segment too, and a write placed after the
         // solve reads the previous segment's anchor without failing to compile.
+        // `&[]`, not a zero-filled vector: this path applies no lagtime (see `dose_f_bio`
+        // above and the `active_infusions` call below), and `tad_anchor_for` reads a
+        // missing entry as zero lag.
         ext_params[crate::types::MAX_PK_PARAMS + 1] =
-            crate::ode::predictions::tad_anchor_for(doses, &no_lag, t_start);
+            crate::ode::predictions::tad_anchor_for(doses, &[], t_start);
 
         // Active infusion rates for this segment (shared with the FOCEI ODE
         // path so the F·RATE / span / lag / reset semantics stay in lockstep).
@@ -402,20 +442,33 @@ pub fn solve_ekf(
                 }
             }
 
-            if let Some(&obs_idx) = obs_map.get(&pt.t.to_bits()) {
+            if let Some(here) = obs_map.get(&pt.t.to_bits()) {
                 // Same assimilate-once mask as the boundary read: an observation sitting
                 // exactly on this segment's `t_end` is read here *and* at the next break as
                 // its `t_start`, and `kalman_update` is not idempotent.
-                if !assimilated[obs_idx] {
-                    let r = r_obs_vec.get(obs_idx).copied().unwrap_or(1.0);
+                //
+                // Records sharing this exact time are **one** measurement instant and share
+                // a single update, exactly as the boundary path above does — `solve_ekf`
+                // has one `obs_cmt_idx`, so N records here are N reads of the same
+                // compartment at the same time, and updating N times would shrink `p_mat`
+                // as though N independent measurements had arrived. Before #1263 only the
+                // last index of a shared time was in the map at all, so the others kept
+                // their `{ ipred: 0.0, p_obs: 0.0 }` prefill.
+                if let Some(&first) = here.iter().find(|&&j| !assimilated[j]) {
+                    let r = r_obs_vec.get(first).copied().unwrap_or(1.0);
                     let (p_new, p_obs) = kalman_update(&p_mat, obs_cmt_idx, r, n);
                     p_mat = p_new;
                     let v = pt.u[obs_cmt_idx];
-                    results[obs_idx] = EkfObsPoint {
+                    let point = EkfObsPoint {
                         ipred: if v.is_nan() || v < 0.0 { 0.0 } else { v },
                         p_obs,
                     };
-                    assimilated[obs_idx] = true;
+                    for &j in here {
+                        if !assimilated[j] {
+                            results[j] = point.clone();
+                            assimilated[j] = true;
+                        }
+                    }
                 }
             }
 
@@ -1363,6 +1416,497 @@ mod tests {
             got.iter().all(|p| !p.ipred.is_finite()),
             "a non-finite timeline must give non-finite EKF ipreds, not a finite pass \
              with the bad dose silently dropped"
+        );
+    }
+
+    /// **NONMEM anchor — a RATE-defined infusion under `F ≠ 1` on the EKF walk.**
+    ///
+    /// `F` reshapes an infusion's **duration**, not its rate (#419): NONMEM holds the data
+    /// `RATE` and delivers `F·AMT` over `F·AMT/RATE`. `ekf.rs` pushed an unscaled
+    /// `dose.time + dose.duration` as the window's break, so `active_infusions`'
+    /// membership test (`predictions.rs:1520-1531`, `end >= t_end - EPS`) rejected the
+    /// window in **every** segment and the infusion delivered zero mass — measured
+    /// `ipred = 0.0` at every observation for `F = 0.5`, against `27.86 / 42.08 / 31.18`
+    /// from `ode_predictions` (#1263 review).
+    ///
+    /// The reference is **NONMEM 7.6.0 PRED**, not ferx: `nonmem_anchor/oral_central_inf_advan2_f06.ctl`
+    /// (ADVAN2 TRANS2, `CL=5, V=50, KA=1, F2=0.6, S2=V`, 100 mg at `RATE=25` into `CMT=2`,
+    /// obs at `t = 1, 3, 6, 10, 16`), whose digits are also pinned in
+    /// `tests/oral_central_infusion_nonmem_anchor.rs` for the analytical paths. The system
+    /// is written here as the explicit two-state ODE twin so it reaches `solve_ekf`, which
+    /// the analytical anchor cannot.
+    ///
+    /// Non-degenerate on both sides of the quantity under test: `t = 1` is **inside** the
+    /// window (where `F` has not yet moved the answer — it is the same value as the `F = 1`
+    /// run) and `t = 3, 6, 10, 16` are all **past** the `F`-shortened end at `2.4 h`, where
+    /// an unscaled duration and a scaled one disagree. An implementation that ignored `F`
+    /// on the window would match the first point and miss the other four.
+    #[test]
+    fn ekf_infusion_under_f_matches_nonmem() {
+        // `oral_central_inf_advan2_f06.tab`, NONMEM 7.6.0 PRED at FORMAT=,1PE17.10.
+        const ADVAN2_F06: [f64; 5] = [
+            4.7581290982e-01,
+            1.0047315645e+00,
+            7.4432344989e-01,
+            4.9893492919e-01,
+            2.7382129479e-01,
+        ];
+        let (cl, v, ka, f) = (5.0f64, 50.0f64, 1.0f64, 0.6f64);
+        // Two states so this is genuinely the ADVAN2 system; the depot is never dosed
+        // (the infusion bypasses it into CMT=2), so `A1 ≡ 0` exactly as under NONMEM.
+        let rhs = move |y: &[f64], p: &[f64], _t: f64, dy: &mut [f64]| {
+            let k = p[crate::types::PK_IDX_CL] / p[crate::types::PK_IDX_V];
+            dy[0] = -ka * y[0];
+            dy[1] = ka * y[0] - k * y[1];
+        };
+        let mut pk = make_pk(cl, v);
+        pk[crate::types::PK_IDX_F] = f;
+        let obs_times = vec![1.0, 3.0, 6.0, 10.0, 16.0];
+        // AMT=100, RATE=25 -> duration 4 h; F=0.6 shortens the window to 2.4 h.
+        let doses = vec![DoseEvent::new(0.0, 100.0, 2, 25.0, false, 0.0)];
+        let opts = OdeSolverOptions {
+            abstol: 1e-12,
+            reltol: 1e-10,
+            ..OdeSolverOptions::default()
+        };
+
+        let pts = solve_ekf(
+            &rhs,
+            2,
+            1, // observable is the central compartment
+            &[0.0, 0.0],
+            &pk,
+            &Default::default(),
+            &[],
+            &doses,
+            &obs_times,
+            &vec![0.01; obs_times.len()],
+            opts,
+        );
+
+        // Measured realised relative errors against the committed NONMEM digits:
+        // 4.84e-13 / 1.10e-11 / 1.79e-13 / 2.36e-11 / 5.24e-11 at t = 1/3/6/10/16, worst
+        // 5.24e-11. That worst case is at the reference's own resolution — the `$TABLE`
+        // prints 11 significant figures, so ~1e-11 is the floor a comparison against it
+        // can reach and a tighter bound would be pinning the last printed digit. 1e-9,
+        // i.e. 19× headroom over the realised worst case.
+        let mut worst = 0.0f64;
+        for (j, &t) in obs_times.iter().enumerate() {
+            let got = pts[j].ipred / v;
+            let want = ADVAN2_F06[j];
+            // `is_finite` before folding: `f64::max` discards `NaN`, so a solve that
+            // diverged would otherwise leave `worst` at whatever the good rows produced.
+            assert!(got.is_finite(), "non-finite EKF ipred at t={t}: {got}");
+            let rel = ((got - want) / want).abs();
+            worst = worst.max(rel);
+            assert!(
+                rel < 1e-9,
+                "t={t}: EKF {got:.10e} vs NONMEM {want:.10e} (rel {rel:.3e})"
+            );
+        }
+        assert!(
+            worst > 0.0,
+            "a zero worst-case error means the loop never compared anything"
+        );
+    }
+
+    /// **The TAFD anchor is the first dose time, not a literal zero.**
+    ///
+    /// Every other fixture in this module doses at `t = 0`, where
+    /// `earliest_dose_time(doses)` and `0.0` are the same number — so replacing the seed
+    /// with `seed_ext_params(pk_params_flat, 0.0)` left `cargo test --lib` at
+    /// **4083 passed, 0 failed** (#1263 review). This fixture's first dose is at `t = 6`,
+    /// and its closed form takes the anchor from `t1` rather than hard-coding `0.0`, so
+    /// that mutation moves the TAFD arm and the test fails.
+    ///
+    /// The `TAD` arm is carried alongside deliberately: the two anchors coincide on the
+    /// first dosing interval and separate only after the second dose, so a fixture that
+    /// scored the first interval alone could not tell them apart either.
+    #[test]
+    fn ekf_tafd_anchors_at_the_first_dose_not_at_zero() {
+        let (cl, v) = (1.0f64, 20.0f64);
+        let ke = cl / v;
+        let c = 0.05f64;
+        // First dose at t = 6, NOT at 0 — the whole point of this fixture.
+        let (t1, t2, amt) = (6.0f64, 18.0f64, 100.0f64);
+        let doses = vec![
+            DoseEvent::new(t1, amt, 1, 0.0, false, 0.0),
+            DoseEvent::new(t2, amt, 1, 0.0, false, 0.0),
+        ];
+        let obs_times = vec![8.0, 14.0, 20.0, 30.0];
+        let pk = make_pk(cl, v);
+        let opts = OdeSolverOptions {
+            abstol: 1e-12,
+            reltol: 1e-10,
+            ..OdeSolverOptions::default()
+        };
+
+        // ∫ (1 + c·u) du over the leg, with `u` measured from `anchor`.
+        let phase = |t_from: f64, t_to: f64, anchor: f64| -> f64 {
+            let (a, b) = (t_from - anchor, t_to - anchor);
+            (b - a) + c * (b * b - a * a) / 2.0
+        };
+        // `TAFD` anchors at `t1` for the whole record; `TAD` re-anchors at `t2`.
+        let closed_form = |t: f64, restarts: bool| -> f64 {
+            if t < t2 {
+                amt * (-ke * phase(t1, t, t1)).exp()
+            } else {
+                let at_t2 = amt * (-ke * phase(t1, t2, t1)).exp();
+                let anchor = if restarts { t2 } else { t1 };
+                (at_t2 + amt) * (-ke * phase(t2, t, anchor)).exp()
+            }
+        };
+
+        let mut worst = 0.0f64;
+        for (name, slot, restarts) in [
+            ("TAFD", crate::types::MAX_PK_PARAMS, false),
+            ("TAD", crate::types::MAX_PK_PARAMS + 1, true),
+        ] {
+            let rhs = time_reading_rhs(slot, c);
+            let pts = solve_ekf(
+                &rhs,
+                1,
+                0,
+                &[0.0], // zero diffusion: the mean walk reduces to plain integration
+                &pk,
+                &Default::default(),
+                &[],
+                &doses,
+                &obs_times,
+                &vec![0.01; obs_times.len()],
+                opts,
+            );
+            for (j, &t) in obs_times.iter().enumerate() {
+                let got = pts[j].ipred;
+                let want = closed_form(t, restarts);
+                assert!(got.is_finite(), "{name}: non-finite ipred at t={t}");
+                let rel = ((got - want) / want).abs();
+                worst = worst.max(rel);
+                // Measured worst realised error across both arms: 5.24e-11 (TAD, t=30);
+                // the TAFD arm's worst is 4.31e-11. Bounded at 1e-9 — 19× headroom over
+                // the realised worst case, and the same order the `reltol = 1e-10`
+                // integration above can support.
+                assert!(
+                    rel < 1e-9,
+                    "{name} at t={t}: EKF {got} vs closed form {want} (rel {rel:.3e})"
+                );
+            }
+        }
+        assert!(worst > 0.0, "the comparison loop never ran");
+
+        // The straddle: with the anchor mutated to a literal 0.0 the TAFD arm integrates
+        // `1 + c·t` instead of `1 + c·(t − 6)`, so the two spellings must actually differ
+        // here. Assert that they do, or this fixture silently becomes a tautology.
+        let at_last = obs_times[obs_times.len() - 1];
+        let with_true_anchor = closed_form(at_last, false);
+        let with_zero_anchor = {
+            let phase0 = |t_from: f64, t_to: f64| -> f64 {
+                let (a, b) = (t_from, t_to);
+                (b - a) + c * (b * b - a * a) / 2.0
+            };
+            let at_t2 = amt * (-ke * phase0(t1, t2)).exp();
+            (at_t2 + amt) * (-ke * phase0(t2, at_last)).exp()
+        };
+        let sep = ((with_true_anchor - with_zero_anchor) / with_true_anchor).abs();
+        assert!(
+            sep > 0.05,
+            "the t1=6 and t1=0 TAFD anchors must give materially different curves for \
+             this fixture to pin the anchor at all — separation {sep:.3e}"
+        );
+    }
+
+    /// **A subject whose records start after `t = 0` gets no phantom leading segment.**
+    ///
+    /// `break_times` was seeded with a literal `0.0` where the ODE path uses
+    /// `subject_integration_start`. For a first event at `t = 24` that left a `[0, 24]`
+    /// segment which `propagate_covariance` actually integrated, so `p_mat` arrived at the
+    /// first observation carrying `q · 24` of process noise the ODE twin never accumulates
+    /// — measured `p_obs = 6.5` against a true `0.5`, i.e. **13×** (#1263 review).
+    ///
+    /// The oracle is a closed form, not a twin: with `CL = 0` the drift vanishes, the
+    /// Jacobian is zero and the Riccati equation is exactly `dP/dt = Q`, so
+    /// `P(t) = q · (t − t_start)` with no solver error to absorb a wrong start.
+    #[test]
+    fn ekf_covariance_starts_at_the_first_record_not_at_zero() {
+        let q = 0.25f64;
+        let pk = make_pk(0.0, 20.0); // CL = 0 -> ke = 0 -> dP/dt = Q exactly
+        let opts = OdeSolverOptions {
+            abstol: 1e-12,
+            reltol: 1e-10,
+            ..OdeSolverOptions::default()
+        };
+
+        // One variable: the same subject, shifted. Both must give the same `p_obs` at the
+        // same elapsed time — a start-dependent answer is the defect.
+        let mut seen = Vec::new();
+        for shift in [0.0f64, 24.0] {
+            let doses = vec![DoseEvent::new(shift, 100.0, 1, 0.0, false, 0.0)];
+            let obs_times = vec![shift + 2.0, shift + 6.0];
+            let pts = solve_ekf(
+                &one_cpt_rhs,
+                1,
+                0,
+                &[q],
+                &pk,
+                &Default::default(),
+                &[],
+                &doses,
+                &obs_times,
+                &vec![0.01; obs_times.len()],
+                opts,
+            );
+            let got = pts[0].p_obs;
+            assert!(got.is_finite(), "shift={shift}: non-finite p_obs {got}");
+            // Measured error against the closed form: 0.0 exactly at both shifts.
+            let want = q * 2.0;
+            assert!(
+                (got - want).abs() < 1e-12,
+                "shift={shift}: p_obs {got} vs closed form q·Δt {want} — a leading \
+                 [0, {shift}] segment would give q·(Δt+{shift}) = {}",
+                q * (2.0 + shift)
+            );
+            seen.push(got);
+        }
+        // The straddle: the two shifts must be a real experiment. `q·2 = 0.5` and
+        // `q·26 = 6.5` are far apart, so a start-dependent implementation cannot pass
+        // both branches above by accident.
+        assert!(
+            (q * 26.0 - q * 2.0).abs() > 1.0,
+            "the shifted and unshifted expectations must differ for this to be a test"
+        );
+        assert_eq!(
+            seen[0].to_bits(),
+            seen[1].to_bits(),
+            "the same subject shifted in time must give bit-identical covariance"
+        );
+    }
+
+    /// **Records sharing an observation time inside a segment are all filled, from one
+    /// Kalman update.**
+    ///
+    /// The in-segment read looked the point up in a `HashMap<u64, usize>`, which keeps one
+    /// index per time — so for two records at the same instant the loser kept its
+    /// `EkfObsPoint { ipred: 0.0, p_obs: 0.0 }` prefill and fed a finite, plausible zero
+    /// into the likelihood. Measured: `obs_times = [2.0, 2.0, 8.0]` returned `ipred = 0.0`
+    /// for index 0 and `90.4837418037` for index 1 (#1263 review). The boundary-read path
+    /// was hardened for this in #1226; this is the same defect one branch over.
+    ///
+    /// Both halves are asserted: the duplicates are **filled**, and they share a **single**
+    /// update — `solve_ekf` has one `obs_cmt_idx`, so N records at one time are N reads of
+    /// the same compartment, and updating N times would shrink `p_mat` as though N
+    /// independent measurements had arrived.
+    #[test]
+    fn ekf_duplicate_in_segment_obs_times_share_one_update() {
+        let pk = make_pk(1.0, 20.0);
+        let opts = OdeSolverOptions {
+            abstol: 1e-12,
+            reltol: 1e-10,
+            ..OdeSolverOptions::default()
+        };
+        let doses = vec![bolus_dose(100.0)];
+        // t = 2 is strictly inside the only segment [0, 8], so this exercises the
+        // in-segment read rather than the boundary read.
+        let dup = solve_ekf(
+            &one_cpt_rhs,
+            1,
+            0,
+            &[0.1],
+            &pk,
+            &Default::default(),
+            &[],
+            &doses,
+            &[2.0, 2.0, 8.0],
+            &[0.01; 3],
+            opts,
+        );
+        // The single-record control: what one record at t = 2 gets.
+        let single = solve_ekf(
+            &one_cpt_rhs,
+            1,
+            0,
+            &[0.1],
+            &pk,
+            &Default::default(),
+            &[],
+            &doses,
+            &[2.0, 8.0],
+            &[0.01; 2],
+            opts,
+        );
+
+        for (i, p) in dup.iter().enumerate() {
+            assert!(
+                p.ipred.is_finite() && p.p_obs.is_finite(),
+                "idx {i}: non-finite point {p:?}"
+            );
+        }
+        assert!(
+            dup[0].ipred > 0.0,
+            "the first of two records at t=2 kept its 0.0 prefill: {:?}",
+            dup[0]
+        );
+        assert_eq!(
+            dup[0].ipred.to_bits(),
+            dup[1].ipred.to_bits(),
+            "records at one instant must share an ipred"
+        );
+        assert_eq!(
+            dup[0].p_obs.to_bits(),
+            dup[1].p_obs.to_bits(),
+            "records at one instant must share a p_obs"
+        );
+        // One update, not two: the duplicate pair must leave the *later* observation with
+        // exactly the covariance the single-record run gives it. Assimilating twice at
+        // t = 2 would over-shrink `p_mat` and this would come out low.
+        assert_eq!(
+            dup[2].p_obs.to_bits(),
+            single[1].p_obs.to_bits(),
+            "a duplicated observation time must not assimilate twice — p_obs at t=8 is \
+             {} with the duplicate and {} without",
+            dup[2].p_obs,
+            single[1].p_obs
+        );
+        // And the straddle: the two-update answer really is different, so the assertion
+        // above can fail.
+        let (p_new, _) = kalman_update(
+            &nalgebra::DMatrix::from_element(1, 1, dup[0].p_obs),
+            0,
+            0.01,
+            1,
+        );
+        assert!(
+            (p_new[(0, 0)] - dup[0].p_obs).abs() > 1e-9,
+            "a second update at the same instant must move p_mat, or this test is vacuous"
+        );
+    }
+
+    /// **The EKF covariance on a time-varying rate, against a quadrature oracle.**
+    ///
+    /// `time_reading_rhs_gets_finite_anchors_on_the_ekf_walk` asserts `p_obs > 0.0`. That is
+    /// a real discriminator — `is_finite()` accepts `0.0` and this rejects it, so an EKF
+    /// that never propagated fails — but it is a **floor**, not a bound: it passes for any
+    /// positive magnitude, including an over-propagating Riccati step (#1263 review). This
+    /// gives the same quantity a two-sided oracle.
+    ///
+    /// `dA/dt = -ke·A·(1 + c·TAFD)` is linear in the state with a time-varying rate
+    /// `k(t) = ke·(1 + c·t)` for a single dose at `t = 0`, so the Riccati equation is the
+    /// scalar `dP/dt = -2k(t)·P + Q` with `P(0) = 0`, whose solution is
+    ///
+    /// ```text
+    ///   P(t) = Q · e^(-2Φ(t)) · ∫₀ᵗ e^(2Φ(s)) ds,   Φ(t) = ke·(t + c·t²/2)
+    /// ```
+    ///
+    /// The inner integral is not elementary (it is an imaginary error function), so it is
+    /// evaluated here by Simpson's rule at 20 000 intervals — arithmetic outside the filter
+    /// entirely, not a second call into it. `R` is large so the Kalman update barely
+    /// contracts `P` and the comparison is against the free-drift solution, the same device
+    /// `ekf_variance_matches_analytic_linear_sde` uses for the constant-rate case.
+    ///
+    /// The `c = 0` arm is carried alongside as the degenerate control: it must reduce to the
+    /// constant-rate closed form `(Q/2ke)·(1 − e^(−2·ke·t))`, and it must differ materially
+    /// from the `c > 0` arm, or the fixture would not be testing the time-varying part at
+    /// all.
+    #[test]
+    fn ekf_covariance_matches_a_quadrature_oracle_on_a_time_varying_rate() {
+        let (cl, v) = (5.0f64, 100.0f64);
+        let ke = cl / v; // 0.05 h⁻¹
+        let q = 0.04f64;
+        let obs_times = vec![1.0, 4.0, 8.0, 12.0];
+        let pk = make_pk(cl, v);
+        let doses = vec![bolus_dose(100.0)];
+        // Large R: the update contracts P by ~Q/R per observation, i.e. negligibly, so
+        // `p_obs` tracks the free-drift solution the oracle below computes.
+        let r_obs_vec = vec![1e8f64; obs_times.len()];
+
+        // ∫₀ᵗ e^(2Φ(s)) ds by Simpson's rule. Even `n`, so the composite rule applies.
+        let simpson = |t: f64, c: f64| -> f64 {
+            let n = 20_000usize;
+            let h = t / n as f64;
+            let phi = |s: f64| ke * (s + c * s * s / 2.0);
+            let f = |s: f64| (2.0 * phi(s)).exp();
+            let mut acc = f(0.0) + f(t);
+            for i in 1..n {
+                let w = if i % 2 == 0 { 2.0 } else { 4.0 };
+                acc += w * f(i as f64 * h);
+            }
+            acc * h / 3.0
+        };
+
+        let mut worst = 0.0f64;
+        let mut at_c0 = Vec::new();
+        let mut at_c1 = Vec::new();
+        for c in [0.0f64, 0.05] {
+            let rhs = time_reading_rhs(crate::types::MAX_PK_PARAMS, c);
+            let pts = solve_ekf(
+                &rhs,
+                1,
+                0,
+                &[q],
+                &pk,
+                &Default::default(),
+                &[],
+                &doses,
+                &obs_times,
+                &r_obs_vec,
+                OdeSolverOptions::default(),
+            );
+            for (j, &t) in obs_times.iter().enumerate() {
+                let phi_t = ke * (t + c * t * t / 2.0);
+                let want = q * (-2.0 * phi_t).exp() * simpson(t, c);
+                let got = pts[j].p_obs;
+                // `is_finite` before folding — `f64::max` discards `NaN`, so a diverged
+                // Riccati step would otherwise leave `worst` at whatever the good rows gave.
+                assert!(got.is_finite(), "c={c}: non-finite p_obs at t={t}: {got}");
+                let rel = ((got - want) / want).abs();
+                worst = worst.max(rel);
+                // Measured realised errors, all eight points:
+                //   c=0.00  2.456e-2 / 2.093e-2 / 1.671e-2 / 1.317e-2  at t = 1/4/8/12
+                //   c=0.05  2.526e-2 / 2.249e-2 / 1.754e-2 / 1.171e-2
+                // Worst 2.526e-2, and it *decreases* with t — this is the forward-Euler
+                // transient in `propagate_covariance`, which steps the Riccati equation at
+                // `DT_MAX = 0.5`: at t=1 that is two steps giving exactly
+                // `0.04·0.5 + (0.04 − 2·0.05·0.02)·0.5 = 0.039` against a true 0.0380650.
+                // So the floor here is the filter's own discretisation, not the oracle;
+                // `ekf_variance_matches_analytic_linear_sde` sits at 5% for the same reason.
+                //
+                // Bounded at 4e-2 — 1.6× over the realised worst case. Loose, and it has to
+                // be, but it still bites: the defect this fixture exists to catch (an engine
+                // that ignores the model-time term, so `c=0.05` returns the `c=0` curve) is
+                // 23% wrong at t=12, six times the bound.
+                assert!(
+                    rel < 4e-2,
+                    "c={c} t={t}: EKF p_obs {got:.10e} vs quadrature {want:.10e} \
+                     (rel {rel:.3e})"
+                );
+                if c == 0.0 {
+                    at_c0.push(got);
+                    // The degenerate arm must also reduce to the elementary closed form,
+                    // which pins the quadrature itself rather than trusting it.
+                    let closed = (q / (2.0 * ke)) * (1.0 - (-2.0 * ke * t).exp());
+                    assert!(
+                        ((want - closed) / closed).abs() < 1e-9,
+                        "the c=0 quadrature must reproduce the constant-rate closed form: \
+                         {want} vs {closed}"
+                    );
+                } else {
+                    at_c1.push(got);
+                }
+            }
+        }
+        assert!(worst > 0.0, "the comparison loop never ran");
+
+        // The straddle: a time-varying rate must actually move `p_obs`, or every assertion
+        // above is satisfied by an engine that ignores the model-time term entirely — the
+        // exact failure this fixture family exists to catch.
+        let sep = at_c0
+            .iter()
+            .zip(&at_c1)
+            .map(|(a, b)| ((a - b) / a).abs())
+            .fold(0.0f64, f64::max);
+        assert!(
+            sep > 0.05,
+            "the c=0 and c=0.05 covariance curves must differ materially — worst \
+             separation {sep:.3e}"
         );
     }
 }

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -181,6 +181,22 @@ pub fn solve_ekf(
         n_obs
     ];
 
+    // The compiled `[odes]` RHS reads TAFD and TAD out of `params[MAX_PK_PARAMS]` and
+    // `params[MAX_PK_PARAMS + 1]`. `pk_params_flat` is a bare `PkParams::values`, i.e.
+    // exactly `MAX_PK_PARAMS` long, so `.get()` on either slot returns `None` and the RHS
+    // injects `NaN` — which multiplies into the state and the Jacobian, and is then
+    // laundered into a plausible `0.0` by the `is_nan()` clamp below while `p_obs` keeps
+    // the `NaN` and destroys the likelihood (#1131). Carry the same extended array the
+    // ODE predictors build; the TAD slot is re-anchored per segment in the walk below.
+    let mut ext_params = crate::ode::predictions::seed_ext_params(
+        pk_params_flat,
+        crate::ode::predictions::earliest_dose_time(doses),
+    );
+    // This path applies no lagtime (see `dose_f_bio` below and the `active_infusions`
+    // call), so the anchor rule is fed zero lags — the same values the rest of this
+    // function already assumes.
+    let no_lag: Vec<f64> = vec![0.0; doses.len()];
+
     let obs_map: HashMap<u64, usize> = obs_times
         .iter()
         .enumerate()
@@ -313,6 +329,12 @@ pub fn solve_ekf(
             continue;
         }
 
+        // Re-anchor TAD for this segment, *before* anything integrates with it — the
+        // ODE predictors write this slot per segment too, and a write placed after the
+        // solve reads the previous segment's anchor without failing to compile.
+        ext_params[crate::types::MAX_PK_PARAMS + 1] =
+            crate::ode::predictions::tad_anchor_for(doses, &no_lag, t_start);
+
         // Active infusion rates for this segment (shared with the FOCEI ODE
         // path so the F·RATE / span / lag / reset semantics stay in lockstep).
         // The EKF path has no per-dose lagtimes and no system resets.
@@ -341,7 +363,7 @@ pub fn solve_ekf(
             &wrapped_rhs,
             &u,
             (t_start, t_end),
-            pk_params_flat,
+            &ext_params,
             &saveat,
             &opts,
         );
@@ -371,7 +393,7 @@ pub fn solve_ekf(
                         &wrapped_rhs,
                         &p_mat,
                         &u_mid,
-                        pk_params_flat,
+                        &ext_params,
                         t_mid,
                         dt_sub,
                         diffusion_var,
@@ -420,6 +442,32 @@ mod tests {
         let v = p[crate::types::PK_IDX_V];
         let ke = if v > 0.0 { cl / v } else { 0.0 };
         dy[0] = -ke * y[0];
+    }
+
+    /// The same 1-cpt bolus with elimination modulated by a **model-time builtin**, read
+    /// out of the extended-parameter slot the compiled `[odes]` RHS uses. `slot` is
+    /// `MAX_PK_PARAMS` for TAFD or `MAX_PK_PARAMS + 1` for TAD; `coef` scales the term.
+    ///
+    /// This mirrors `parser/model_parser.rs`'s injection exactly, including the
+    /// `.get(..).filter(is_finite).map_or(NAN, ..)` shape — so a short `params` slice
+    /// yields `NaN` here for the same reason it does in production. Writing it any other
+    /// way (e.g. indexing, or defaulting to 0.0) would make the fixture unable to
+    /// reproduce the defect at all.
+    fn time_reading_rhs(
+        slot: usize,
+        coef: f64,
+    ) -> impl Fn(&[f64], &[f64], f64, &mut [f64]) + Send + Sync {
+        move |y: &[f64], p: &[f64], t: f64, dy: &mut [f64]| {
+            let cl = p[crate::types::PK_IDX_CL];
+            let v = p[crate::types::PK_IDX_V];
+            let ke = if v > 0.0 { cl / v } else { 0.0 };
+            let builtin = p
+                .get(slot)
+                .copied()
+                .filter(|x| x.is_finite())
+                .map_or(f64::NAN, |anchor| t - anchor);
+            dy[0] = -ke * y[0] * (1.0 + coef * builtin);
+        }
     }
 
     fn make_pk(cl: f64, v: f64) -> Vec<f64> {
@@ -507,6 +555,272 @@ mod tests {
             assert_relative_eq!(ekf.ipred, ode, epsilon = 1e-4, max_relative = 1e-4);
             assert_relative_eq!(ekf.p_obs, 0.0, epsilon = 1e-10);
         }
+    }
+
+    /// #1131: an `[odes]` RHS reading a model-time builtin poisons the EKF, because
+    /// `solve_ekf` was handed a bare `PkParams::values` — exactly `MAX_PK_PARAMS` long —
+    /// while the RHS reads TAFD/TAD from slots `MAX_PK_PARAMS` and `+1`. `.get()` returned
+    /// `None`, so both builtins evaluated to `NaN` for the whole trajectory.
+    ///
+    /// **Assert `p_obs`, never `ipred`.** The two failed differently and only one of them
+    /// can carry this test: `ipred` is clamped by `if v.is_nan() { 0.0 }` in the assimilate
+    /// branch, and by the time this was measured at `579d1e96` the sdtab column was already
+    /// reporting the correct value-path numbers — so an `ipred` assertion passes both
+    /// before and after the fix and cannot fail. `p_obs` has no such clamp, and it is what
+    /// feeds the likelihood: the defect surfaced as the `1e20` objective sentinel.
+    ///
+    /// No SS dose and no lagtime here — the defect needs neither, which is why #1131 is
+    /// not the steady-state bug it was filed alongside.
+    #[test]
+    fn time_reading_rhs_gets_finite_anchors_on_the_ekf_walk() {
+        for (name, slot) in [
+            ("TAFD", crate::types::MAX_PK_PARAMS),
+            ("TAD", crate::types::MAX_PK_PARAMS + 1),
+        ] {
+            // Two doses: under a single dose TAD == TAFD, so a one-dose fixture cannot
+            // tell the two slots apart and would agree with an engine that plumbed only
+            // one of them.
+            let doses = vec![
+                bolus_dose(100.0),
+                DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+            ];
+            let obs_times = vec![2.0, 4.0, 8.0, 24.0];
+            let pk = make_pk(1.0, 20.0);
+            let r_obs_vec: Vec<f64> = vec![0.01; obs_times.len()];
+
+            let pts = solve_ekf(
+                &time_reading_rhs(slot, 0.05),
+                1,
+                0,
+                &[0.01],
+                &pk,
+                &Default::default(),
+                &[],
+                &doses,
+                &obs_times,
+                &r_obs_vec,
+                OdeSolverOptions::default(),
+            );
+
+            assert_eq!(pts.len(), obs_times.len(), "{name}: wrong point count");
+            for (j, pt) in pts.iter().enumerate() {
+                // `is_finite` before anything else: a `NaN` compared with `<` or folded
+                // through `f64::max` silently reads as "in range".
+                assert!(
+                    pt.p_obs.is_finite(),
+                    "{name}: p_obs[{j}] = {} — the anchor slot is still absent",
+                    pt.p_obs
+                );
+                assert!(
+                    pt.p_obs > 0.0,
+                    "{name}: p_obs[{j}] = {} — a non-positive variance would also be \
+                     produced by an EKF that never propagated, so assert the positive",
+                    pt.p_obs
+                );
+                assert!(
+                    pt.ipred.is_finite() && pt.ipred > 0.0,
+                    "{name}: ipred[{j}] = {} — drug is present at every one of these times",
+                    pt.ipred
+                );
+            }
+        }
+    }
+
+    /// The discriminator for the test above: with the modulation coefficient at zero the
+    /// builtin contributes nothing, so the walk must be **bit-identical** to the plain
+    /// `one_cpt_rhs`. Before the fix this failed for the opposite reason to the usual one
+    /// — `0.0 * NaN` is `NaN`, so merely *mentioning* the builtin destroyed the run.
+    #[test]
+    fn a_zero_coefficient_model_time_term_is_bit_identical_to_omitting_it() {
+        let doses = vec![
+            bolus_dose(100.0),
+            DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+        ];
+        let obs_times = vec![2.0, 4.0, 8.0, 24.0];
+        let pk = make_pk(1.0, 20.0);
+        let r_obs_vec: Vec<f64> = vec![0.01; obs_times.len()];
+        let run = |rhs: &(dyn Fn(&[f64], &[f64], f64, &mut [f64]) + Send + Sync)| {
+            solve_ekf(
+                rhs,
+                1,
+                0,
+                &[0.01],
+                &pk,
+                &Default::default(),
+                &[],
+                &doses,
+                &obs_times,
+                &r_obs_vec,
+                OdeSolverOptions::default(),
+            )
+        };
+        let plain = run(&one_cpt_rhs);
+        for slot in [crate::types::MAX_PK_PARAMS, crate::types::MAX_PK_PARAMS + 1] {
+            let zero_coef = run(&time_reading_rhs(slot, 0.0));
+            for (j, (a, b)) in zero_coef.iter().zip(plain.iter()).enumerate() {
+                assert_eq!(
+                    a.ipred.to_bits(),
+                    b.ipred.to_bits(),
+                    "slot {slot}: ipred[{j}] {} vs {}",
+                    a.ipred,
+                    b.ipred
+                );
+                assert_eq!(
+                    a.p_obs.to_bits(),
+                    b.p_obs.to_bits(),
+                    "slot {slot}: p_obs[{j}] {} vs {}",
+                    a.p_obs,
+                    b.p_obs
+                );
+            }
+        }
+    }
+
+    /// The **value** oracle for #1131, and the strongest one available: with the diffusion
+    /// variance at zero the EKF's mean walk reduces to the ordinary ODE integration, so
+    /// `solve_ekf`'s `ipred` must equal `ode_predictions`' — on a TAD- and a TAFD-reading
+    /// RHS, the exact models the bare-slice defect destroyed.
+    ///
+    /// Both engines call `predictions::tad_anchor_for` after this fix, so this test cannot
+    /// observe a wrong *anchor rule* shared by both — that is what the NONMEM anchors in
+    /// `nonmem_anchor/` are for. What it does observe is the defect that was actually there:
+    /// the EKF passing a slice too short for the RHS to read the slot at all. Deleting
+    /// either the `seed_ext_params` call or the per-segment anchor write in `solve_ekf`
+    /// turns the EKF column into the `0.0` clamp while the ODE column stays correct.
+    ///
+    /// A third reference, independent of both engines, keeps them from agreeing on a wrong
+    /// answer. For `dA/dt = -ke·A·(1 + c·u)` the exponent integrates in closed form:
+    /// with `u = TAD` the clock restarts at each arrival, with `u = TAFD` it does not, so
+    /// the two slots have *different* closed forms after the second dose — a fixture that
+    /// plumbed one slot into both would fail here.
+    #[test]
+    fn ekf_matches_the_ode_twin_and_a_closed_form_on_a_model_time_rhs() {
+        use crate::ode::predictions::{ode_predictions, OdeSpec};
+        use crate::types::Subject;
+        use std::collections::HashMap;
+
+        let (cl, v) = (1.0f64, 20.0f64);
+        let ke = cl / v;
+        let c = 0.05f64;
+        // Two doses: after a single dose TAD ≡ TAFD, so a one-dose fixture agrees with an
+        // engine that plumbed one slot into both.
+        let (t2, amt) = (12.0f64, 100.0f64);
+        let doses = vec![
+            DoseEvent::new(0.0, amt, 1, 0.0, false, 0.0),
+            DoseEvent::new(t2, amt, 1, 0.0, false, 0.0),
+        ];
+        // Samples straddle the second dose, so the post-dose leg — where the two clocks
+        // disagree — is actually scored.
+        let obs_times = vec![2.0, 8.0, 14.0, 24.0];
+        let pk = make_pk(cl, v);
+        let opts = OdeSolverOptions {
+            abstol: 1e-12,
+            reltol: 1e-10,
+            ..OdeSolverOptions::default()
+        };
+
+        // ∫ (1 + c·u) over the leg, with `u` measured from `anchor`.
+        let phase = |t_from: f64, t_to: f64, anchor: f64| -> f64 {
+            let (a, b) = (t_from - anchor, t_to - anchor);
+            (b - a) + c * (b * b - a * a) / 2.0
+        };
+        // `TAD` restarts at `t2`; `TAFD` keeps running from the first dose.
+        let closed_form = |t: f64, restarts: bool| -> f64 {
+            if t < t2 {
+                amt * (-ke * phase(0.0, t, 0.0)).exp()
+            } else {
+                let at_t2 = amt * (-ke * phase(0.0, t2, 0.0)).exp();
+                let anchor = if restarts { t2 } else { 0.0 };
+                (at_t2 + amt) * (-ke * phase(t2, t, anchor)).exp()
+            }
+        };
+
+        for (name, slot, restarts) in [
+            ("TAFD", crate::types::MAX_PK_PARAMS, false),
+            ("TAD", crate::types::MAX_PK_PARAMS + 1, true),
+        ] {
+            let rhs = time_reading_rhs(slot, c);
+            let ekf_pts = solve_ekf(
+                &rhs,
+                1,
+                0,
+                &[0.0], // zero diffusion: the mean walk reduces to plain integration
+                &pk,
+                &Default::default(),
+                &[],
+                &doses,
+                &obs_times,
+                &vec![0.01; obs_times.len()],
+                opts,
+            );
+
+            let subj = Subject {
+                id: "1".into(),
+                doses: doses.clone(),
+                obs_times: obs_times.clone(),
+                obs_raw_times: Vec::new(),
+                observations: vec![0.0; obs_times.len()],
+                obs_cmts: vec![1; obs_times.len()],
+                covariates: HashMap::new(),
+                dose_covariates: Vec::new(),
+                obs_covariates: Vec::new(),
+                pk_only_times: Vec::new(),
+                pk_only_covariates: Vec::new(),
+                reset_times: Vec::new(),
+                reset_covariates: Vec::new(),
+                cens: vec![0; obs_times.len()],
+                occasions: Vec::new(),
+                obs_l2: Vec::new(),
+                dose_occasions: Vec::new(),
+                reset_occasions: Vec::new(),
+                fremtype: Vec::new(),
+                obs_records: vec![],
+            };
+            let ode_spec = OdeSpec {
+                chz_state_slots: Vec::new(),
+                rhs: Box::new(time_reading_rhs(slot, c)),
+                n_states: 1,
+                state_names: vec!["central".into()],
+                readout: crate::ode::OdeReadout::ObsCmt(0),
+                diffusion_var: Vec::new(),
+                init_fn: None,
+                solver_opts: opts,
+                input_rate: Vec::new(),
+                rhs_program: None,
+                readout_program: None,
+                indiv_param_program: None,
+                dose_attr_map: Default::default(),
+            };
+            let ode_preds = ode_predictions(&ode_spec, &pk, &[], &[], &subj);
+
+            for (j, &t) in obs_times.iter().enumerate() {
+                let want = closed_form(t, restarts);
+                let (ekf, ode) = (ekf_pts[j].ipred, ode_preds[j]);
+                // `is_finite` first: a `NaN` compared with `<` reads as "in range", and the
+                // `0.0` clamp in the assimilate branch would otherwise be judged only by
+                // the relative check below.
+                assert!(
+                    ekf.is_finite() && ode.is_finite(),
+                    "{name}: non-finite at t={t} — ekf {ekf}, ode {ode}"
+                );
+                assert!(
+                    ekf > 0.0,
+                    "{name}: ekf ipred at t={t} is {ekf} — the `is_nan()` clamp reports a \
+                     poisoned walk as 0.0, which is exactly the #1131 signature"
+                );
+                assert_relative_eq!(ekf, ode, epsilon = 1e-6, max_relative = 1e-6);
+                assert_relative_eq!(ekf, want, epsilon = 1e-6, max_relative = 1e-6);
+            }
+        }
+
+        // The straddle: assert the two clocks actually disagree on this fixture, so the
+        // loop above cannot quietly become the same assertion twice.
+        let (tad_24, tafd_24) = (closed_form(24.0, true), closed_form(24.0, false));
+        assert!(
+            (tad_24 - tafd_24).abs() / tad_24 > 0.1,
+            "TAD and TAFD must differ materially after the second dose \
+             ({tad_24:.6} vs {tafd_24:.6}) or this fixture cannot tell the slots apart"
+        );
     }
 
     /// #1226 on the EKF walk: an observation **one ULP after** a dose record is read

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -2356,14 +2356,31 @@ fn tad_anchor(subject: &Subject, dose_lagtimes: &[f64], t_start: f64) -> f64 {
 /// (segment start, and the pre/post sides of a saltation) — and three of them disagree
 /// on `(t_dose = 120, ALAG = 3, II = 12, t = 121)`, returning `-2.0`, `NaN` and `+1.0`.
 /// A seventh was not worth adding for the sake of a `&Subject` this engine does not have.
+///
+/// `dose_lagtimes` may be **shorter than `doses`, including empty** — a missing entry is
+/// zero lag, matching [`active_infusions`] and `api::output_columns::tad_at_time`. An
+/// engine with no lagtime concept passes `&[]`.
+///
+/// **The `ss` branch describes a periodic pulse train.** It folds the elapsed time into
+/// `[0, II)` as though virtual doses had arrived at `t_dose + k·II`, so a caller whose
+/// state was *not* built from such a train gets an anchor its own dose history does not
+/// justify — measured on #1263 as a 24.1% `ipred` divergence for one `SS=1` infusion
+/// whose end break lands past a virtual pulse. Callers that do not equilibrate an `SS`
+/// dose must warn (`W_SDE_STEADY_STATE`) rather than quietly consume this.
 #[inline]
 pub(crate) fn tad_anchor_for(doses: &[DoseEvent], dose_lagtimes: &[f64], t_start: f64) -> f64 {
+    // `.get(..).unwrap_or(0.0)`, not `dose_lagtimes[i]`: a short slice means "no lag on
+    // the remaining doses", which is what `active_infusions` (`:1520`) and
+    // `api::output_columns::tad_at_time` already spell, and it lets a caller with no
+    // lagtime concept at all pass `&[]` instead of allocating a zero-filled vector whose
+    // only job is to satisfy a length invariant enforced by a panic (#1263 review).
+    let lag_at = |i: usize| dose_lagtimes.get(i).copied().unwrap_or(0.0);
     let last_dose_eff = doses
         .iter()
         .enumerate()
-        .filter(|(i, d)| d.time + dose_lagtimes[*i] <= t_start + 1e-12)
+        .filter(|(i, d)| d.time + lag_at(*i) <= t_start + 1e-12)
         .map(|(i, d)| {
-            let lag = dose_lagtimes[i];
+            let lag = lag_at(i);
             if d.ss && d.ii > 0.0 {
                 let elapsed = t_start - (d.time + lag);
                 t_start - elapsed.rem_euclid(d.ii)
@@ -2381,7 +2398,7 @@ pub(crate) fn tad_anchor_for(doses: &[DoseEvent], dose_lagtimes: &[f64], t_start
     let first_arrival = doses
         .iter()
         .enumerate()
-        .map(|(i, d)| d.time + dose_lagtimes[i])
+        .map(|(i, d)| d.time + lag_at(i))
         .fold(f64::INFINITY, f64::min);
     if first_arrival.is_finite() {
         first_arrival

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -2342,8 +2342,23 @@ fn clamp_negative_predictions(readout: &OdeReadout, predictions: &mut [f64]) {
 /// (the pre-existing answer, and the sdtab convention, for that case).
 #[inline]
 fn tad_anchor(subject: &Subject, dose_lagtimes: &[f64], t_start: f64) -> f64 {
-    let last_dose_eff = subject
-        .doses
+    tad_anchor_for(&subject.doses, dose_lagtimes, t_start)
+}
+
+/// The dose-list body of [`tad_anchor`]. Split out so an engine that holds only a
+/// `&[DoseEvent]` — the EKF (`crate::ode::ekf::solve_ekf`), which has no `Subject` —
+/// anchors `TAD` by the same rule as the two ODE predictors instead of growing yet
+/// another spelling of it (#1131).
+///
+/// There are already at least six in the tree — this function, the inline duplicate
+/// further down this file, `api::output_columns::tad_at_time`, the lag-ignoring sdtab
+/// fallback in `io::output`, and the dual walk's own anchors in `sens::ode_provider`
+/// (segment start, and the pre/post sides of a saltation) — and three of them disagree
+/// on `(t_dose = 120, ALAG = 3, II = 12, t = 121)`, returning `-2.0`, `NaN` and `+1.0`.
+/// A seventh was not worth adding for the sake of a `&Subject` this engine does not have.
+#[inline]
+pub(crate) fn tad_anchor_for(doses: &[DoseEvent], dose_lagtimes: &[f64], t_start: f64) -> f64 {
+    let last_dose_eff = doses
         .iter()
         .enumerate()
         .filter(|(i, d)| d.time + dose_lagtimes[*i] <= t_start + 1e-12)
@@ -2363,8 +2378,7 @@ fn tad_anchor(subject: &Subject, dose_lagtimes: &[f64], t_start: f64) -> f64 {
     // No dose has arrived yet. `fold` over an empty dose list leaves `+∞`, which is
     // the dose-free case and must read NaN rather than propagate as an infinite
     // anchor.
-    let first_arrival = subject
-        .doses
+    let first_arrival = doses
         .iter()
         .enumerate()
         .map(|(i, d)| d.time + dose_lagtimes[i])
@@ -2398,14 +2412,15 @@ fn subject_dose_attrs(
     (dose_lagtimes, dose_f_bio)
 }
 
-/// Earliest dose record time, or `+∞` when the subject has no doses.
+/// Earliest dose record time, or `+∞` when there are no doses.
+///
+/// Takes the dose list rather than the `Subject` so the EKF
+/// (`crate::ode::ekf::solve_ekf`), which has no `Subject`, seeds its TAFD anchor from this
+/// function instead of re-spelling the fold — the same reason [`tad_anchor_for`] exists.
+/// `seed_ext_params` maps the dose-free `+∞` to `NaN`, so callers pass this straight through.
 #[inline]
-fn earliest_dose_time(subject: &Subject) -> f64 {
-    subject
-        .doses
-        .iter()
-        .map(|d| d.time)
-        .fold(f64::INFINITY, f64::min)
+pub(crate) fn earliest_dose_time(doses: &[DoseEvent]) -> f64 {
+    doses.iter().map(|d| d.time).fold(f64::INFINITY, f64::min)
 }
 
 /// Lower the reactive driver's TAFD anchor (`ext_params[MAX_PK_PARAMS]`) to `t` if `t`
@@ -2428,7 +2443,7 @@ fn update_tafd_anchor(ext_params: &mut [f64], t: f64) {
 /// dose time, NaN when there are no doses so the RHS injects NaN rather than `-∞`);
 /// slot `MAX_PK_PARAMS + 1` (TAD) is left NaN for the per-segment update.
 #[inline]
-fn seed_ext_params(
+pub(crate) fn seed_ext_params(
     pk_params_flat: &[f64],
     first_dose_time: f64,
 ) -> [f64; crate::types::MAX_PK_PARAMS + 2] {
@@ -3171,7 +3186,7 @@ fn ode_predictions_with_extra_breaks_and_stats(
 
     // Extended params: slots 0..MAX_PK_PARAMS hold the PK parameters; slots
     // MAX_PK_PARAMS and MAX_PK_PARAMS+1 carry TAFD/TAD anchors for the ODE RHS.
-    let first_dose_time = earliest_dose_time(subject);
+    let first_dose_time = earliest_dose_time(&subject.doses);
     let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     // Build obs_time → indices map. Multiple observations can share a time
@@ -4123,7 +4138,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
     let copy_n = pk_params_flat.len().min(crate::types::MAX_PK_PARAMS);
     ext_params[..copy_n].copy_from_slice(&pk_params_flat[..copy_n]);
     ext_params[crate::types::MAX_PK_PARAMS] = if n_base > 0 {
-        earliest_dose_time(&shadow)
+        earliest_dose_time(&shadow.doses)
     } else {
         f64::NAN
     };
@@ -5212,7 +5227,7 @@ fn adaptive_frozen_replay_tv(
     // NB: PK slots are left NaN here (unlike `seed_ext_params`) — the replay
     // overwrites them per-segment from each event's own snapshot before integrating.
     let mut ext_params = [f64::NAN; crate::types::MAX_PK_PARAMS + 2];
-    let first_dose_time = earliest_dose_time(subject);
+    let first_dose_time = earliest_dose_time(&subject.doses);
     ext_params[crate::types::MAX_PK_PARAMS] = if first_dose_time.is_finite() {
         first_dose_time
     } else {
@@ -6366,7 +6381,7 @@ pub fn ode_predictions_with_states(
     // this no-TV path, where every dose reads the same `pk_params_flat`.
     let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
-    let first_dose_time = earliest_dose_time(subject);
+    let first_dose_time = earliest_dose_time(&subject.doses);
     let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     let obs_map = build_obs_index_map(&subject.obs_times);
@@ -6956,7 +6971,7 @@ pub fn ode_dense_solve_states(
     // this no-TV path, where every dose reads the same `pk_params_flat`.
     let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
-    let first_dose_time = earliest_dose_time(subject);
+    let first_dose_time = earliest_dose_time(&subject.doses);
     let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     // Build saveat → index map for fast lookup.
@@ -7199,7 +7214,7 @@ pub(crate) fn ode_solve_until_chz_threshold(
 
     let (dose_lagtimes, dose_f_bio) = subject_dose_attrs(subject, ode, pk_params_flat);
 
-    let first_dose_time = earliest_dose_time(subject);
+    let first_dose_time = earliest_dose_time(&subject.doses);
     let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
 
     // Zero-order windows, reused for the break points and the per-segment injection


### PR DESCRIPTION
## Why

Two defects, one root cause, found while measuring the batch-T plan (#1258).

**#1131** — an `[odes]` right-hand side that reads `TAD` or `TAFD` destroys the objective on a
`[diffusion]` (SDE / extended-Kalman-filter) model. The compiled RHS reads the two model-time
anchors out of `params[MAX_PK_PARAMS]` and `params[MAX_PK_PARAMS + 1]`; `solve_ekf` was handed a
bare `PkParams::values`, which is exactly `MAX_PK_PARAMS` long. Both `.get()` calls returned
`None`, the RHS injected `NaN`, and the `NaN` multiplied into the state and the Jacobian.

The issue reports "`ipred = 0`". Measured at `579d1e96`, that is no longer the symptom — the
sdtab `IPRED` column is *correct* (`87.809543 / 72.614904 / 41.478291 / 22.110924`), because
`stats/likelihood.rs:892` takes `let (_, p_obs) = ...` and discards the EKF mean entirely. What
is broken is the objective: **`OFV = 2e20`** (the diverged-subject sentinel) against
**`94.7893`** for the same model with the `TAD` term dropped. So an assertion on `ipred` is
vacuously green, and every test here asserts `p_obs` or the objective instead.

**#1259** — the #1131 reproducer has no random effects, so its 0×0 OMEGA reaches
`extract_eigenvalues` through the covariance step's non-finite-objective *diagnostic*, and
`nalgebra` panics: `Unable to compute the symmetric tridiagonal decomposition of an empty
matrix`. Both conjuncts are required, measured: `n_eta = 1` + non-finite gives `2e20` and no
panic; `n_eta = 0` + finite is fine; `n_eta = 0` + non-finite panics. It rides here because
without it the #1131 fix cannot be observed on #1131's own model.

## What changed

- `ode/predictions.rs` — `tad_anchor`'s dose-list body split out as `tad_anchor_for(&[DoseEvent], &[f64], f64)`,
  and `seed_ext_params` made `pub(crate)`. The EKF holds no `Subject`, so without this it would
  have grown a **seventh** spelling of the TAD rule. The six already in the tree: `tad_anchor`
  itself, the inline duplicate at `predictions.rs:5947`, `api::output_columns::tad_at_time`,
  the lag-ignoring sdtab fallback at `io/output.rs:1355`, and the dual walk's segment-start and
  saltation anchors in `sens/ode_provider.rs`. Three of them disagree on
  `(t_dose = 120, ALAG = 3, II = 12, t = 121)`, returning `-2.0`, `NaN` and `+1.0`.
- `ode/ekf.rs` — `solve_ekf` builds the same extended array the ODE predictors build, and
  re-anchors the `TAD` slot per dose segment. The anchor write is placed **before** the segment
  integrates: `apply_segment_boundary` compiles either way and writes its own anchor *after* the
  SS call, so a write in the wrong position reads the previous segment's anchor without failing
  to compile. Two integration sites take the extended array (the `solve_ode` call and
  `propagate_covariance`); `dose_f_bio` keeps the bare slice, since `PK_IDX_F` is below
  `MAX_PK_PARAMS`.
- `estimation/covariance.rs` — `extract_eigenvalues` returns `None` on an empty matrix, so the
  caller reports the non-finite objective as the reason, which is what the diagnostic exists to
  say. The doc comment records that the empty case is reachable, not defensive. The guard is
  **one** predicate (`sym.is_empty()`), not `nrows() == 0 || ncols() == 0`: for this input those
  two reject exactly the same matrices, so either could be deleted with the new test still
  green — the redundant-gate hole from #1229 / #1255. It was written the redundant way first
  and caught on a re-read of this diff.

No behaviour change for a model whose RHS reads neither builtin — pinned by a `to_bits()`
equality test, not a tolerance.

## Alternatives considered

Anchoring `TAFD` at 0 inside `solve_ekf` rather than plumbing the real array. Rejected on
measurement: it yields a finite, plausible number for a quantity whose value has not converged,
which is the same class of silent wrong answer the fix is removing (#1258, finding 4).

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public-API change; `tools/update-public-api.sh --check` reports the baseline unchanged.

## Breaking changes
- [x] None

## Numerical validation

NONMEM has no extended Kalman filter, so there is no NONMEM run for an SDE `p_obs`. The oracle
is the **ODE twin as the diffusion variance goes to zero**, plus a closed form computed outside
both engines so the two cannot agree on a wrong answer.

- [x] Compared against: prior ferx commit `579d1e96`, and an ODE twin + closed form

```
# model: d/dt(central) = -(CL/V)*central*(1.0 + KTAD*TAD),  CL=1, V=20, KTAD=0.3
#        doses at t=0 and t=12; maxiter=0; ode_reltol=1e-10

# before (579d1e96)
[diffusion] central ~ 0.01     OFV = 200000000000000032768.0000    <- 2e20 sentinel
[diffusion] central ~ 1e-14    OFV = 200000000000000032768.0000
no [diffusion]                 OFV = 14.7016

# after
[diffusion] central ~ 0.01     OFV = 14.7043
[diffusion] central ~ 1e-14    OFV = 14.7016   == the ODE twin, exactly
no [diffusion]                 OFV = 14.7016

# control — an RHS reading neither builtin, unchanged either side
[diffusion] central ~ 0.01     OFV = 94.7893   (before and after)

# #1259 — same model, no omega declarations
before: thread panicked, "Unable to compute the symmetric tridiagonal decomposition
        of an empty matrix"
after:  reported as OFV: NaN with the non-finite-objective reason
```

## Performance
- [x] No significant impact expected — one `Vec` of length `MAX_PK_PARAMS + 2` per subject solve,
      and one `f64` write per dose segment.

## Tests
- [x] Unit test(s) added in the same module
- [x] Regression test added that fails without this fix

Three in `ode/ekf.rs`, one in `estimation/outer_optimizer_tests.rs`:

| test | what it pins |
|---|---|
| `time_reading_rhs_gets_finite_anchors_on_the_ekf_walk` | `p_obs` finite **and positive** for both slots, looped over `TAFD` and `TAD` separately |
| `a_zero_coefficient_model_time_term_is_bit_identical_to_omitting_it` | the discriminator — `0.0 * NaN` is `NaN`, so before the fix merely *mentioning* a builtin broke the run; `to_bits()` equality |
| `ekf_matches_the_ode_twin_and_a_closed_form_on_a_model_time_rhs` | the value oracle — EKF ≡ `ode_predictions` at zero diffusion, **and** ≡ a closed form computed outside both |
| `test_extract_eigenvalues_none_on_empty_matrix` | `None` on 0×0, with the measured two-conjunct condition recorded |

**Mutation-checked, each side named separately** (the #1223 lesson — a twin whose second leg
never runs is an assertion against a constant):

| mutation | result |
|---|---|
| M1 — revert the `solve_ode` site to `pk_params_flat` | all three EKF tests RED |
| M2 — delete the per-segment `TAD` anchor write | RED, message names `TAD` at `t=2` |
| M3 — make the **shared** `tad_anchor_for` return the first dose time (TAD ≡ TAFD) | RED **only on the closed form** (`left = 123.657…`, `right = 131.304…`); the twin comparison passes, because both engines take the wrong rule together |

M3 is the one worth reading: it is exactly the failure a two-engine oracle cannot see, and it
is why the third reference is in the test rather than in the PR description.

Two fixtures deliberately carry **two doses**, at `t = 0` and `t = 12`. Under a single dose
`TAD ≡ TAFD`, so a one-dose fixture agrees with an engine that plumbed one slot into both. The
twin test asserts that straddle explicitly (`TAD` and `TAFD` must differ by >10% at `t = 24`)
so it cannot quietly decay into the same assertion twice.

**No `Dual2`-vs-FD parity test is possible here.** The SDE path does not support analytic
gradients at all (`gradient_method = fd` is required — see `docs/model-file/diffusion.qmd`), so
there is no dual twin of `solve_ekf` to compare against. Stated rather than omitted.

## Example (user-facing features only)
- [x] Example added inline, and to `docs/model-file/diffusion.qmd`

## Docs
- [x] `docs/` updated — new **Model-time builtins in the RHS** section in
      `docs/model-file/diffusion.qmd`, which previously mentioned neither `TAD` nor `TAFD`.
      `cargo run -p docs-lint -- --check` green.
- [x] No new pages, so `docs/_quarto.yml` is unchanged
- [x] `CHANGELOG.md` `[Unreleased]` entry added (two bullets, under `### Fixed`)

## Checklist
- [x] `tools/preflight.sh` green — `preflight OK — fmt check clippy rustdoc docs public-api`
- [x] Gradient-reachable code untouched — `sens/` is not on this path
- [x] No version bump needed

## Docs & examples
- [x] No example execution step needed — no `examples/*.ferx` or `data/` file is affected, and
      no `.ferx` DSL syntax or `[fit_options]` key is added

## Reviewer hints

The subtle part is **where** the per-segment anchor write sits, not what it computes. It must
precede the segment's `solve_ode`; placing it after compiles cleanly and silently reads the
previous segment's anchor. `ode/predictions.rs:6884` is the existing instance of exactly that
ordering hazard.

Worth a second pair of eyes: `no_lag`. The EKF path applies no lagtime anywhere — `dose_f_bio`
reads only `f_bio`, and `active_infusions` is called with empty lag slices — so feeding
`tad_anchor_for` a zero-filled lag vector matches what the rest of the function already assumes.
If the EKF ever gains lagtime support, that vector is the thing to change, and it is commented
as such.

## Open questions

None blocking. Three adjacent findings are filed rather than folded in: #1260 (the EKF ignores
`SS` records — measured at 120.5 OFV on a nonlinear model), #1261 (the same bare-slice defect on
the survival hazard readout — `2e20` vs `41164.7786`), and #1262 (NONMEM's constant-infusion
steady state is unimplemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
