### PR TITLE
fix(tools): seed a child off a near-singular omega block, and say why every start failed [refs #1256]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ section of the SDLC for the versioning policy).
   to read. No effect on `.ferx` models, the CLI or the R wrapper, none of which constructs it.
 
 ### Fixed
+- **A search child seeded from a parent whose ω block is near-singular can start (#1256).** On
+  the vancomycin base the (CL, V1, V2) block's Cholesky diagonal for `ETA_V2` sat on the
+  optimizer's rail (6e-6) through its correlations, every declared variance being ordinary; the
+  three-compartment candidate seeded from it was refused by every start. The shared seed now
+  nudges such a block by `1e-5·I` until its factor clears the rail, alongside the diagonal floor.
+- **"All multi-start fits failed" now carries each start's reason** (`start 0: …; start 1: …`),
+  so a search table says *why* a candidate never fitted — a refused start is a different repair
+  from a diverged fit.
 - **`ferx modelsearch` never selects the input model (#1181).** The input has a row of its own
   only when a base had to be derived from it — which happens exactly when its structure lies
   outside the space the MFL declares — so it is ranked in the table but excluded from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@ section of the SDLC for the versioning policy).
   the vancomycin base the (CL, V1, V2) block's Cholesky diagonal for `ETA_V2` sat on the
   optimizer's rail (6e-6) through its correlations, every declared variance being ordinary; the
   three-compartment candidate seeded from it was refused by every start. The shared seed now
-  nudges such a block by `1e-5·I` until its factor clears the rail, alongside the diagonal floor.
+  nudges that block alone by `1e-5·I` until its factor clears the rail, alongside the diagonal
+  floor; a standalone ω beside it and a `FIX`ed block are untouched, and a block that cannot be
+  repaired within the bound goes through verbatim.
 - **"All multi-start fits failed" now carries each start's reason** (`start 0: …; start 1: …`),
   so a search table says *why* a candidate never fitted — a refused start is a different repair
   from a diverged fit.

--- a/crates/ferx-tools/src/search/seed.rs
+++ b/crates/ferx-tools/src/search/seed.rs
@@ -35,29 +35,67 @@ pub(crate) const MIN_SEED_VARIANCE: f64 = 1e-5;
 /// The floored variance is the same no-variability model the parent found —
 /// spelled so the child can move off it.
 pub(crate) fn seed_from(model: &mut ModelText, fit: &FitResult) -> Result<(), String> {
-    let floored = floor_variances(fit);
+    let blocks = free_blocks_of(model, &fit.eta_names);
+    let floored = floor_variances(fit, &blocks);
     model.apply(ModelEdit::SeedInits(floored.as_ref().unwrap_or(fit)))
 }
 
-/// How many times a near-singular ω may be nudged by `MIN_SEED_VARIANCE·I`
-/// before the seed gives up and hands the parent's ω through verbatim (so
-/// the engine's own message names the block).
+/// How many times a near-singular block may be nudged by `MIN_SEED_VARIANCE·I`
+/// before the seed gives up on it and hands the parent's block through
+/// verbatim (so the engine's own message names the block).
 const MAX_NUDGES: usize = 16;
+
+/// The η indices of every `block_omega` the model declares **free** — a
+/// `FIX`ed block is a statement about the model, which `SeedInits` leaves
+/// alone and the engine exempts from the rail, so it is never nudged and
+/// never a reason to touch anything else. A block naming an η the fit does
+/// not carry is skipped too: there is nothing to seed it from.
+fn free_blocks_of(model: &ModelText, eta_names: &[String]) -> Vec<Vec<usize>> {
+    let mut blocks = Vec::new();
+    for line in model.block_lines("parameters") {
+        let Some(rest) = line.strip_prefix("block_omega") else {
+            continue;
+        };
+        if rest
+            .split(|c: char| !c.is_alphanumeric())
+            .any(|tok| tok.eq_ignore_ascii_case("FIX"))
+        {
+            continue;
+        }
+        let Some((_, inner)) = rest.split_once('(') else {
+            continue;
+        };
+        let Some((names, _)) = inner.split_once(')') else {
+            continue;
+        };
+        let idx: Option<Vec<usize>> = names
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|name| eta_names.iter().position(|n| n == name))
+            .collect();
+        if let Some(idx) = idx.filter(|i| i.len() > 1) {
+            blocks.push(idx);
+        }
+    }
+    blocks
+}
 
 /// `fit` with its ω made startable, or `None` when it already was — the
 /// common case, and the one that costs no clone.
 ///
 /// Two things put an ω on the rail. A collapsed **diagonal** (`ω_kk ≤ e⁻¹²`)
-/// is raised to the floor. A **block** whose correlations make it
+/// is raised to the floor. A free **block** whose correlations make it
 /// near-singular — the #1256 vancomycin case, where every declared variance
 /// is ordinary but the Cholesky diagonal for `ETA_V2` is what is left of its
-/// variance after the covariances, 6.1e-6 — is nudged by `δ·I`, δ the same
-/// floor: for a positive-semidefinite ω every Schur complement of `ω + δI`
-/// is at least δ, so one nudge lifts every Cholesky diagonal above the rail
-/// while moving the declared variances by a part in 10⁵ of the floor. A
-/// fitted ω that is slightly *indefinite* in the last digits may need more
-/// than one; the loop is bounded and, past it, the seed is verbatim.
-fn floor_variances(fit: &FitResult) -> Option<FitResult> {
+/// variance after the covariances, 6.1e-6 — is nudged by `δ·I` **on that
+/// block alone**, δ the same floor: for a positive-semidefinite block every
+/// Schur complement of `ω + δI` is at least δ, so one nudge lifts every
+/// Cholesky diagonal above the rail while moving the block's variances by
+/// the floor and nothing outside the block at all. A fitted block that is
+/// slightly *indefinite* in the last digits may need more than one; the
+/// loop is bounded and, past the bound, the block goes through verbatim.
+fn floor_variances(fit: &FitResult, blocks: &[Vec<usize>]) -> Option<FitResult> {
     let n = fit.omega.nrows();
     let mut omega = fit.omega.clone();
     let mut changed = false;
@@ -68,16 +106,35 @@ fn floor_variances(fit: &FitResult) -> Option<FitResult> {
             changed = true;
         }
     }
-    // The block check is on the whole matrix: outside a block ω is diagonal,
-    // so its Cholesky diagonals are the per-block ones and the floored
-    // variances above.
-    let mut nudges = 0;
-    while nudges < MAX_NUDGES && !cholesky_above_rail(&omega) {
-        for k in 0..n {
-            omega[(k, k)] += MIN_SEED_VARIANCE;
+    for block in blocks {
+        if block.iter().any(|&k| k >= n) {
+            continue;
         }
-        changed = true;
-        nudges += 1;
+        let mut sub = omega.select_rows(block).select_columns(block);
+        let mut nudges = 0;
+        while nudges < MAX_NUDGES && !cholesky_above_rail(&sub) {
+            for k in 0..sub.nrows() {
+                sub[(k, k)] += MIN_SEED_VARIANCE;
+            }
+            nudges += 1;
+        }
+        if nudges == 0 {
+            continue;
+        }
+        if cholesky_above_rail(&sub) {
+            for (a, &ia) in block.iter().enumerate() {
+                omega[(ia, ia)] = sub[(a, a)];
+            }
+            changed = true;
+        } else {
+            // Exhausted: the parent's block, verbatim — not sixteen nudges
+            // that still do not start. The engine's message then names it.
+            for &ia in block {
+                for &ib in block {
+                    omega[(ia, ib)] = fit.omega[(ia, ib)];
+                }
+            }
+        }
     }
     if !changed {
         return None;

--- a/crates/ferx-tools/src/search/seed.rs
+++ b/crates/ferx-tools/src/search/seed.rs
@@ -27,34 +27,94 @@ pub(crate) const MIN_SEED_VARIANCE: f64 = 1e-5;
 
 /// Carry `fit`'s estimates into `model` as a **child's** starting values:
 /// [`ModelEdit::SeedInits`], with every ω diagonal raised to
-/// [`MIN_SEED_VARIANCE`] so a parent whose η collapsed still yields a model
-/// the engine will start.
+/// [`MIN_SEED_VARIANCE`] and every ω block regularised so its Cholesky
+/// diagonal is above the rail too — a parent whose η collapsed, on its own
+/// or through a block's correlations, still yields a model the engine will
+/// start.
 ///
-/// Raising only the diagonal keeps a block positive-definite, and the floored
-/// variance is the same no-variability model the parent found — spelled so
-/// the child can move off it.
+/// The floored variance is the same no-variability model the parent found —
+/// spelled so the child can move off it.
 pub(crate) fn seed_from(model: &mut ModelText, fit: &FitResult) -> Result<(), String> {
     let floored = floor_variances(fit);
     model.apply(ModelEdit::SeedInits(floored.as_ref().unwrap_or(fit)))
 }
 
-/// `fit` with its ω diagonal floored, or `None` when nothing was below the
-/// floor — the common case, and the one that costs no clone.
+/// How many times a near-singular ω may be nudged by `MIN_SEED_VARIANCE·I`
+/// before the seed gives up and hands the parent's ω through verbatim (so
+/// the engine's own message names the block).
+const MAX_NUDGES: usize = 16;
+
+/// `fit` with its ω made startable, or `None` when it already was — the
+/// common case, and the one that costs no clone.
+///
+/// Two things put an ω on the rail. A collapsed **diagonal** (`ω_kk ≤ e⁻¹²`)
+/// is raised to the floor. A **block** whose correlations make it
+/// near-singular — the #1256 vancomycin case, where every declared variance
+/// is ordinary but the Cholesky diagonal for `ETA_V2` is what is left of its
+/// variance after the covariances, 6.1e-6 — is nudged by `δ·I`, δ the same
+/// floor: for a positive-semidefinite ω every Schur complement of `ω + δI`
+/// is at least δ, so one nudge lifts every Cholesky diagonal above the rail
+/// while moving the declared variances by a part in 10⁵ of the floor. A
+/// fitted ω that is slightly *indefinite* in the last digits may need more
+/// than one; the loop is bounded and, past it, the seed is verbatim.
 fn floor_variances(fit: &FitResult) -> Option<FitResult> {
-    let below: Vec<usize> = (0..fit.omega.nrows())
-        .filter(|k| {
-            let v = fit.omega[(*k, *k)];
-            v.is_finite() && v < MIN_SEED_VARIANCE
-        })
-        .collect();
-    if below.is_empty() {
+    let n = fit.omega.nrows();
+    let mut omega = fit.omega.clone();
+    let mut changed = false;
+    for k in 0..n {
+        let v = omega[(k, k)];
+        if v.is_finite() && v < MIN_SEED_VARIANCE {
+            omega[(k, k)] = MIN_SEED_VARIANCE;
+            changed = true;
+        }
+    }
+    // The block check is on the whole matrix: outside a block ω is diagonal,
+    // so its Cholesky diagonals are the per-block ones and the floored
+    // variances above.
+    let mut nudges = 0;
+    while nudges < MAX_NUDGES && !cholesky_above_rail(&omega) {
+        for k in 0..n {
+            omega[(k, k)] += MIN_SEED_VARIANCE;
+        }
+        changed = true;
+        nudges += 1;
+    }
+    if !changed {
         return None;
     }
     let mut out = fit.clone();
-    for k in below {
-        out.omega[(k, k)] = MIN_SEED_VARIANCE;
-    }
+    out.omega = omega;
     Some(out)
+}
+
+/// The engine's rail on a packed Cholesky diagonal, as a variance:
+/// `ln(L) = −6`, i.e. `L² = e⁻¹²`. A start at or below it is refused
+/// (`api/validation.rs`).
+const RAIL_VARIANCE: f64 = 6.144_212_353_328_21e-6;
+
+/// The smallest Cholesky diagonal (squared) the block check accepts: the
+/// rail with headroom. Deliberately *below* [`MIN_SEED_VARIANCE`] — a block
+/// whose diagonals were just floored to 1e-5 and whose covariance is small
+/// has a Cholesky diagonal a hair under 1e-5, and is startable; nudging it
+/// again would move the declared variances for nothing.
+const MIN_CHOLESKY_VARIANCE: f64 = 8e-6;
+
+/// Whether `omega` has a Cholesky factor whose every diagonal entry, squared,
+/// is above the rail with headroom ([`MIN_CHOLESKY_VARIANCE`]). A matrix
+/// that is not positive-definite has no factor and fails too.
+fn cholesky_above_rail(omega: &nalgebra::DMatrix<f64>) -> bool {
+    debug_assert!(MIN_CHOLESKY_VARIANCE > RAIL_VARIANCE);
+    if omega.iter().any(|v| !v.is_finite()) {
+        // Nothing to regularise: `SeedInits` skips a non-finite entry.
+        return true;
+    }
+    match nalgebra::Cholesky::new(omega.clone()) {
+        Some(chol) => {
+            let l = chol.l();
+            (0..omega.nrows()).all(|k| l[(k, k)] * l[(k, k)] >= MIN_CHOLESKY_VARIANCE)
+        }
+        None => false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/ferx-tools/src/search/seed_tests.rs
+++ b/crates/ferx-tools/src/search/seed_tests.rs
@@ -180,5 +180,137 @@ fn seed_from_regularises_a_block_whose_cholesky_diagonal_is_at_the_rail() {
 fn seed_from_leaves_a_well_conditioned_block_alone() {
     let fit = fixture_fit();
     assert!(super::cholesky_above_rail(&fit.omega));
-    assert!(super::floor_variances(&fit).is_none());
+    let blocks = super::free_blocks_of(&warfarin_text(), &fit.eta_names);
+    assert!(blocks.is_empty(), "warfarin's ωs are diagonal");
+    assert!(super::floor_variances(&fit, &[vec![0, 1, 2]]).is_none());
+}
+
+/// The review on #1265: the nudge is scoped to the failing block. A
+/// near-singular `(ETA_CL, ETA_V)` block beside a healthy standalone
+/// `ETA_KA` at 2e-5: the block is nudged, `ETA_KA` is written verbatim.
+#[test]
+fn seed_from_nudges_only_the_failing_block_not_a_healthy_standalone_omega() {
+    let mut fit = fixture_fit();
+    let names = fit.eta_names.clone();
+    let cl = names.iter().position(|n| n == "ETA_CL").unwrap();
+    let v = names.iter().position(|n| n == "ETA_V").unwrap();
+    let ka = names.iter().position(|n| n == "ETA_KA").unwrap();
+    // (CL, V) = L Lᵀ with the second Cholesky diagonal on the rail.
+    let rail: f64 = 6.144_212_353_328_21e-6;
+    let (a, b, c) = (0.5f64, 0.3f64, rail.sqrt());
+    fit.omega[(cl, cl)] = a * a;
+    fit.omega[(cl, v)] = a * b;
+    fit.omega[(v, cl)] = a * b;
+    fit.omega[(v, v)] = b * b + c * c;
+    fit.omega[(ka, ka)] = 2e-5;
+    fit.omega[(ka, cl)] = 0.0;
+    fit.omega[(cl, ka)] = 0.0;
+    fit.omega[(ka, v)] = 0.0;
+    fit.omega[(v, ka)] = 0.0;
+
+    let src = std::fs::read_to_string(MODEL).unwrap();
+    let src = src.replace(
+        "omega ETA_CL ~ 0.09\n  omega ETA_V  ~ 0.04",
+        "block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.04]",
+    );
+    let mut model = ModelText::parse(&src).unwrap();
+    seed_from(&mut model, &fit).expect("seeding a child");
+    let params = model.block_lines("parameters");
+    assert!(
+        params.contains(&"omega ETA_KA ~ 0.00002".to_string()),
+        "the standalone ω is untouched: {params:?}"
+    );
+    let block = params
+        .iter()
+        .find(|l| l.starts_with("block_omega"))
+        .unwrap();
+    let tri: Vec<f64> = block
+        .split_once('[')
+        .unwrap()
+        .1
+        .trim_end_matches(']')
+        .split(',')
+        .map(|s| s.trim().parse().unwrap())
+        .collect();
+    assert!(
+        (tri[0] - (a * a + MIN_SEED_VARIANCE)).abs() < 1e-12,
+        "{block}"
+    );
+    assert!(
+        (tri[1] - a * b).abs() < 1e-12,
+        "the covariance is verbatim: {block}"
+    );
+    assert!(
+        (tri[2] - (b * b + c * c + MIN_SEED_VARIANCE)).abs() < 1e-12,
+        "{block}"
+    );
+}
+
+/// A `FIX`ed block is never nudged, and is never a reason to touch anything
+/// else: the engine exempts it from the rail, and `SeedInits` leaves a `FIX`
+/// line alone. The standalone ω beside it is seeded verbatim.
+#[test]
+fn seed_from_leaves_a_fixed_block_and_its_neighbours_alone() {
+    let mut fit = fixture_fit();
+    let names = fit.eta_names.clone();
+    let cl = names.iter().position(|n| n == "ETA_CL").unwrap();
+    let v = names.iter().position(|n| n == "ETA_V").unwrap();
+    let ka = names.iter().position(|n| n == "ETA_KA").unwrap();
+    fit.omega[(cl, cl)] = 0.25;
+    fit.omega[(cl, v)] = 0.15;
+    fit.omega[(v, cl)] = 0.15;
+    fit.omega[(v, v)] = 0.09; // exactly singular: 0.15² = 0.25 · 0.09
+    fit.omega[(ka, ka)] = 2e-5;
+    let src = std::fs::read_to_string(MODEL).unwrap();
+    let src = src.replace(
+        "omega ETA_CL ~ 0.09\n  omega ETA_V  ~ 0.04",
+        "block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.04] FIX",
+    );
+    let mut model = ModelText::parse(&src).unwrap();
+    seed_from(&mut model, &fit).expect("seeding a child");
+    let params = model.block_lines("parameters");
+    assert!(
+        params.contains(&"block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.04] FIX".to_string()),
+        "{params:?}"
+    );
+    assert!(
+        params.contains(&"omega ETA_KA ~ 0.00002".to_string()),
+        "{params:?}"
+    );
+    assert!(super::free_blocks_of(&model, &names).is_empty());
+}
+
+/// Past `MAX_NUDGES` the block goes through verbatim — not sixteen nudges
+/// that still do not start. An indefinite block (covariance far larger than
+/// its variances) never becomes positive-definite by `16·δ`.
+#[test]
+fn seed_from_hands_an_unrepairable_block_through_verbatim() {
+    let mut fit = fixture_fit();
+    let names = fit.eta_names.clone();
+    let cl = names.iter().position(|n| n == "ETA_CL").unwrap();
+    let v = names.iter().position(|n| n == "ETA_V").unwrap();
+    fit.omega[(cl, cl)] = 1e-5;
+    fit.omega[(v, v)] = 1e-5;
+    fit.omega[(cl, v)] = 1e-3;
+    fit.omega[(v, cl)] = 1e-3;
+    let src = std::fs::read_to_string(MODEL).unwrap();
+    let src = src.replace(
+        "omega ETA_CL ~ 0.09\n  omega ETA_V  ~ 0.04",
+        "block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.04]",
+    );
+    let blocks = super::free_blocks_of(&ModelText::parse(&src).unwrap(), &names);
+    assert_eq!(blocks, vec![vec![cl, v]]);
+    let floored = super::floor_variances(&fit, &blocks);
+    // Nothing else was below the floor, and the block was given back as it
+    // was: no change at all.
+    assert!(floored.is_none(), "{:?}", floored.map(|f| f.omega));
+
+    let mut model = ModelText::parse(&src).unwrap();
+    seed_from(&mut model, &fit).expect("seeding a child");
+    let mut verbatim = ModelText::parse(&src).unwrap();
+    verbatim.apply(ModelEdit::SeedInits(&fit)).unwrap();
+    assert_eq!(
+        model.block_lines("parameters"),
+        verbatim.block_lines("parameters")
+    );
 }

--- a/crates/ferx-tools/src/search/seed_tests.rs
+++ b/crates/ferx-tools/src/search/seed_tests.rs
@@ -92,3 +92,93 @@ fn seed_from_raises_the_diagonal_only() {
         "diagonal floored, off-diagonal verbatim: {params:?}"
     );
 }
+
+/// The #1256 vancomycin case: every declared variance is ordinary, but the
+/// block's correlations leave `ETA_V2` with a Cholesky diagonal of 6.1e-6 —
+/// the engine refuses to start a child there (`E_OMEGA_INIT_AT_RAIL`). The
+/// seed nudges the block by `δ·I` until its factor is above the rail.
+#[test]
+fn seed_from_regularises_a_block_whose_cholesky_diagonal_is_at_the_rail() {
+    // A 3×3 block whose third Schur complement is exactly the rail.
+    let mut fit = fixture_fit();
+    let names = fit.eta_names.clone();
+    assert_eq!(names.len(), 3, "the warfarin fixture has three η");
+    let rail: f64 = 6.144_212_353_328_21e-6;
+    // ω = L Lᵀ with L = [[a,0,0],[b,c,0],[d,e,f]], f² = rail.
+    let (a, b, c, d, e, f) = (0.6f64, 0.3f64, 0.1f64, 0.2f64, 0.9f64, rail.sqrt());
+    let l = nalgebra::DMatrix::from_row_slice(3, 3, &[a, 0.0, 0.0, b, c, 0.0, d, e, f]);
+    fit.omega = &l * l.transpose();
+    assert!(
+        (0..3).all(|k| fit.omega[(k, k)] > MIN_SEED_VARIANCE),
+        "every declared variance is ordinary: {:?}",
+        fit.omega
+    );
+    assert!(!super::cholesky_above_rail(&fit.omega));
+
+    // A model that blocks the three η, so `SeedInits` writes the block.
+    let src = std::fs::read_to_string(MODEL).unwrap();
+    let src = src
+        .replace("  omega ETA_CL ~ 0.09\n", "")
+        .replace("  omega ETA_V  ~ 0.04\n", "")
+        .replace(
+            "  omega ETA_KA ~ 0.30\n",
+            "  block_omega (ETA_CL, ETA_V, ETA_KA) = [0.09, 0.0, 0.04, 0.0, 0.0, 0.30]\n",
+        );
+    let mut model = ModelText::parse(&src).unwrap();
+    seed_from(&mut model, &fit).expect("seeding a child");
+    let line = model
+        .block_lines("parameters")
+        .into_iter()
+        .find(|l| l.starts_with("block_omega"))
+        .expect("the block is written");
+    // Read the written triangle back and factor it: every Cholesky diagonal
+    // is now above the floor, and the declared variances moved by one δ.
+    let tri: Vec<f64> = line
+        .split_once('[')
+        .unwrap()
+        .1
+        .trim_end_matches(']')
+        .split(',')
+        .map(|s| s.trim().parse().unwrap())
+        .collect();
+    assert_eq!(tri.len(), 6, "{line}");
+    let mut written = nalgebra::DMatrix::zeros(3, 3);
+    let mut i = 0;
+    for r in 0..3 {
+        for c in 0..=r {
+            written[(r, c)] = tri[i];
+            written[(c, r)] = tri[i];
+            i += 1;
+        }
+    }
+    assert!(super::cholesky_above_rail(&written), "{line}");
+    for k in 0..3 {
+        let moved = written[(k, k)] - fit.omega[(k, k)];
+        assert!(
+            (moved - MIN_SEED_VARIANCE).abs() < 1e-12,
+            "diagonal {k} moved by {moved:e}, not one δ"
+        );
+    }
+    // One nudge of δ lifts the collapsed Schur complement to at least δ.
+    let l_new = nalgebra::Cholesky::new(written).unwrap();
+    let l_new = l_new.l();
+    assert!(l_new[(2, 2)] * l_new[(2, 2)] >= MIN_SEED_VARIANCE);
+
+    // The mutation this pins: `SeedInits` alone writes the singular block.
+    let mut verbatim = ModelText::parse(&src).unwrap();
+    verbatim.apply(ModelEdit::SeedInits(&fit)).unwrap();
+    let raw = verbatim
+        .block_lines("parameters")
+        .into_iter()
+        .find(|l| l.starts_with("block_omega"))
+        .unwrap();
+    assert_ne!(raw, line);
+}
+
+/// A healthy block is left alone: no nudge, no clone.
+#[test]
+fn seed_from_leaves_a_well_conditioned_block_alone() {
+    let fit = fixture_fit();
+    assert!(super::cholesky_above_rail(&fit.omega));
+    assert!(super::floor_variances(&fit).is_none());
+}

--- a/docs/tools/modelsearch.qmd
+++ b/docs/tools/modelsearch.qmd
@@ -116,7 +116,12 @@ orders happen to render the same text. A variance the parent collapsed
 (an ω at the optimizer's rail, 6 × 10⁻⁶) is seeded at the smallest value
 the engine will start from, 10⁻⁵, so the child can still be fitted; on the
 warfarin example a lag whose η collapsed would otherwise have left every
-two-compartment lag candidate seeded from it unfittable.
+two-compartment lag candidate seeded from it unfittable. A `block_omega`
+can collapse the same way through its *correlations* — every declared
+variance ordinary, one Cholesky diagonal at the rail (the vancomycin base's
+`ETA_V2`) — and is nudged by 10⁻⁵ on its diagonal until its factor clears
+the rail. `SeedInits` on its own stays faithful to the fit; the floor and
+the nudge belong to a search deriving a child.
 
 **`reduced_stepwise`** — the default, as in Pharmpy. As above, but before a
 layer is extended the models that carry the same feature *set* are collapsed

--- a/docs/tools/modelsearch.qmd
+++ b/docs/tools/modelsearch.qmd
@@ -119,8 +119,11 @@ warfarin example a lag whose η collapsed would otherwise have left every
 two-compartment lag candidate seeded from it unfittable. A `block_omega`
 can collapse the same way through its *correlations* — every declared
 variance ordinary, one Cholesky diagonal at the rail (the vancomycin base's
-`ETA_V2`) — and is nudged by 10⁻⁵ on its diagonal until its factor clears
-the rail. `SeedInits` on its own stays faithful to the fit; the floor and
+`ETA_V2`) — and that block alone is nudged by 10⁻⁵ on its diagonal until
+its factor clears the rail; a standalone ω beside it, and a `FIX`ed block,
+are left as they are, and a block that does not clear the rail after a
+bounded number of nudges goes through verbatim so the engine's own message
+names it. `SeedInits` on its own stays faithful to the fit; the floor and
 the nudge belong to a search deriving a child.
 
 **`reduced_stepwise`** — the default, as in Pharmpy. As above, but before a

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -830,7 +830,14 @@ pub fn fit(
     }
 
     match best {
-        None => Err("All multi-start fits failed".to_string()),
+        // Every start failed: say *why*, or a search table reads "All
+        // multi-start fits failed" over a candidate whose model the engine
+        // refused to start at all (#1256: a seeded ω block at the rail),
+        // which is a different repair from a fit that diverged.
+        None => Err(format!(
+            "All multi-start fits failed: {}",
+            failed_starts.join("; ")
+        )),
         Some((k, mut result)) => {
             result.warnings.splice(0..0, pre_warnings);
             if !failed_starts.is_empty() {

--- a/src/api/tests/pool_plan_tests.rs
+++ b/src/api/tests/pool_plan_tests.rs
@@ -312,3 +312,30 @@ fn a_fit_is_bit_identical_across_thread_counts() {
     );
     assert_eq!(one.n_iterations, four.n_iterations);
 }
+
+#[test]
+fn a_fit_whose_every_start_is_refused_says_why() {
+    // #1256: a search child seeded with an ω on the optimizer's rail is
+    // refused by every start, and the runner's table showed only "All
+    // multi-start fits failed" — the repair (regularise the seed) is a
+    // different one from a fit that diverged, so the reason must survive.
+    let model = one_cpt_model();
+    let pop = population();
+    let mut params = model.default_params.clone();
+    params.omega = crate::types::OmegaMatrix::from_diagonal(
+        &[6.144_212_353_328_21e-6],
+        params.omega.eta_names.clone(),
+    );
+    let mut opts = short_fit_opts();
+    opts.n_starts = 2;
+    let err = fit(&model, &pop, &params, &opts).expect_err("every start is refused");
+    assert!(
+        err.starts_with("All multi-start fits failed: start 0:"),
+        "{err}"
+    );
+    assert!(err.contains("start 1:"), "{err}");
+    assert!(
+        err.contains("lower bound") || err.contains("rail"),
+        "the engine's own reason is carried: {err}"
+    );
+}


### PR DESCRIPTION
## Why

Stacked on #1256. Running `ferx modelsearch` on the vancomycin_uvm base (`PERIPHERALS(0..2)`), the three-compartment candidate showed `failed — All multi-start fits failed` after 0.0 s. Not the model: the base fit's (CL, V1, V2) `block_omega` is near-singular through its correlations — every declared variance ordinary, the Cholesky diagonal for `ETA_V2` on the optimizer's rail (6.1e-6) — and the child was seeded with that block verbatim, so the engine refused every start (`E_OMEGA_INIT_AT_RAIL`). The one-compartment candidate got through only because narrowing dropped `ETA_V2` from the block. And the table hid the reason.

## What changed

- `search::seed::seed_from` (shared by covsearch and modelsearch): after the diagonal floor, a block whose Cholesky diagonal is at the rail is nudged by `1e-5·I` until its factor clears it — for a PSD ω every Schur complement of `ω + δI` is at least δ, so one nudge normally does it; bounded at 16 for a fitted ω that is slightly indefinite in the last digits, past which the seed is verbatim and the engine's own message names the block. The block check uses the engine's rail with headroom (`8e-6`), not the diagonal floor, so a block whose diagonals were just floored to `1e-5` with a small covariance (Cholesky diagonal a hair under `1e-5`) is not nudged twice — the existing `seed_from_raises_the_diagonal_only` test caught exactly that.
- `fit()`'s multi-start failure now reads `All multi-start fits failed: start 0: …; start 1: …`, so a runner row says why a candidate never fitted.
- `SeedInits` itself is untouched — it stays faithful to the fit (`final.ferx` = `final-fit.yaml`).

## Alternatives considered

Shrinking the block's correlations instead of nudging the diagonal: also works, but moves the declared correlations by a data-dependent amount; `δ·I` moves each variance by exactly the floor and is what the diagonal path already does.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

## Breaking changes
- [x] None (the multi-start error string gained a suffix; nothing parses it)

## Numerical validation
- [x] Not applicable — seeding a start and an error message; no estimate changes. The nudge moves a declared variance by 1e-5.
- Reproduced on the vancomycin_uvm run: the three-compartment candidate is refused at the rail before the fix; the resume with the fixed binary refits it (result posted below when the run finishes).

## Performance
- [x] No significant impact expected (one Cholesky per seed)

## Tests
- [x] `seed_from_regularises_a_block_whose_cholesky_diagonal_is_at_the_rail`: a 3×3 block built as `L Lᵀ` with `L₃₃² = rail`, every declared variance ordinary; the written block factors above the rail, each diagonal moved by exactly one δ, and `SeedInits` alone writes the singular block (the mutation).
- [x] `seed_from_leaves_a_well_conditioned_block_alone`: no clone, no nudge.
- [x] `a_fit_whose_every_start_is_refused_says_why` (core): a start at the rail with `n_starts = 2` errors with both starts' reasons.
- Existing seed tests (diagonal floor, diagonal-only, verbatim on a healthy fit) still pass.

## Docs
- [x] `docs/tools/modelsearch.qmd` (the seeding paragraph), `CHANGELOG.md` (two Fixed bullets)

## Checklist
- [x] `tools/preflight.sh` green (run with these changes on the parent branch's tree)
- [x] No `Dual2` path touched

## Reviewer hints
`seed.rs::floor_variances` and `cholesky_above_rail`; the threshold comment explains the `8e-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193LzWXUgwiRMtFQBUyt9PS