### PR TITLE
perf(estimation): reuse exclusive fit pools and fuse FOCEI subject work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -379,9 +379,10 @@ section of the SDLC for the versioning policy).
 - The main FOCE/FOCEI optimizer paths combine EBE solves with subject scores;
   mixed analytic/FD gradients use one subject pass. This reduces synchronization
   between inner and outer optimization and avoids EBE-buffer copies (#1115).
-- Reuse idle worker pools for explicitly sized fits and `PoolPlan` batches; concurrent
-  fits with identical ODE overrides retain independent worker budgets, and idle pool
-  retention is bounded across thread counts and solver settings (#1115, #1212).
+- Reuse worker pools for repeated fits and `PoolPlan` batches. Explicitly sized fits
+  retain independent budgets; unpinned fits with identical ODE overrides share one
+  persistent pool instead of multiplying worker counts. Idle retention is bounded across
+  thread counts and solver settings, with one most-recent wide pool retained (#1115, #1212).
 - **A joint PK-TTE model with a linear PK block now takes the exact steady-state solve
   (#1210).** The hazard accumulator's one-cycle map is the identity, so it made `I - M`
   singular and the exact `(I - M)^-1 b` fixed point (#914) declined for *every* joint model,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,7 +372,7 @@ section of the SDLC for the versioning policy).
 
 ### Performance
 - Allocate per-event PK scratch storage only when the prediction path needs it,
-  reducing allocation traffic for static-model FOCE/FOCEI fits.
+  reducing allocation traffic for static-model FOCE/FOCEI fits (#1283).
 - IOV inner optimization reuses per-event PK parameter buffers across likelihood
   probes, reducing allocation traffic while recomputing every event at the current
   parameters, covariates, time, and occasion (#104).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,17 @@ section of the SDLC for the versioning policy).
   silently scoring the declared value — `[saem, focei]` is fine, `[focei, imp]` needs `FIX`.
 
 ### Performance
+- Allocate per-event PK scratch storage only when the prediction path needs it,
+  reducing allocation traffic for static-model FOCE/FOCEI fits.
+- IOV inner optimization reuses per-event PK parameter buffers across likelihood
+  probes, reducing allocation traffic while recomputing every event at the current
+  parameters, covariates, time, and occasion (#104).
+- The main FOCE/FOCEI optimizer paths combine EBE solves with subject scores;
+  mixed analytic/FD gradients use one subject pass. This reduces synchronization
+  between inner and outer optimization and avoids EBE-buffer copies (#1115).
+- Reuse idle worker pools for explicitly sized fits and `PoolPlan` batches; concurrent
+  fits with identical ODE overrides retain independent worker budgets, and idle pool
+  retention is bounded across thread counts and solver settings (#1115, #1212).
 - **A joint PK-TTE model with a linear PK block now takes the exact steady-state solve
   (#1210).** The hazard accumulator's one-cycle map is the identity, so it made `I - M`
   singular and the exact `(I - M)^-1 b` fixed point (#914) declined for *every* joint model,

--- a/codecov.yml
+++ b/codecov.yml
@@ -166,3 +166,9 @@ ignore:
   - "src/bin/generate_data.rs"
   - "src/bin/pktte_sim_anchor.rs"
   - "src/bin/rtte_sim_anchor.rs"
+  # Maintainer timing harness; real fits and numerical comparisons run manually
+  # on both revisions, outside the PR coverage job.
+  - "examples/pool_benchmark.rs"
+  - "examples/focei_pipeline_benchmark.rs"
+  - "examples/focei_profile.rs"
+  - "tools/profiling_alloc.rs"

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -45,19 +45,23 @@ What runs, how long, and how it is resumed or traced.
 
 #### Worker reuse for repeated fits
 
-Default fits share a persistent worker pool.
-Fits with a positive `threads` value, or fit-level ODE overrides, exclusively
-lease a pool for the call. An idle pool with the same width and solver settings
-can be reused; concurrent fits get independent pools even when their settings
-match. This preserves the per-fit budgets assigned by `PoolPlan`.
+Default fits share a persistent worker pool. Unpinned fits with the same
+fit-level ODE overrides also share a persistent pool keyed by those solver
+settings, so changing a tolerance does not multiply worker counts for concurrent
+calls. A positive `threads` value explicitly budgets the fit and exclusively
+leases a pool for the call; an idle pool with the same width and solver settings
+can be reused, while concurrent pinned fits keep independent budgets. This
+preserves the per-fit budgets assigned by `PoolPlan`.
 This isolates worker budgets and ODE settings; concurrent fits should still use
 consistent process-wide inner-optimizer and EBE warm-start settings.
 
-Idle pools retain at most twice the automatic thread budget across all settings
-(at most 16 workers). Older idle pools are evicted, and pools wider than that
-limit are released after use. Active fits keep their requested width; this idle
-limit is not a process-wide limit on concurrent fitting. Worker stacks remain
-32 MiB each, which is reserved capacity rather than necessarily resident memory.
+The caches ordinarily retain at most twice the automatic thread budget across
+all settings (at most 16 workers each). Older entries are evicted. When a single
+pool is wider than that budget, it can remain as the sole most-recent entry so a
+repeated explicit wide configuration still avoids rebuilding its workers.
+Active fits keep their requested width; the idle limits are not process-wide
+limits on concurrent fitting. Worker stacks remain 32 MiB each, which is
+reserved capacity rather than necessarily resident memory.
 
 During FOCE/FOCEI optimization, the same pool serves the inner EBE solves and
 outer gradient evaluations. The main NLopt and built-in BFGS/L-BFGS paths evaluate

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -43,6 +43,30 @@ What runs, how long, and how it is resumed or traced.
 | `checkpoint_interval_secs` | integer | `300` | Minimum wall-clock seconds between checkpoint writes. Larger values reduce I/O overhead but lose more progress on an interrupt; smaller values save more often. Only used when `checkpoint = true`. |
 | `optimizer_trace` | `true`, `false` | `false` | Write a per-iteration CSV to `/tmp/ferx_trace_<pid>_<ts>.csv`. The path is stored in `FitResult::trace_path`. Useful for diagnosing convergence problems or comparing optimizers. See [Optimizer Trace](#optimizer-trace). |
 
+**Worker reuse for repeated fits.** Default fits share a persistent worker pool.
+Fits with a positive `threads` value, or fit-level ODE overrides, exclusively
+lease a pool for the call. An idle pool with the same width and solver settings
+can be reused; concurrent fits get independent pools even when their settings
+match. This preserves the per-fit budgets assigned by `PoolPlan`.
+
+Idle pools retain at most twice the automatic thread budget across all settings
+(at most 16 workers). Older idle pools are evicted, and pools wider than that
+limit are released after use. Active fits keep their requested width; this idle
+limit is not a process-wide limit on concurrent fitting. Worker stacks remain
+32 MiB each, which is reserved capacity rather than necessarily resident memory.
+
+During FOCE/FOCEI optimization, the same pool serves the inner EBE solves and
+outer gradient evaluations. The main NLopt and built-in BFGS/L-BFGS paths evaluate
+each subject's marginal contribution immediately after its EBE solve. The mixed
+analytic/FD gradient path also finishes each subject's fallback in the same task.
+This reduces synchronization between stages while preserving subject-order
+reductions. Workers still use Rayon's normal idle policy; pool reuse does not
+mean keeping idle CPU cores busy continuously.
+
+IOV inner solves also reuse per-event PK parameter buffer capacity between
+likelihood probes. Each probe still evaluates the current parameters and every
+event's covariates, time, and occasion; stored numerical values are not reused.
+
 ### Outer optimizer {#outer-optimizer}
 
 The population-parameter search: which algorithm, when it stops, and whether a global pre-search runs first. See [Optimizer Choices](#optimizer-choices) for how to pick one.

--- a/docs/model-file/fit-options.qmd
+++ b/docs/model-file/fit-options.qmd
@@ -43,11 +43,15 @@ What runs, how long, and how it is resumed or traced.
 | `checkpoint_interval_secs` | integer | `300` | Minimum wall-clock seconds between checkpoint writes. Larger values reduce I/O overhead but lose more progress on an interrupt; smaller values save more often. Only used when `checkpoint = true`. |
 | `optimizer_trace` | `true`, `false` | `false` | Write a per-iteration CSV to `/tmp/ferx_trace_<pid>_<ts>.csv`. The path is stored in `FitResult::trace_path`. Useful for diagnosing convergence problems or comparing optimizers. See [Optimizer Trace](#optimizer-trace). |
 
-**Worker reuse for repeated fits.** Default fits share a persistent worker pool.
+#### Worker reuse for repeated fits
+
+Default fits share a persistent worker pool.
 Fits with a positive `threads` value, or fit-level ODE overrides, exclusively
 lease a pool for the call. An idle pool with the same width and solver settings
 can be reused; concurrent fits get independent pools even when their settings
 match. This preserves the per-fit budgets assigned by `PoolPlan`.
+This isolates worker budgets and ODE settings; concurrent fits should still use
+consistent process-wide inner-optimizer and EBE warm-start settings.
 
 Idle pools retain at most twice the automatic thread budget across all settings
 (at most 16 workers). Older idle pools are evicted, and pools wider than that

--- a/examples/focei_pipeline_benchmark.rs
+++ b/examples/focei_pipeline_benchmark.rs
@@ -1,0 +1,167 @@
+//! Reproducible FOCEI inner/outer pipeline benchmark. Run with the same profile on
+//! both revisions: cargo run --profile ci-test --example focei_pipeline_benchmark -- LABEL
+//! Optional second argument: number of measured rounds (default 7).
+use ferx_core::{fit, parser::model_parser::parse_model_string, types::*, PoolPlan};
+use rayon::prelude::*;
+use std::{collections::HashMap, time::Instant};
+
+fn model(ode: bool) -> CompiledModel {
+    let structural = if ode {
+        "ode(states=[central])\n[odes]\n d/dt(central) = -(CL / V) * central\n[scaling]\n y = central / V"
+    } else {
+        "pk one_cpt_iv(cl=CL, v=V)"
+    };
+    parse_model_string(&format!(
+        "[parameters]\n theta TVCL(1.0, 0.1, 50.0)\n theta TVV(10.0, 1.0, 500.0)\n omega ETA_CL ~ 0.04\n sigma PROP ~ 0.04\n[individual_parameters]\n CL = TVCL * exp(ETA_CL)\n V = TVV\n[structural_model]\n {structural}\n[error_model]\n DV ~ proportional(PROP)"
+    )).unwrap()
+}
+
+fn population(n: usize) -> Population {
+    Population {
+        subjects: (0..n)
+            .map(|i| {
+                let obs_times = vec![0.5, 2.0, 8.0, 24.0];
+                let observations = obs_times
+                    .iter()
+                    .enumerate()
+                    .map(|(j, &t)| {
+                        let cl = 1.1 * (0.2 * ((i * 7 % 13) as f64 / 6.0 - 1.0)).exp();
+                        10.0 * (-cl * t / 10.0).exp()
+                            * (1.0 + 0.08 * ((i + j * 3) % 7) as f64 - 0.24)
+                    })
+                    .collect();
+                Subject {
+                    id: (i + 1).to_string(),
+                    doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                    obs_times,
+                    observations,
+                    obs_cmts: vec![1; 4],
+                    cens: vec![0; 4],
+                    obs_raw_times: vec![],
+                    covariates: HashMap::new(),
+                    dose_covariates: vec![],
+                    obs_covariates: vec![],
+                    pk_only_times: vec![],
+                    pk_only_covariates: vec![],
+                    reset_times: vec![],
+                    reset_covariates: vec![],
+                    occasions: vec![],
+                    obs_l2: vec![],
+                    dose_occasions: vec![],
+                    reset_occasions: vec![],
+                    fremtype: vec![],
+                    obs_records: vec![],
+                }
+            })
+            .collect(),
+        covariate_names: vec![],
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+fn signature(f: &FitResult) -> Vec<u64> {
+    std::iter::once(f.ofv)
+        .chain(f.theta.iter().copied())
+        .chain(f.sigma.iter().copied())
+        .chain(f.omega.iter().copied())
+        .map(f64::to_bits)
+        .chain([f.n_iterations as u64])
+        .collect()
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    let label = args.get(1).map(String::as_str).unwrap_or("unlabelled");
+    let rounds = args.get(2).map(|v| v.parse().unwrap()).unwrap_or(7);
+    println!("label,case,round,fits,elapsed_ms,signature");
+    // All fits have a fixed iteration budget; these are throughput benchmarks,
+    // not convergence comparisons. Model/data construction is outside timing.
+    for (name, ode, override_ode, width, parallel, count, subjects, iters) in [
+        (
+            "analytical_6sub_1t",
+            false,
+            false,
+            Some(1),
+            false,
+            32,
+            6,
+            30,
+        ),
+        (
+            "analytical_6sub_4t",
+            false,
+            false,
+            Some(4),
+            false,
+            32,
+            6,
+            30,
+        ),
+        (
+            "analytical_24sub_4t",
+            false,
+            false,
+            Some(4),
+            false,
+            16,
+            24,
+            30,
+        ),
+        (
+            "analytical_128sub_8t",
+            false,
+            false,
+            Some(8),
+            false,
+            8,
+            128,
+            30,
+        ),
+        ("ode_12sub_1t", true, true, Some(1), false, 4, 12, 30),
+        ("ode_12sub_4t", true, true, Some(4), false, 4, 12, 30),
+        ("ode_48sub_8t", true, true, Some(8), false, 4, 48, 30),
+        ("batch_ode", true, true, Some(1), true, 32, 12, 5),
+    ] {
+        let m = model(ode);
+        let p = population(subjects);
+        let mut opts = FitOptions {
+            threads: width,
+            outer_maxiter: iters,
+            run_covariance_step: false,
+            ..Default::default()
+        }
+        .quiet();
+        if override_ode {
+            opts.ode_reltol = 1e-7;
+        }
+        let expected = signature(&fit(&m, &p, &m.default_params, &opts).unwrap());
+        let one = || {
+            let f = fit(&m, &p, &m.default_params, &opts).unwrap();
+            assert!(f.ofv.is_finite());
+            assert_eq!(signature(&f), expected, "{name}: numerical drift");
+            if let Some(n) = width {
+                assert_eq!(f.n_threads_used, n);
+            }
+        };
+        // Round 0 warms all batch lanes and is reported but excluded from medians.
+        for round in 0..=rounds {
+            let start = Instant::now();
+            if parallel {
+                PoolPlan::new(8, 1)
+                    .install(|| (0..count).into_par_iter().for_each(|_| one()))
+                    .unwrap();
+            } else {
+                for _ in 0..count {
+                    one();
+                }
+            }
+            println!(
+                "{label},{name},{round},{count},{:.6},\"{expected:?}\"",
+                start.elapsed().as_secs_f64() * 1000.0
+            );
+        }
+    }
+}

--- a/examples/focei_pipeline_benchmark.rs
+++ b/examples/focei_pipeline_benchmark.rs
@@ -1,5 +1,5 @@
 //! Reproducible FOCEI inner/outer pipeline benchmark. Run with the same profile on
-//! both revisions: cargo run --profile ci-test --example focei_pipeline_benchmark -- LABEL
+//! both revisions: cargo run -p ferx-core --profile ci-test --example focei_pipeline_benchmark -- LABEL
 //! Optional second argument: number of measured rounds (default 7).
 use ferx_core::{fit, parser::model_parser::parse_model_string, types::*, PoolPlan};
 use rayon::prelude::*;

--- a/examples/focei_profile.rs
+++ b/examples/focei_profile.rs
@@ -1,0 +1,298 @@
+//! Usage: focei_profile CASE THREADS REPEATS MODE OUTPUT_JSON
+//! CASE: analytical | iov | stiff. MODE: time | kernels | counts | stacks | byte_stacks.
+//! Allocation builds: cargo rustc --profile ci-test --example focei_profile --
+//! --cfg profiling_allocations -C debuginfo=1. Normal builds have no allocator hook.
+#![allow(unexpected_cfgs)] // example-only --cfg, not an engine feature/API
+use ferx_core::estimation::{
+    inner_optimizer as inner,
+    parameterization::{pack_params, unpack_params},
+    sens_outer_gradient as gradient,
+};
+use ferx_core::sens::provider;
+use ferx_core::{fit, parser::model_parser::parse_model_string, read_nonmem_csv, types::*};
+use serde_json::{json, Value};
+use std::{hint::black_box, path::Path, sync::atomic::Ordering::Relaxed, time::Instant};
+
+#[cfg(profiling_allocations)]
+#[path = "../tools/profiling_alloc.rs"]
+mod allocation;
+#[cfg(profiling_allocations)]
+#[global_allocator]
+static ALLOCATOR: allocation::Allocator = allocation::Allocator;
+
+fn counters() -> Value {
+    json!({"full_sens_calls": provider::PROFILE_SENS_CALLS.load(Relaxed),
+        "full_sens_ns": provider::PROFILE_SENS_NANOS.load(Relaxed),
+        "eta_sens_calls": provider::PROFILE_ETA_CALLS.load(Relaxed),
+        "eta_sens_ns": provider::PROFILE_ETA_NANOS.load(Relaxed),
+        "inner_solves": inner::PROFILE_INNER_SOLVES.load(Relaxed),
+        "inner_analytic_steps": inner::PROFILE_INNER_ANALYTIC_GRAD.load(Relaxed),
+        "inner_fd_steps": inner::PROFILE_INNER_FD_FALLBACK.load(Relaxed)})
+}
+fn reset_counters() {
+    for c in [
+        &provider::PROFILE_SENS_CALLS,
+        &provider::PROFILE_SENS_NANOS,
+        &provider::PROFILE_ETA_CALLS,
+        &provider::PROFILE_ETA_NANOS,
+        &inner::PROFILE_INNER_SOLVES,
+        &inner::PROFILE_INNER_ANALYTIC_GRAD,
+        &inner::PROFILE_INNER_FD_FALLBACK,
+    ] {
+        c.store(0, Relaxed);
+    }
+}
+fn measure<T>(name: &str, stride: u64, op: impl FnOnce() -> T) -> (T, Value) {
+    reset_counters();
+    #[cfg(profiling_allocations)]
+    allocation::start(stride);
+    #[cfg(not(profiling_allocations))]
+    let _ = stride;
+    let start = Instant::now();
+    let result = op();
+    let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+    #[cfg(profiling_allocations)]
+    let allocations = allocation::stop();
+    #[cfg(not(profiling_allocations))]
+    let allocations = Value::Null;
+    (
+        result,
+        json!({"phase":name,"elapsed_ms":elapsed,"providers":counters(),"allocations":allocations}),
+    )
+}
+
+fn exact_binding(t: f64, cl: f64, v: f64) -> f64 {
+    let a = -cl / v - 1e4;
+    let d = -1e3;
+    let trace = a + d;
+    let det = cl / v * 1e3;
+    let big = (trace - (trace * trace - 4.0 * det).sqrt()) / 2.0;
+    let small = det / big;
+    100.0 / v * ((small * t).exp() * (a - big) - (big * t).exp() * (a - small)) / (small - big)
+}
+fn fixture(case: &str) -> (CompiledModel, Population) {
+    if case != "stiff" {
+        let (model_file, data_file, occ) = match case {
+            "analytical" => ("examples/warfarin.ferx", "data/warfarin.csv", None),
+            "iov" => (
+                "examples/warfarin_iov.ferx",
+                "data/warfarin_iov.csv",
+                Some("OCC"),
+            ),
+            _ => panic!("unknown case: {case}"),
+        };
+        let model = parse_model_string(&std::fs::read_to_string(model_file).unwrap()).unwrap();
+        return (
+            model,
+            read_nonmem_csv(Path::new(data_file), None, occ).unwrap(),
+        );
+    }
+    let model = parse_model_string(
+        r"
+[parameters]
+ theta TVCL(3, 0.1, 30)
+ theta TVV(20, 2, 200)
+ omega ETA_CL ~ 0.04
+ sigma PROP ~ 0.01
+[individual_parameters]
+ CL = TVCL * exp(ETA_CL)
+ V = TVV
+ KON = 10000
+ KOFF = 1000
+[structural_model]
+ ode(states=[central,bound])
+[odes]
+ d/dt(central) = -(CL/V)*central - KON*central + KOFF*bound
+ d/dt(bound) = KON*central - KOFF*bound
+[scaling]
+ y = central/V
+[error_model]
+ DV ~ proportional(PROP)
+[fit_options]
+ ode_method = rodas5p
+ ode_reltol = 1e-6
+ ode_abstol = 1e-8
+",
+    )
+    .unwrap();
+    let mut pop = read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).unwrap();
+    pop.subjects.truncate(4);
+    for (i, s) in pop.subjects.iter_mut().enumerate() {
+        s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)];
+        s.obs_times = vec![0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 12.0, 24.0];
+        s.obs_raw_times.clear();
+        let cl = 3.0 * (0.08 * (i as f64 - 1.5)).exp();
+        s.observations = s
+            .obs_times
+            .iter()
+            .enumerate()
+            .map(|(j, &t)| exact_binding(t, cl, 20.0) * (0.95 + 0.02 * ((i + j) % 6) as f64))
+            .collect();
+        s.obs_cmts = vec![1; 8];
+        s.cens = vec![0; 8];
+    }
+    // Check the stiff trajectory against its matrix-exponential closed form.
+    for pred in ferx_core::predict(&model, &pop, &model.default_params) {
+        let exact = exact_binding(pred.time, 3.0, 20.0);
+        assert!((pred.pred - exact).abs() < 2e-5 * exact.abs().max(1e-6));
+    }
+    (model, pop)
+}
+fn signature(f: &FitResult) -> Vec<u64> {
+    std::iter::once(f.ofv)
+        .chain(f.theta.iter().copied())
+        .chain(f.sigma.iter().copied())
+        .chain(f.omega.iter().copied())
+        .chain(f.omega_iov.iter().flat_map(|m| m.iter().copied()))
+        .map(f64::to_bits)
+        .chain([f.n_iterations as u64])
+        .collect()
+}
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    let case = &args[1];
+    let threads: usize = args[2].parse().unwrap();
+    let repeats: usize = args[3].parse().unwrap();
+    let mode = &args[4];
+    assert!(repeats > 0);
+    assert!(["time", "kernels", "counts", "stacks", "byte_stacks"].contains(&mode.as_str()));
+    assert_eq!(
+        mode == "counts" || mode == "stacks" || mode == "byte_stacks",
+        cfg!(profiling_allocations),
+        "counts/stacks need the allocation build; time/kernels need the normal build"
+    );
+    #[cfg(profiling_allocations)]
+    allocation::sample_bytes(mode == "byte_stacks");
+    let (model, pop) = fixture(case);
+    let params = &model.default_params;
+    let opts = FitOptions {
+        method: EstimationMethod::FoceI,
+        interaction: true,
+        threads: Some(threads),
+        outer_maxiter: 5,
+        inner_maxiter: 30,
+        run_covariance_step: false,
+        ..Default::default()
+    }
+    .quiet();
+    let reference = fit(&model, &pop, params, &opts).expect("reference fit");
+    assert!(reference.ofv.is_finite());
+    let expected = signature(&reference);
+    let mut measurements = Vec::new();
+    let mut stride = 0;
+    for _ in 0..repeats {
+        let (result, row) = measure("full_fit", stride, || {
+            fit(&model, &pop, params, &opts).unwrap()
+        });
+        assert_eq!(
+            signature(&result),
+            expected,
+            "repeated fit changed numerically"
+        );
+        assert_eq!(result.n_threads_used, threads);
+        if mode == "stacks" || mode == "byte_stacks" {
+            let metric = if mode == "byte_stacks" {
+                "requested_bytes"
+            } else {
+                "allocation_calls"
+            };
+            stride = (row["allocations"][metric].as_u64().unwrap() / 128).max(1);
+        }
+        measurements.push(row);
+    }
+    // Pointwise kernel breakdown, separate from the full optimizer trajectory.
+    if mode != "time" {
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .stack_size(ferx_core::FIT_RAYON_STACK_SIZE)
+            .build()
+            .unwrap();
+        pool.install(|| {
+            let (ebes, row) = measure("inner_cold_at_initial", 0, || {
+                inner::run_inner_loop_warm(
+                    &model,
+                    &pop,
+                    params,
+                    opts.inner_maxiter,
+                    opts.inner_tol,
+                    None,
+                    None,
+                    0,
+                    0,
+                )
+            });
+            measurements.push(row);
+            let (_, row) = measure("inner_warm_same_point", 0, || {
+                inner::run_inner_loop_warm(
+                    &model,
+                    &pop,
+                    params,
+                    opts.inner_maxiter,
+                    opts.inner_tol,
+                    Some(&ebes.0),
+                    None,
+                    0,
+                    0,
+                )
+            });
+            measurements.push(row);
+            let (value, row) = measure("likelihood_at_initial", 0, || {
+                if let Some(iov) = &params.omega_iov {
+                    ferx_core::stats::likelihood::foce_population_nll_iov(
+                        &model,
+                        &pop,
+                        &params.theta,
+                        &ebes.0,
+                        &ebes.1,
+                        &ebes.3,
+                        &params.omega,
+                        iov,
+                        &params.sigma.values,
+                        true,
+                    )
+                } else {
+                    ferx_core::stats::likelihood::foce_population_nll(
+                        &model,
+                        &pop,
+                        &params.theta,
+                        &ebes.0,
+                        &ebes.1,
+                        &params.omega,
+                        &params.sigma.values,
+                        &params.residual_correlations,
+                        true,
+                    )
+                }
+            });
+            assert!(value.is_finite());
+            measurements.push(row);
+            let x = pack_params(params);
+            let (grads, mut row) = measure("analytic_gradient_at_initial", 0, || {
+                if model.n_kappa > 0 {
+                    gradient::per_subject_packed_gradients_iov(
+                        &model, &pop, params, &x, &ebes.0, &ebes.3, true,
+                    )
+                } else {
+                    gradient::per_subject_packed_gradients(
+                        &model, &pop, params, &x, &ebes.0, true, None,
+                    )
+                }
+            });
+            row["unsupported_subjects"] = json!(grads.iter().filter(|g| g.is_none()).count());
+            measurements.push(row);
+            let (_, row) = measure("unpack_params_1000_calls", 0, || {
+                for _ in 0..1000 {
+                    black_box(unpack_params(black_box(&x), params));
+                }
+            });
+            measurements.push(row);
+        });
+    }
+    let report = json!({"case":case,"threads":threads,"mode":mode,
+        "allocation_build":cfg!(profiling_allocations),"signature":expected,
+        "subjects":pop.subjects.len(),"observations":pop.subjects.iter().map(|s|s.observations.len()).sum::<usize>(),
+        "theta":model.n_theta,"eta":model.n_eta,"kappa":model.n_kappa,
+        "outer_maxiter":opts.outer_maxiter,"inner_maxiter":opts.inner_maxiter,"measurements":measurements});
+    std::fs::write(&args[5], serde_json::to_string_pretty(&report).unwrap()).unwrap();
+    println!("{case} threads={threads} mode={mode} -> {}", args[5]);
+}

--- a/examples/pool_benchmark.rs
+++ b/examples/pool_benchmark.rs
@@ -1,0 +1,129 @@
+//! Reproducible pool-lifecycle / real-fit benchmark. Run with the same profile on
+//! both revisions: cargo run --profile ci-test --example pool_benchmark -- LABEL
+//! Optional second argument: number of measured rounds (default 7).
+use ferx_core::{fit, parser::model_parser::parse_model_string, types::*, PoolPlan};
+use rayon::prelude::*;
+use std::{collections::HashMap, time::Instant};
+
+fn model(ode: bool) -> CompiledModel {
+    let structural = if ode {
+        "ode(states=[central])\n[odes]\n d/dt(central) = -(CL / V) * central\n[scaling]\n y = central / V"
+    } else {
+        "pk one_cpt_iv(cl=CL, v=V)"
+    };
+    parse_model_string(&format!(
+        "[parameters]\n theta TVCL(1.0, 0.1, 50.0)\n theta TVV(10.0, 1.0, 500.0)\n omega ETA_CL ~ 0.04\n sigma PROP ~ 0.04\n[individual_parameters]\n CL = TVCL * exp(ETA_CL)\n V = TVV\n[structural_model]\n {structural}\n[error_model]\n DV ~ proportional(PROP)"
+    )).unwrap()
+}
+
+fn population(n: usize) -> Population {
+    Population {
+        subjects: (0..n)
+            .map(|i| {
+                let obs_times = vec![0.5, 2.0, 8.0, 24.0];
+                let observations = obs_times
+                    .iter()
+                    .enumerate()
+                    .map(|(j, &t)| {
+                        let cl = 1.1 * (0.2 * ((i * 7 % 13) as f64 / 6.0 - 1.0)).exp();
+                        10.0 * (-cl * t / 10.0).exp()
+                            * (1.0 + 0.08 * ((i + j * 3) % 7) as f64 - 0.24)
+                    })
+                    .collect();
+                Subject {
+                    id: (i + 1).to_string(),
+                    doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+                    obs_times,
+                    observations,
+                    obs_cmts: vec![1; 4],
+                    cens: vec![0; 4],
+                    obs_raw_times: vec![],
+                    covariates: HashMap::new(),
+                    dose_covariates: vec![],
+                    obs_covariates: vec![],
+                    pk_only_times: vec![],
+                    pk_only_covariates: vec![],
+                    reset_times: vec![],
+                    reset_covariates: vec![],
+                    occasions: vec![],
+                    obs_l2: vec![],
+                    dose_occasions: vec![],
+                    reset_occasions: vec![],
+                    fremtype: vec![],
+                    obs_records: vec![],
+                }
+            })
+            .collect(),
+        covariate_names: vec![],
+        dv_column: "DV".into(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    }
+}
+
+fn signature(f: &FitResult) -> Vec<u64> {
+    std::iter::once(f.ofv)
+        .chain(f.theta.iter().copied())
+        .chain(f.sigma.iter().copied())
+        .chain(f.omega.iter().copied())
+        .map(f64::to_bits)
+        .chain([f.n_iterations as u64])
+        .collect()
+}
+
+fn main() {
+    let args: Vec<_> = std::env::args().collect();
+    let label = args.get(1).map(String::as_str).unwrap_or("unlabelled");
+    let rounds = args.get(2).map(|v| v.parse().unwrap()).unwrap_or(7);
+    println!("label,case,round,fits,elapsed_ms,signature");
+    // All fits have a fixed iteration budget; these are throughput benchmarks,
+    // not convergence comparisons. Model/data construction is outside timing.
+    for (name, ode, override_ode, width, parallel, count, subjects, iters) in [
+        ("short_1t", false, false, Some(1), false, 64, 6, 2),
+        ("short_4t", false, false, Some(4), false, 64, 6, 2),
+        ("default", false, false, None, false, 32, 24, 5),
+        ("batch_analytical", false, false, Some(1), true, 32, 24, 5),
+        ("batch_ode", true, true, Some(1), true, 32, 12, 5),
+        ("ode_4t", true, true, Some(4), false, 4, 48, 10),
+    ] {
+        let m = model(ode);
+        let p = population(subjects);
+        let mut opts = FitOptions {
+            threads: width,
+            outer_maxiter: iters,
+            run_covariance_step: false,
+            ..Default::default()
+        }
+        .quiet();
+        if override_ode {
+            opts.ode_reltol = 1e-7;
+        }
+        let expected = signature(&fit(&m, &p, &m.default_params, &opts).unwrap());
+        let one = || {
+            let f = fit(&m, &p, &m.default_params, &opts).unwrap();
+            assert!(f.ofv.is_finite());
+            assert_eq!(signature(&f), expected, "{name}: numerical drift");
+            if let Some(n) = width {
+                assert_eq!(f.n_threads_used, n);
+            }
+        };
+        // Round 0 warms all batch lanes and is reported but excluded from medians.
+        for round in 0..=rounds {
+            let start = Instant::now();
+            if parallel {
+                PoolPlan::new(8, 1)
+                    .install(|| (0..count).into_par_iter().for_each(|_| one()))
+                    .unwrap();
+            } else {
+                for _ in 0..count {
+                    one();
+                }
+            }
+            println!(
+                "{label},{name},{round},{count},{:.6},\"{expected:?}\"",
+                start.elapsed().as_secs_f64() * 1000.0
+            );
+        }
+    }
+}

--- a/examples/pool_benchmark.rs
+++ b/examples/pool_benchmark.rs
@@ -1,5 +1,5 @@
 //! Reproducible pool-lifecycle / real-fit benchmark. Run with the same profile on
-//! both revisions: cargo run --profile ci-test --example pool_benchmark -- LABEL
+//! both revisions: cargo run -p ferx-core --profile ci-test --example pool_benchmark -- LABEL
 //! Optional second argument: number of measured rounds (default 7).
 use ferx_core::{fit, parser::model_parser::parse_model_string, types::*, PoolPlan};
 use rayon::prelude::*;

--- a/src/api/pool.rs
+++ b/src/api/pool.rs
@@ -126,95 +126,89 @@ pub(crate) fn default_fit_pool() -> Option<&'static rayon::ThreadPool> {
 
 #[path = "pool_cache.rs"]
 mod cache;
-use cache::{FitPoolLease, PoolCache};
+use cache::{FitPoolLease, PoolCache, SharedPoolCache};
 
 fn fit_pool_cache() -> &'static PoolCache {
     static CACHE: std::sync::OnceLock<PoolCache> = std::sync::OnceLock::new();
-    // Retain at most twice the automatic worker budget (at most 16 workers,
-    // 512 MiB reserved stack capacity), independently of the number of settings.
+    // Ordinarily retain at most twice the automatic worker budget (at most 16
+    // workers, 512 MiB reserved stack capacity). A single most-recent wider
+    // pool is retained so explicit wide configurations still get reuse.
     CACHE.get_or_init(|| PoolCache::new(default_thread_count() * 2))
+}
+
+fn shared_override_pool_cache() -> &'static SharedPoolCache {
+    static CACHE: std::sync::OnceLock<SharedPoolCache> = std::sync::OnceLock::new();
+    CACHE.get_or_init(|| SharedPoolCache::new(default_thread_count() * 2))
 }
 
 /// Lease a pool carrying exactly this override. Idle pools are reused, but active
 /// callers never share one: identical settings must not collapse a batch's
 /// independently budgeted fits onto a single pool. Workers keep immutable ODE
-/// settings for their lifetime; eviction bounds idle workers across all keys.
+/// settings for their lifetime; eviction bounds ordinary idle workers across
+/// all keys while retaining one most-recent oversized pool.
 /// Acquisition never waits for a busy pool, including inside nested fits.
 pub(crate) fn ode_override_pool(
     ov: crate::ode::solver::OdeSolverOverride,
     n_threads: usize,
-) -> Option<FitPoolLease<'static>> {
-    fit_pool_cache().acquire(n_threads, ov).ok()
+) -> Result<FitPoolLease<'static>, String> {
+    fit_pool_cache().acquire(n_threads, ov)
+}
+
+fn shared_ode_override_pool(
+    ov: crate::ode::solver::OdeSolverOverride,
+    n_threads: usize,
+) -> Result<std::sync::Arc<rayon::ThreadPool>, String> {
+    shared_override_pool_cache().acquire(n_threads, ov)
 }
 /// Run `f` with `options`' ODE solver settings reaching every thread that can integrate for
 /// it: armed on this thread, and — when the caller actually set one — on a pool whose workers
 /// carry the same value (see [`ode_override_pool`]).
 ///
 /// Used by the standalone `run_covariance` / `run_sir` / `run_sir_core` entry points, which
-/// integrate exactly as `fit` does but have no pool of their own. `fit` does not call this: it
-/// already chooses a pool (for `threads` and for its multi-start fan-out) and folds the
-/// override into that choice, so routing through here would nest a second pool inside the
-/// first.
+/// integrate exactly as `fit` does but may have no pool of their own. When `run_sir_core` is
+/// reached from inside `fit`, the current worker already carries the override and this runs
+/// inline, avoiding a second full-width pool.
 pub(crate) fn with_fit_ode_scope<R: Send>(
     options: &FitOptions,
     f: impl FnOnce() -> R + Send,
 ) -> Result<R, String> {
-    let _armed = crate::ode::solver::arm_ode_solver_override(options.ode_solver_override());
-    match ode_scope_pool(options)? {
-        Some(pool) => Ok(pool.install(f)),
-        None => Ok(f()),
-    }
-}
-
-/// The pool a call with these options must run on to keep its ODE settings, or `None` when the
-/// caller set no `ode_*` at all and any pool will do.
-///
-/// Split out so [`with_fit_ode_scope`] and `fit`'s own pool selection cannot drift: both have
-/// to consult it *before* falling back to the shared pool, and both must fail loudly rather
-/// than run unpooled, since unpooled workers integrate at the baked options and the result
-/// still looks successful.
-///
-/// A non-empty override always names its pool, even on a thread that is already a worker of
-/// that same pool. Short-circuiting there looks like a free optimisation and is not: the
-/// caller's fallback is a pool built without the override, so a nested call that pinned
-/// `threads` would land on plain workers and integrate at the model file's options. Since the
-/// cache lends idle pools exclusively, a nested call gets its own correctly configured
-/// pool. It never waits for an enclosing call to return a busy lease.
-pub(crate) fn ode_scope_pool(
-    options: &FitOptions,
-) -> Result<Option<FitPoolLease<'static>>, String> {
     let ov = options.ode_solver_override();
-    if ov.is_empty() {
-        return Ok(None);
-    }
-    let n = options
+    ov.validate()?;
+    let requested_threads = options
         .threads
         .filter(|&n| n > 0)
         .unwrap_or_else(effective_default_threads);
-    ode_override_pool(ov, n).map(Some).ok_or_else(|| {
-        format!(
-            "failed to build the {n}-thread pool this call's ODE solver settings need. \
-             Refusing to continue: without it the workers would integrate at the model \
-             file's settings and the result would look successful."
-        )
-    })
+    let already_scoped = crate::ode::solver::worker_carries_ode_override(ov)
+        && rayon::current_num_threads() == requested_threads;
+    let _armed = crate::ode::solver::arm_ode_solver_override(ov);
+    if ov.is_empty() || already_scoped {
+        return Ok(f());
+    }
+    match options.threads.filter(|&n| n > 0) {
+        Some(n) => Ok(ode_override_pool(ov, n)?.install(f)),
+        None => Ok(shared_ode_override_pool(ov, requested_threads)?.install(f)),
+    }
 }
 
 /// Run `f` on the pool this `fit()` call should use, with its ODE settings armed.
 ///
-/// Pool choice, in order: the pool carrying this call's ODE override when it set one (so the
-/// workers integrate at the requested accuracy — #1212); an exclusively leased pool sized to a pinned
-/// `threads`; otherwise the shared big-stack pool, falling back to the ambient one only if
-/// that one-time build failed, which must not turn a previously-successful default fit into an
-/// `Err`. One pool serves both levels of a multi-start fan-out, which is why this is called
-/// once per `fit()` and not per start.
+/// Pool choice, in order: a pool carrying this call's ODE override when it set one (shared for
+/// unpinned fits, exclusive for a positive `threads` budget); an exclusively leased plain pool
+/// sized to a pinned `threads`; otherwise the shared big-stack pool, falling back to the ambient
+/// one only if that one-time build failed. One pool serves both levels of a multi-start fan-out,
+/// which is why this is called once per `fit()` and not per start.
 pub(crate) fn install_on_fit_pool<R: Send>(
     options: &FitOptions,
     f: impl FnOnce() -> R + Send,
 ) -> Result<R, String> {
-    let _armed = crate::ode::solver::arm_ode_solver_override(options.ode_solver_override());
-    if let Some(pool) = ode_scope_pool(options)? {
-        return Ok(pool.install(f));
+    let ov = options.ode_solver_override();
+    ov.validate()?;
+    let _armed = crate::ode::solver::arm_ode_solver_override(ov);
+    if !ov.is_empty() {
+        return match options.threads.filter(|&n| n > 0) {
+            Some(n) => Ok(ode_override_pool(ov, n)?.install(f)),
+            None => Ok(shared_ode_override_pool(ov, effective_default_threads())?.install(f)),
+        };
     }
     match options.threads.filter(|&n| n > 0) {
         // A pinned positive `threads` leases an idle pool or builds a new one,
@@ -387,8 +381,10 @@ impl PoolPlan {
     /// Run `op` on an exclusively leased outer Rayon pool of
     /// [`replicates`](Self::replicates) workers, each with the ferx worker stack
     /// ([`FIT_RAYON_STACK_SIZE`]). Idle pools are reused within a bounded cache.
-    /// The lease lasts until `op` returns. Join any unscoped spawned work before
-    /// returning if it must finish before another caller can reuse the pool.
+    /// The lease lasts until `op` returns. `op` must not let work submitted with
+    /// `rayon::spawn` / `spawn_fifo` outlive it: after return another caller may
+    /// reuse the workers. Scoped work and parallel iterators satisfy this because
+    /// they join before returning; these are also the forms used by ferx-tools.
     ///
     /// Any `par_iter` inside `op` fans out over that pool. Returns `Err` if the
     /// pool cannot be built (e.g. resource limits).

--- a/src/api/pool.rs
+++ b/src/api/pool.rs
@@ -387,6 +387,8 @@ impl PoolPlan {
     /// Run `op` on an exclusively leased outer Rayon pool of
     /// [`replicates`](Self::replicates) workers, each with the ferx worker stack
     /// ([`FIT_RAYON_STACK_SIZE`]). Idle pools are reused within a bounded cache.
+    /// The lease lasts until `op` returns. Join any unscoped spawned work before
+    /// returning if it must finish before another caller can reuse the pool.
     ///
     /// Any `par_iter` inside `op` fans out over that pool. Returns `Err` if the
     /// pool cannot be built (e.g. resource limits).

--- a/src/api/pool.rs
+++ b/src/api/pool.rs
@@ -79,7 +79,7 @@ static GLOBAL_THREADS_EXPLICIT: std::sync::atomic::AtomicBool =
 /// Explicitly size the process-wide Rayon pool and mark it as user-chosen. Intended for a
 /// CLI binary sizing its one process-wide pool from `--threads N` before the first fit;
 /// library callers that want a pinned thread count for a single fit should use
-/// `FitOptions::threads` instead, which scopes a fit-local pool via `build_fit_pool`.
+/// `FitOptions::threads` instead, which exclusively leases a pool for that call.
 ///
 /// `n_threads` must be positive — a caller wanting the engine's own default should simply
 /// not call this at all, rather than pass `0` (which Rayon would otherwise silently treat
@@ -97,16 +97,6 @@ pub fn configure_global_thread_pool(n_threads: usize) -> Result<(), String> {
         .map_err(|e| format!("failed to configure thread pool with {n_threads} threads: {e}"))?;
     GLOBAL_THREADS_EXPLICIT.store(true, std::sync::atomic::Ordering::Release);
     Ok(())
-}
-
-/// Build a fit-scoped Rayon pool with the ferx worker stack and an explicit thread
-/// count. Used only when the caller pins `options.threads` to a positive value; the
-/// common (unpinned) path reuses the shared [`default_fit_pool`] instead.
-pub(crate) fn build_fit_pool(n_threads: usize) -> Result<rayon::ThreadPool, String> {
-    fit_thread_pool_builder()
-        .num_threads(n_threads)
-        .build()
-        .map_err(|e| format!("failed to build rayon pool with {n_threads} threads: {e}"))
 }
 
 /// The process-wide fit pool, built once with the ferx worker stack (32 MiB) so wide
@@ -134,74 +124,28 @@ pub(crate) fn default_fit_pool() -> Option<&'static rayon::ThreadPool> {
     .as_ref()
 }
 
-/// A pool whose workers all carry `ov`, built once per `(override, width)` and kept for the
-/// life of the process.
-///
-/// This is what makes a fit-scoped ODE override (#1212) correct under concurrency. The
-/// override has to reach the rayon workers doing the integrating, and a worker cannot tell
-/// which fit's task it is running — so instead of asking, the value is installed on the
-/// worker at thread start and the pool is *keyed by it*. A worker here serves only fits
-/// carrying this exact override; a fit with no override never enters this pool at all and
-/// integrates at the spec's baked options, whatever any concurrent fit is doing.
-///
-/// Cached rather than built per fit for the same reason [`default_fit_pool`] is shared: a
-/// bootstrap running hundreds of replicate fits off one `FitOptions` arms the same override
-/// every time, and a fresh `N × 32 MiB` pool per replicate would oversubscribe the CPUs and
-/// churn address space. Distinct overrides in one process are few (one per settings object a
-/// caller actually uses), so the table stays small.
-///
-/// Returns `None` if the pool cannot be built; callers must treat that as an error rather
-/// than running unpooled, since unpooled workers would silently integrate at the baked
-/// options — the exact failure #1212 is about.
+#[path = "pool_cache.rs"]
+mod cache;
+use cache::{FitPoolLease, PoolCache};
+
+fn fit_pool_cache() -> &'static PoolCache {
+    static CACHE: std::sync::OnceLock<PoolCache> = std::sync::OnceLock::new();
+    // Retain at most twice the automatic worker budget (at most 16 workers,
+    // 512 MiB reserved stack capacity), independently of the number of settings.
+    CACHE.get_or_init(|| PoolCache::new(default_thread_count() * 2))
+}
+
+/// Lease a pool carrying exactly this override. Idle pools are reused, but active
+/// callers never share one: identical settings must not collapse a batch's
+/// independently budgeted fits onto a single pool. Workers keep immutable ODE
+/// settings for their lifetime; eviction bounds idle workers across all keys.
+/// Acquisition never waits for a busy pool, including inside nested fits.
 pub(crate) fn ode_override_pool(
     ov: crate::ode::solver::OdeSolverOverride,
     n_threads: usize,
-) -> Option<&'static rayon::ThreadPool> {
-    /// `OdeSolverOverride` carries `f64`s, so it is keyed by bit pattern — two overrides that
-    /// differ only in a NaN payload would share a pool, which is harmless, and no tolerance
-    /// anyone can pass is a NaN.
-    type Key = (
-        usize,
-        u64,
-        u64,
-        Option<usize>,
-        Option<u8>,
-        Option<u64>,
-        Option<bool>,
-    );
-    fn key(ov: &crate::ode::solver::OdeSolverOverride, n: usize) -> Key {
-        (
-            n,
-            ov.reltol.map_or(u64::MAX, f64::to_bits),
-            ov.abstol.map_or(u64::MAX, f64::to_bits),
-            ov.max_steps,
-            ov.method.map(|m| m as u8),
-            ov.stiff_abort_after.map(|b| b.map_or(u64::MAX, u64::from)),
-            ov.auto_switch,
-        )
-    }
-    static POOLS: std::sync::Mutex<Option<HashMap<Key, &'static rayon::ThreadPool>>> =
-        std::sync::Mutex::new(None);
-
-    let mut guard = POOLS
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let pools = guard.get_or_insert_with(HashMap::new);
-    if let Some(pool) = pools.get(&key(&ov, n_threads)) {
-        return Some(pool);
-    }
-    let pool = fit_thread_pool_builder()
-        .num_threads(n_threads)
-        .start_handler(move |_| crate::ode::solver::install_worker_ode_override(ov))
-        .build()
-        .ok()?;
-    // Leaked deliberately: the pool outlives the fit that asked for it so the next fit with
-    // the same settings reuses it, exactly as `default_fit_pool` is reused.
-    let pool: &'static rayon::ThreadPool = Box::leak(Box::new(pool));
-    pools.insert(key(&ov, n_threads), pool);
-    Some(pool)
+) -> Option<FitPoolLease<'static>> {
+    fit_pool_cache().acquire(n_threads, ov).ok()
 }
-
 /// Run `f` with `options`' ODE solver settings reaching every thread that can integrate for
 /// it: armed on this thread, and — when the caller actually set one — on a pool whose workers
 /// carry the same value (see [`ode_override_pool`]).
@@ -234,11 +178,11 @@ pub(crate) fn with_fit_ode_scope<R: Send>(
 /// that same pool. Short-circuiting there looks like a free optimisation and is not: the
 /// caller's fallback is a pool built without the override, so a nested call that pinned
 /// `threads` would land on plain workers and integrate at the model file's options. Since the
-/// table is keyed, "the pool for these settings" is the one we are already on, and rayon runs
-/// an `install` on the current pool inline — the nesting costs nothing to begin with.
+/// cache lends idle pools exclusively, a nested call gets its own correctly configured
+/// pool. It never waits for an enclosing call to return a busy lease.
 pub(crate) fn ode_scope_pool(
     options: &FitOptions,
-) -> Result<Option<&'static rayon::ThreadPool>, String> {
+) -> Result<Option<FitPoolLease<'static>>, String> {
     let ov = options.ode_solver_override();
     if ov.is_empty() {
         return Ok(None);
@@ -259,7 +203,7 @@ pub(crate) fn ode_scope_pool(
 /// Run `f` on the pool this `fit()` call should use, with its ODE settings armed.
 ///
 /// Pool choice, in order: the pool carrying this call's ODE override when it set one (so the
-/// workers integrate at the requested accuracy — #1212); a fit-scoped pool sized to a pinned
+/// workers integrate at the requested accuracy — #1212); an exclusively leased pool sized to a pinned
 /// `threads`; otherwise the shared big-stack pool, falling back to the ambient one only if
 /// that one-time build failed, which must not turn a previously-successful default fit into an
 /// `Err`. One pool serves both levels of a multi-start fan-out, which is why this is called
@@ -273,9 +217,9 @@ pub(crate) fn install_on_fit_pool<R: Send>(
         return Ok(pool.install(f));
     }
     match options.threads.filter(|&n| n > 0) {
-        // A pinned positive `threads` builds a fit-scoped pool sized to it, and surfaces a
-        // build failure as `Err`.
-        Some(n) => Ok(build_fit_pool(n)?.install(f)),
+        // A pinned positive `threads` leases an idle pool or builds a new one,
+        // preserving independently budgeted concurrent fits.
+        Some(n) => Ok(fit_pool_cache().acquire(n, Default::default())?.install(f)),
         None => Ok(match default_fit_pool() {
             Some(pool) => pool.install(f),
             None => f(),
@@ -316,7 +260,7 @@ pub(crate) fn effective_default_threads() -> usize {
 ///
 /// Both are always ≥ 1, so a plan can never silently mean "let Rayon decide".
 ///
-/// The outer pool is built by [`install`](Self::install) with the ferx worker
+/// The outer pool is leased by [`install`](Self::install) with the ferx worker
 /// stack ([`FIT_RAYON_STACK_SIZE`]), **not** the platform default: wide ODE+IOV
 /// analytic-gradient models overflow a stock 2 MiB Rayon worker stack, and an
 /// outer pool built from a bare `rayon::ThreadPoolBuilder::new()` would inherit
@@ -409,7 +353,7 @@ impl PoolPlan {
         self.replicates.saturating_mul(self.threads_per_fit)
     }
 
-    /// Worker-stack size of the outer pool [`install`](Self::install) builds —
+    /// Worker-stack size of the outer pool [`install`](Self::install) leases —
     /// always [`FIT_RAYON_STACK_SIZE`], never the platform default.
     pub fn worker_stack_size(&self) -> usize {
         FIT_RAYON_STACK_SIZE
@@ -440,8 +384,9 @@ impl PoolPlan {
         options.threads = Some(self.threads_per_fit);
     }
 
-    /// Run `op` on an outer Rayon pool of [`replicates`](Self::replicates)
-    /// workers, each with the ferx worker stack ([`FIT_RAYON_STACK_SIZE`]).
+    /// Run `op` on an exclusively leased outer Rayon pool of
+    /// [`replicates`](Self::replicates) workers, each with the ferx worker stack
+    /// ([`FIT_RAYON_STACK_SIZE`]). Idle pools are reused within a bounded cache.
     ///
     /// Any `par_iter` inside `op` fans out over that pool. Returns `Err` if the
     /// pool cannot be built (e.g. resource limits).
@@ -450,7 +395,9 @@ impl PoolPlan {
         OP: FnOnce() -> R + Send,
         R: Send,
     {
-        Ok(build_fit_pool(self.replicates)?.install(op))
+        Ok(fit_pool_cache()
+            .acquire(self.replicates, Default::default())?
+            .install(op))
     }
 }
 

--- a/src/api/pool_cache.rs
+++ b/src/api/pool_cache.rs
@@ -91,7 +91,7 @@ impl PoolCache {
     }
 }
 
-/// Owns one pool until all work installed by this caller has completed. Returning
+/// Owns one pool until the caller's scoped work has completed. Returning
 /// it on unwind is safe too: Rayon propagates a panic after its scoped work joins.
 pub(crate) struct FitPoolLease<'a> {
     entry: Option<CachedPool>,

--- a/src/api/pool_cache.rs
+++ b/src/api/pool_cache.rs
@@ -1,18 +1,36 @@
-//! Exclusive pool leases: reuse idle workers without merging concurrent fit budgets.
+//! Persistent shared pools and exclusive leases for fit worker reuse.
 use super::fit_thread_pool_builder;
 use crate::ode::solver::OdeSolverOverride;
 use std::collections::VecDeque;
 use std::ops::Deref;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 struct CachedPool {
     pool: rayon::ThreadPool,
     ov: OdeSolverOverride,
 }
 
-/// Only idle workers count towards this cache's limit. Active callers retain
-/// their requested widths; acquisition never waits for another fit to finish,
-/// which also allows nested fits without a lease-capacity deadlock.
+struct SharedCachedPool {
+    pool: Arc<rayon::ThreadPool>,
+    ov: OdeSolverOverride,
+}
+
+fn build_pool(threads: usize, ov: OdeSolverOverride) -> Result<rayon::ThreadPool, String> {
+    fit_thread_pool_builder()
+        .num_threads(threads)
+        .start_handler(move |_| {
+            if !ov.is_empty() {
+                crate::ode::solver::install_worker_ode_override(ov);
+            }
+        })
+        .build()
+        .map_err(|e| format!("failed to build rayon pool with {threads} threads: {e}"))
+}
+
+/// Only idle workers count towards this cache's ordinary limit. Active callers
+/// retain their requested widths; acquisition never waits for another fit to
+/// finish. One most-recent oversized pool may remain idle so explicit wide
+/// configurations still benefit from reuse.
 pub(super) struct PoolCache {
     idle: Mutex<VecDeque<CachedPool>>,
     max_idle_workers: usize,
@@ -31,16 +49,18 @@ impl PoolCache {
         threads: usize,
         ov: OdeSolverOverride,
     ) -> Result<FitPoolLease<'_>, String> {
+        if threads == 0 {
+            return Err("thread count must be positive".to_string());
+        }
+        ov.validate()?;
         let cached = {
             let mut idle = self
                 .idle
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            // Search newest first to keep recently used workers hot. Validated
-            // overrides contain finite positive tolerances, so PartialEq is a
-            // complete settings key (including nested Options and false).
+            // Search newest first to keep recently used workers hot.
             idle.iter()
-                .rposition(|p| p.pool.current_num_threads() == threads && p.ov == ov)
+                .rposition(|p| p.pool.current_num_threads() == threads && p.ov.same_pool_key(&ov))
                 .and_then(|i| idle.remove(i))
         };
         let entry = match cached {
@@ -48,17 +68,7 @@ impl PoolCache {
             None => CachedPool {
                 // Build outside the lock: unrelated fits can acquire/return
                 // their leases while OS threads are being started.
-                pool: fit_thread_pool_builder()
-                    .num_threads(threads)
-                    .start_handler(move |_| {
-                        if !ov.is_empty() {
-                            crate::ode::solver::install_worker_ode_override(ov);
-                        }
-                    })
-                    .build()
-                    .map_err(|e| {
-                        format!("failed to build rayon pool with {threads} threads: {e}")
-                    })?,
+                pool: build_pool(threads, ov)?,
                 ov,
             },
         };
@@ -69,9 +79,6 @@ impl PoolCache {
     }
 
     fn release(&self, entry: CachedPool) {
-        if entry.pool.current_num_threads() > self.max_idle_workers {
-            return; // Oversized pools work normally, but are not retained idle.
-        }
         let mut evicted = Vec::new();
         {
             let mut idle = self
@@ -80,7 +87,11 @@ impl PoolCache {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             idle.push_back(entry);
             let mut workers: usize = idle.iter().map(|p| p.pool.current_num_threads()).sum();
-            while workers > self.max_idle_workers {
+            // Keep at least the newest pool even when it alone exceeds the
+            // ordinary idle-worker budget. This preserves reuse for an
+            // explicitly requested wide pool while retaining only one such
+            // reservation and evicting it as soon as a newer key is used.
+            while workers > self.max_idle_workers && idle.len() > 1 {
                 let p = idle.pop_front().expect("workers counted an idle pool");
                 workers -= p.pool.current_num_threads();
                 evicted.push(p);
@@ -88,6 +99,82 @@ impl PoolCache {
         }
         // Dropping a pool signals worker shutdown; do so without the cache lock.
         drop(evicted);
+    }
+}
+
+/// Shared pools for unpinned calls. Such calls did not request an independent
+/// worker budget, so callers with identical ODE settings may use one pool
+/// concurrently instead of multiplying the process worker count.
+pub(super) struct SharedPoolCache {
+    pools: Mutex<VecDeque<SharedCachedPool>>,
+    max_cached_workers: usize,
+}
+
+impl SharedPoolCache {
+    pub(super) fn new(max_cached_workers: usize) -> Self {
+        Self {
+            pools: Mutex::new(VecDeque::new()),
+            max_cached_workers,
+        }
+    }
+
+    pub(super) fn acquire(
+        &self,
+        threads: usize,
+        ov: OdeSolverOverride,
+    ) -> Result<Arc<rayon::ThreadPool>, String> {
+        if threads == 0 {
+            return Err("thread count must be positive".to_string());
+        }
+        ov.validate()?;
+        {
+            let mut pools = self
+                .pools
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(index) = pools
+                .iter()
+                .rposition(|p| p.pool.current_num_threads() == threads && p.ov.same_pool_key(&ov))
+            {
+                let entry = pools.remove(index).expect("matching shared pool");
+                let pool = Arc::clone(&entry.pool);
+                pools.push_back(entry);
+                return Ok(pool);
+            }
+        }
+
+        let built = Arc::new(build_pool(threads, ov)?);
+        let mut evicted = Vec::new();
+        {
+            let mut pools = self
+                .pools
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            // Another caller may have built the same key while this build ran.
+            // Prefer the pool it published so concurrent unpinned calls still
+            // converge on one shared budget.
+            if let Some(index) = pools
+                .iter()
+                .rposition(|p| p.pool.current_num_threads() == threads && p.ov.same_pool_key(&ov))
+            {
+                let entry = pools.remove(index).expect("matching shared pool");
+                let pool = Arc::clone(&entry.pool);
+                pools.push_back(entry);
+                return Ok(pool);
+            }
+            pools.push_back(SharedCachedPool {
+                pool: Arc::clone(&built),
+                ov,
+            });
+            let mut workers: usize = pools.iter().map(|p| p.pool.current_num_threads()).sum();
+            while workers > self.max_cached_workers && pools.len() > 1 {
+                let old = pools.pop_front().expect("workers counted a shared pool");
+                workers -= old.pool.current_num_threads();
+                evicted.push(old);
+            }
+        }
+        drop(evicted);
+        Ok(built)
     }
 }
 

--- a/src/api/pool_cache.rs
+++ b/src/api/pool_cache.rs
@@ -1,0 +1,119 @@
+//! Exclusive pool leases: reuse idle workers without merging concurrent fit budgets.
+use super::fit_thread_pool_builder;
+use crate::ode::solver::OdeSolverOverride;
+use std::collections::VecDeque;
+use std::ops::Deref;
+use std::sync::Mutex;
+
+struct CachedPool {
+    pool: rayon::ThreadPool,
+    ov: OdeSolverOverride,
+}
+
+/// Only idle workers count towards this cache's limit. Active callers retain
+/// their requested widths; acquisition never waits for another fit to finish,
+/// which also allows nested fits without a lease-capacity deadlock.
+pub(super) struct PoolCache {
+    idle: Mutex<VecDeque<CachedPool>>,
+    max_idle_workers: usize,
+}
+
+impl PoolCache {
+    pub(super) fn new(max_idle_workers: usize) -> Self {
+        Self {
+            idle: Mutex::new(VecDeque::new()),
+            max_idle_workers,
+        }
+    }
+
+    pub(super) fn acquire(
+        &self,
+        threads: usize,
+        ov: OdeSolverOverride,
+    ) -> Result<FitPoolLease<'_>, String> {
+        let cached = {
+            let mut idle = self
+                .idle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            // Search newest first to keep recently used workers hot. Validated
+            // overrides contain finite positive tolerances, so PartialEq is a
+            // complete settings key (including nested Options and false).
+            idle.iter()
+                .rposition(|p| p.pool.current_num_threads() == threads && p.ov == ov)
+                .and_then(|i| idle.remove(i))
+        };
+        let entry = match cached {
+            Some(p) => p,
+            None => CachedPool {
+                // Build outside the lock: unrelated fits can acquire/return
+                // their leases while OS threads are being started.
+                pool: fit_thread_pool_builder()
+                    .num_threads(threads)
+                    .start_handler(move |_| {
+                        if !ov.is_empty() {
+                            crate::ode::solver::install_worker_ode_override(ov);
+                        }
+                    })
+                    .build()
+                    .map_err(|e| {
+                        format!("failed to build rayon pool with {threads} threads: {e}")
+                    })?,
+                ov,
+            },
+        };
+        Ok(FitPoolLease {
+            entry: Some(entry),
+            cache: self,
+        })
+    }
+
+    fn release(&self, entry: CachedPool) {
+        if entry.pool.current_num_threads() > self.max_idle_workers {
+            return; // Oversized pools work normally, but are not retained idle.
+        }
+        let mut evicted = Vec::new();
+        {
+            let mut idle = self
+                .idle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            idle.push_back(entry);
+            let mut workers: usize = idle.iter().map(|p| p.pool.current_num_threads()).sum();
+            while workers > self.max_idle_workers {
+                let p = idle.pop_front().expect("workers counted an idle pool");
+                workers -= p.pool.current_num_threads();
+                evicted.push(p);
+            }
+        }
+        // Dropping a pool signals worker shutdown; do so without the cache lock.
+        drop(evicted);
+    }
+}
+
+/// Owns one pool until all work installed by this caller has completed. Returning
+/// it on unwind is safe too: Rayon propagates a panic after its scoped work joins.
+pub(crate) struct FitPoolLease<'a> {
+    entry: Option<CachedPool>,
+    cache: &'a PoolCache,
+}
+
+impl Deref for FitPoolLease<'_> {
+    type Target = rayon::ThreadPool;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entry.as_ref().expect("live pool lease").pool
+    }
+}
+
+impl Drop for FitPoolLease<'_> {
+    fn drop(&mut self) {
+        if let Some(entry) = self.entry.take() {
+            self.cache.release(entry);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "tests/pool_cache_tests.rs"]
+mod tests;

--- a/src/api/run.rs
+++ b/src/api/run.rs
@@ -999,10 +999,9 @@ fn obs_routing_for(model: &CompiledModel, missing_dv: MissingDvPolicy) -> ObsRou
     // binary-only `Vec` above, and the two are equal today only because CTMM `--simulate`
     // is rejected upstream. When CTMM simulation lands (#820) they diverge.
     let discrete_cmts: std::collections::HashSet<usize> = {
-        let mut discrete: std::collections::HashSet<usize> =
-            model.binary_cmts().into_iter().collect();
+        let discrete: std::collections::HashSet<usize> = model.binary_cmts().into_iter().collect();
         #[cfg(feature = "markov")]
-        discrete.extend(model.ctmm_cmts());
+        let discrete = discrete.into_iter().chain(model.ctmm_cmts()).collect();
         discrete
     };
     #[cfg(not(feature = "survival"))]

--- a/src/api/tests/pool_cache_tests.rs
+++ b/src/api/tests/pool_cache_tests.rs
@@ -1,9 +1,16 @@
 use super::*;
 use crate::ode::solver::{effective_solver_options, OdeMethod, OdeSolverOptions};
+use std::collections::HashSet;
 use std::thread;
 
 fn worker(pool: &rayon::ThreadPool) -> thread::ThreadId {
     pool.install(|| thread::current().id())
+}
+
+fn workers(pool: &rayon::ThreadPool) -> HashSet<thread::ThreadId> {
+    pool.broadcast(|_| thread::current().id())
+        .into_iter()
+        .collect()
 }
 
 #[test]
@@ -81,7 +88,7 @@ fn settings_and_width_are_part_of_the_key() {
 }
 
 #[test]
-fn idle_worker_budget_evicts_oldest_settings_and_rejects_oversized_pools() {
+fn idle_worker_budget_evicts_oldest_settings_and_keeps_one_oversized_pool() {
     let cache = PoolCache::new(2);
     for n in 1..=5 {
         let ov = OdeSolverOverride {
@@ -96,12 +103,66 @@ fn idle_worker_budget_evicts_oldest_settings_and_rejects_oversized_pools() {
         assert_eq!(idle[0].ov.max_steps, Some(4));
         assert_eq!(idle[1].ov.max_steps, Some(5));
     }
-    drop(cache.acquire(3, Default::default()).unwrap());
-    assert_eq!(cache.idle.lock().unwrap().len(), 2);
+    let wide_workers = {
+        let wide = cache.acquire(3, Default::default()).unwrap();
+        workers(&wide)
+    };
+    {
+        let idle = cache.idle.lock().unwrap();
+        assert_eq!(idle.len(), 1);
+        assert_eq!(idle[0].pool.current_num_threads(), 3);
+    }
+    let reused_wide = cache.acquire(3, Default::default()).unwrap();
+    assert_eq!(workers(&reused_wide), wide_workers);
+    drop(reused_wide);
     drop(cache.acquire(2, Default::default()).unwrap());
     let idle = cache.idle.lock().unwrap();
     assert_eq!(idle.len(), 1);
     assert_eq!(idle[0].pool.current_num_threads(), 2);
+}
+
+#[test]
+fn shared_cache_reuses_one_live_pool_for_identical_unpinned_calls() {
+    let cache = SharedPoolCache::new(4);
+    let ov = OdeSolverOverride {
+        reltol: Some(1e-9),
+        ..Default::default()
+    };
+    let first = cache.acquire(2, ov).unwrap();
+    let second = cache.acquire(2, ov).unwrap();
+    assert!(std::sync::Arc::ptr_eq(&first, &second));
+}
+
+#[test]
+fn invalid_rust_api_overrides_are_rejected_before_pool_build() {
+    let cache = PoolCache::new(4);
+    for (ov, field) in [
+        (
+            OdeSolverOverride {
+                reltol: Some(f64::NAN),
+                ..Default::default()
+            },
+            "ode_reltol",
+        ),
+        (
+            OdeSolverOverride {
+                abstol: Some(0.0),
+                ..Default::default()
+            },
+            "ode_abstol",
+        ),
+        (
+            OdeSolverOverride {
+                max_steps: Some(0),
+                ..Default::default()
+            },
+            "ode_max_steps",
+        ),
+    ] {
+        let err = cache.acquire(1, ov).err().expect("invalid override");
+        assert!(err.contains(field), "{err}");
+    }
+    assert!(cache.idle.lock().unwrap().is_empty());
 }
 
 #[test]

--- a/src/api/tests/pool_cache_tests.rs
+++ b/src/api/tests/pool_cache_tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+use crate::ode::solver::{effective_solver_options, OdeMethod, OdeSolverOptions};
+use std::thread;
+
+fn worker(pool: &rayon::ThreadPool) -> thread::ThreadId {
+    pool.install(|| thread::current().id())
+}
+
+#[test]
+fn completed_leases_reuse_workers_but_live_leases_are_exclusive() {
+    let cache = PoolCache::new(4);
+    let first = cache.acquire(1, Default::default()).unwrap();
+    let id = worker(&first);
+    let concurrent = cache.acquire(1, Default::default()).unwrap();
+    assert_ne!(id, worker(&concurrent));
+    drop(first);
+    let reused = cache.acquire(1, Default::default()).unwrap();
+    assert_eq!(id, worker(&reused));
+}
+
+#[test]
+fn settings_and_width_are_part_of_the_key() {
+    let cache = PoolCache::new(16);
+    let base = OdeSolverOverride {
+        reltol: Some(1e-9),
+        ..Default::default()
+    };
+    let id = {
+        let p = cache.acquire(1, base).unwrap();
+        worker(&p)
+    };
+    for ov in [
+        OdeSolverOverride::default(),
+        OdeSolverOverride {
+            reltol: Some(1e-10),
+            ..base
+        },
+        OdeSolverOverride {
+            abstol: Some(1e-12),
+            ..base
+        },
+        OdeSolverOverride {
+            max_steps: Some(13),
+            ..base
+        },
+        OdeSolverOverride {
+            method: Some(OdeMethod::Vern7),
+            ..base
+        },
+        OdeSolverOverride {
+            stiff_abort_after: Some(None),
+            ..base
+        },
+        OdeSolverOverride {
+            stiff_abort_after: Some(Some(0)),
+            ..base
+        },
+        OdeSolverOverride {
+            auto_switch: Some(false),
+            ..base
+        },
+    ] {
+        let p = cache.acquire(1, ov).unwrap();
+        assert_ne!(id, worker(&p));
+        let baked = OdeSolverOptions::default();
+        p.install(|| {
+            let actual = effective_solver_options(baked);
+            let expected = ov.apply_to(baked);
+            assert_eq!(actual.reltol, expected.reltol);
+            assert_eq!(actual.abstol, expected.abstol);
+            assert_eq!(actual.max_steps, expected.max_steps);
+            assert_eq!(actual.method, expected.method);
+            assert_eq!(actual.stiff_abort_after, expected.stiff_abort_after);
+            assert_eq!(actual.auto_switch, expected.auto_switch);
+        });
+    }
+    let wide = cache.acquire(2, base).unwrap();
+    assert_eq!(wide.current_num_threads(), 2);
+    assert_ne!(worker(&wide), id);
+    assert_eq!(worker(&cache.acquire(1, base).unwrap()), id);
+}
+
+#[test]
+fn idle_worker_budget_evicts_oldest_settings_and_rejects_oversized_pools() {
+    let cache = PoolCache::new(2);
+    for n in 1..=5 {
+        let ov = OdeSolverOverride {
+            max_steps: Some(n),
+            ..Default::default()
+        };
+        drop(cache.acquire(1, ov).unwrap());
+    }
+    {
+        let idle = cache.idle.lock().unwrap();
+        assert_eq!(idle.len(), 2);
+        assert_eq!(idle[0].ov.max_steps, Some(4));
+        assert_eq!(idle[1].ov.max_steps, Some(5));
+    }
+    drop(cache.acquire(3, Default::default()).unwrap());
+    assert_eq!(cache.idle.lock().unwrap().len(), 2);
+    drop(cache.acquire(2, Default::default()).unwrap());
+    let idle = cache.idle.lock().unwrap();
+    assert_eq!(idle.len(), 1);
+    assert_eq!(idle[0].pool.current_num_threads(), 2);
+}
+
+#[test]
+fn panic_returns_a_usable_lease_and_nested_acquisition_never_waits() {
+    let cache = PoolCache::new(4);
+    let first = cache.acquire(1, Default::default()).unwrap();
+    let id = worker(&first);
+    let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _lease = first;
+        _lease.install(|| panic!("intentional worker panic"));
+    }));
+    assert!(panic.is_err());
+    let reused = cache.acquire(1, Default::default()).unwrap();
+    assert_eq!(worker(&reused), id);
+    reused.install(|| {
+        let nested = cache.acquire(1, Default::default()).unwrap();
+        assert_ne!(worker(&nested), id);
+    });
+}
+
+#[test]
+fn poisoned_cache_lock_is_recovered() {
+    let cache = PoolCache::new(1);
+    let _ = std::panic::catch_unwind(|| {
+        let _guard = cache.idle.lock().unwrap();
+        panic!("poison the idle list");
+    });
+    drop(cache.acquire(1, Default::default()).unwrap());
+    assert_eq!(
+        cache
+            .idle
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len(),
+        1
+    );
+}

--- a/src/api/tests/pool_plan_tests.rs
+++ b/src/api/tests/pool_plan_tests.rs
@@ -173,7 +173,7 @@ fn apply_to_pins_the_inner_fit_thread_count() {
 /// against regression deadlocks; successful runs do not sleep.
 #[test]
 fn identical_overrides_preserve_concurrent_fit_capacity() {
-    use std::{sync::mpsc, thread, time::Duration};
+    use std::{sync::mpsc, thread, time::Duration, time::Instant};
     let options = FitOptions {
         threads: Some(1),
         ode_reltol: 1e-11,
@@ -201,8 +201,11 @@ fn identical_overrides_preserve_concurrent_fit_capacity() {
                 .unwrap();
             }));
         }
-        let first = entered_rx.recv_timeout(Duration::from_secs(5));
-        let second = entered_rx.recv_timeout(Duration::from_secs(2));
+        let deadline = Instant::now() + Duration::from_secs(15);
+        let receive_before_deadline =
+            || entered_rx.recv_timeout(deadline.saturating_duration_since(Instant::now()));
+        let first = receive_before_deadline();
+        let second = receive_before_deadline();
         // Unblock both callers before asserting so a failing test joins cleanly.
         for tx in releases {
             let _ = tx.send(());
@@ -213,6 +216,58 @@ fn identical_overrides_preserve_concurrent_fit_capacity() {
         assert_ne!(
             first.unwrap(),
             second.expect("second fit was serialized onto the first fit's pool")
+        );
+    });
+}
+
+#[test]
+fn fit_routing_rejects_invalid_programmatic_ode_options() {
+    for (options, field) in [
+        (
+            FitOptions {
+                ode_reltol: f64::NAN,
+                ..Default::default()
+            },
+            "ode_reltol",
+        ),
+        (
+            FitOptions {
+                ode_abstol: -1.0,
+                ..Default::default()
+            },
+            "ode_abstol",
+        ),
+        (
+            FitOptions {
+                ode_max_steps: 0,
+                ..Default::default()
+            },
+            "ode_max_steps",
+        ),
+    ] {
+        let err = install_on_fit_pool(&options, || panic!("invalid options reached the fit"))
+            .expect_err("invalid Rust API options");
+        assert!(err.contains(field), "{err}");
+    }
+}
+
+#[test]
+fn nested_ode_scope_stays_on_the_enclosing_fit_pool() {
+    use std::thread;
+    let options = FitOptions {
+        threads: Some(1),
+        ode_reltol: 1e-11,
+        ..Default::default()
+    };
+    let ov = options.ode_solver_override();
+    let pool = ode_override_pool(ov, 1).expect("outer override pool");
+    pool.install(|| {
+        let outer_worker = thread::current().id();
+        let nested_worker =
+            with_fit_ode_scope(&options, || thread::current().id()).expect("nested ODE scope");
+        assert_eq!(
+            nested_worker, outer_worker,
+            "an internal SIR-style scope leased a second pool"
         );
     });
 }

--- a/src/api/tests/pool_plan_tests.rs
+++ b/src/api/tests/pool_plan_tests.rs
@@ -168,6 +168,55 @@ fn apply_to_pins_the_inner_fit_thread_count() {
     assert_eq!(opts.threads, Some(4));
 }
 
+/// Exercise the actual routing, not just the cache: an override must not divert
+/// two independently budgeted calls to one busy worker. Timeouts only guard
+/// against regression deadlocks; successful runs do not sleep.
+#[test]
+fn identical_overrides_preserve_concurrent_fit_capacity() {
+    use std::{sync::mpsc, thread, time::Duration};
+    let options = FitOptions {
+        threads: Some(1),
+        ode_reltol: 1e-11,
+        ..Default::default()
+    };
+    let (entered_tx, entered_rx) = mpsc::channel();
+    thread::scope(|scope| {
+        let mut releases = Vec::new();
+        let mut handles = Vec::new();
+        for _ in 0..2 {
+            let (tx, rx) = mpsc::channel();
+            releases.push(tx);
+            let entered = entered_tx.clone();
+            let opts = &options;
+            handles.push(scope.spawn(move || {
+                install_on_fit_pool(opts, move || {
+                    assert_eq!(rayon::current_num_threads(), 1);
+                    assert_eq!(
+                        crate::ode::solver::effective_solver_options(Default::default()).reltol,
+                        1e-11
+                    );
+                    entered.send(thread::current().id()).unwrap();
+                    rx.recv_timeout(Duration::from_secs(10)).unwrap();
+                })
+                .unwrap();
+            }));
+        }
+        let first = entered_rx.recv_timeout(Duration::from_secs(5));
+        let second = entered_rx.recv_timeout(Duration::from_secs(2));
+        // Unblock both callers before asserting so a failing test joins cleanly.
+        for tx in releases {
+            let _ = tx.send(());
+        }
+        for handle in handles {
+            handle.join().unwrap();
+        }
+        assert_ne!(
+            first.unwrap(),
+            second.expect("second fit was serialized onto the first fit's pool")
+        );
+    });
+}
+
 // ── end-to-end: what the inner fit actually does with the plan ───────────────
 
 fn one_cpt_model() -> CompiledModel {

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -3435,12 +3435,6 @@ impl VarianceDecl {
         }
     }
 
-    /// Is this a `block_omega` / `block_kappa` diagonal, where `L_ii` carries
-    /// the off-diagonals and no per-eta declared variance describes it?
-    fn is_block_element(&self) -> bool {
-        self.block_keyword().is_some()
-    }
-
     /// How the enclosing block is spelled in the model file, for the arm that
     /// reports a near-singular block. `None` for anything that is not a block
     /// diagonal.

--- a/src/estimation/focei_pipeline_tests.rs
+++ b/src/estimation/focei_pipeline_tests.rs
@@ -1,0 +1,288 @@
+use super::*;
+use crate::parser::model_parser::parse_model_string;
+
+fn fixture(iov: bool, mixed_fallback: bool) -> (CompiledModel, Population) {
+    let kappa = if iov { "kappa KAPPA_CL ~ 0.03" } else { "" };
+    let cl = if iov {
+        "TVCL * exp(ETA_CL + KAPPA_CL)"
+    } else {
+        "TVCL * exp(ETA_CL)"
+    };
+    let model = parse_model_string(&format!(
+        "[parameters]\n theta TVCL(5, 0.1, 50)\n theta TVV(50, 5, 500)\n omega ETA_CL ~ 0.04\n {kappa}\n sigma PROP ~ 0.01\n[individual_parameters]\n CL = {cl}\n V = TVV\n F = 0.7\n[structural_model]\n pk one_cpt_iv(cl=CL, v=V, f=F)\n[error_model]\n DV ~ proportional(PROP)"
+    )).unwrap();
+    let mut pop = make_population(3);
+    for (i, s) in pop.subjects.iter_mut().enumerate() {
+        s.id = (i + 1).to_string();
+        s.observations = s
+            .obs_times
+            .iter()
+            .enumerate()
+            .map(|(j, &t)| 1.4 * (-0.1 * t).exp() * (0.92 + 0.04 * (i + j) as f64))
+            .collect();
+        if iov {
+            s.occasions = vec![1, 1, 2];
+            s.doses.push(DoseEvent::new(6.0, 100.0, 1, 0.0, false, 0.0));
+            s.dose_occasions.push(2);
+        }
+    }
+    if mixed_fallback {
+        // The analytic provider deliberately declines rate-defined infusion
+        // under F: F reshapes its duration. Other subjects remain analytic.
+        pop.subjects[0].doses[0] = DoseEvent::new(0.0, 100.0, 1, 25.0, false, 0.0);
+    }
+    (model, pop)
+}
+
+fn bits(values: &[f64]) -> Vec<u64> {
+    values.iter().map(|v| v.to_bits()).collect()
+}
+
+#[test]
+fn fused_inner_and_marginal_match_separate_passes() {
+    for iov in [false, true] {
+        let (model, pop) = fixture(iov, false);
+        let params = &model.default_params;
+        for interaction in [false, true] {
+            let opts = FitOptions {
+                interaction,
+                inner_maxiter: 4,
+                min_obs_for_convergence_check: 4,
+                ..Default::default()
+            };
+            let mu = compute_mu_k(&model, &params.theta, true);
+            for width in [1, 3] {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(width)
+                    .stack_size(crate::FIT_RAYON_STACK_SIZE)
+                    .build()
+                    .unwrap();
+                pool.install(|| {
+                    let reference = run_inner_loop_warm(
+                        &model,
+                        &pop,
+                        params,
+                        4,
+                        opts.inner_tol,
+                        None,
+                        Some(&mu),
+                        4,
+                        opts.inner_restarts,
+                    );
+                    for warm in [None, Some(reference.0.as_slice())] {
+                        let separate = run_inner_loop_warm(
+                            &model,
+                            &pop,
+                            params,
+                            4,
+                            opts.inner_tol,
+                            warm,
+                            Some(&mu),
+                            4,
+                            opts.inner_restarts,
+                        );
+                        let expected_nll = if iov {
+                            crate::stats::likelihood::foce_population_nll_iov(
+                                &model,
+                                &pop,
+                                &params.theta,
+                                &separate.0,
+                                &separate.1,
+                                &separate.3,
+                                &params.omega,
+                                params.omega_iov.as_ref().unwrap(),
+                                &params.sigma.values,
+                                interaction,
+                            )
+                        } else {
+                            crate::stats::likelihood::foce_population_nll(
+                                &model,
+                                &pop,
+                                &params.theta,
+                                &separate.0,
+                                &separate.1,
+                                &params.omega,
+                                &params.sigma.values,
+                                &params.residual_correlations,
+                                interaction,
+                            )
+                        };
+                        let fused =
+                            run_inner_loop_and_nll(&model, &pop, params, &opts, warm, Some(&mu));
+                        assert_eq!(expected_nll.to_bits(), fused.4.to_bits());
+                        for (a, b) in separate.0.iter().zip(&fused.0) {
+                            assert_eq!(bits(a.as_slice()), bits(b.as_slice()));
+                        }
+                        for (a, b) in separate.1.iter().zip(&fused.1) {
+                            assert_eq!(bits(a.as_slice()), bits(b.as_slice()));
+                        }
+                        assert_eq!(separate.3, fused.3);
+                        assert_eq!(separate.2.n_unconverged, fused.2.n_unconverged);
+                        assert_eq!(separate.2.n_fallback, fused.2.n_fallback);
+                        assert_eq!(separate.2.n_start_rejected, fused.2.n_start_rejected);
+                    }
+                });
+            }
+        }
+    }
+}
+
+#[test]
+fn fused_dispatch_keeps_laplace_and_agq_objectives() {
+    let (model, pop) = fixture(false, false);
+    let params = &model.default_params;
+    for (method, n_agq) in [(EstimationMethod::Laplace, 1), (EstimationMethod::FoceI, 3)] {
+        let opts = FitOptions {
+            method,
+            n_agq,
+            inner_maxiter: 3,
+            ..Default::default()
+        };
+        let separate = run_inner_loop_warm(
+            &model,
+            &pop,
+            params,
+            3,
+            opts.inner_tol,
+            None,
+            None,
+            opts.min_obs_for_convergence_check as usize,
+            opts.inner_restarts,
+        );
+        let expected = pop_nll_opts(
+            &model,
+            &pop,
+            params,
+            &separate.0,
+            &separate.1,
+            &separate.3,
+            &opts,
+        );
+        let fused = run_inner_loop_and_nll(&model, &pop, params, &opts, None, None);
+        assert_eq!(expected.to_bits(), fused.4.to_bits());
+    }
+}
+
+#[test]
+fn fused_gradient_preserves_analytic_and_subject_fallback_results() {
+    for iov in [false, true] {
+        for mixed in [false, true] {
+            let (model, pop) = fixture(iov, mixed);
+            let params = &model.default_params;
+            let x = pack_params(params);
+            let bounds = compute_bounds(params);
+            for interaction in [false, true] {
+                let opts = FitOptions {
+                    interaction,
+                    inner_maxiter: 4,
+                    ..Default::default()
+                };
+                let (etas, _, _, kappas) =
+                    run_inner_loop_warm(&model, &pop, params, 4, opts.inner_tol, None, None, 0, 0);
+                let per_subject = if iov {
+                    crate::estimation::sens_outer_gradient::per_subject_packed_gradients_iov(
+                        &model,
+                        &pop,
+                        params,
+                        &x,
+                        &etas,
+                        &kappas,
+                        interaction,
+                    )
+                } else {
+                    crate::estimation::sens_outer_gradient::per_subject_packed_gradients(
+                        &model,
+                        &pop,
+                        params,
+                        &x,
+                        &etas,
+                        interaction,
+                        None,
+                    )
+                };
+                if mixed {
+                    assert!(
+                        per_subject[0].is_none(),
+                        "infusion must exercise FD fallback"
+                    );
+                    assert!(
+                        per_subject[1].is_some(),
+                        "bolus must keep analytic gradient"
+                    );
+                }
+                let mut expected = vec![0.0; x.len()];
+                for (i, g) in per_subject.into_iter().enumerate() {
+                    let g = match g {
+                        Some(g) if g.iter().all(|v| v.is_finite()) => g,
+                        _ if iov => subject_reconverged_fd_gradient_iov(
+                            &x,
+                            params,
+                            &model,
+                            &pop.subjects[i],
+                            &etas[i],
+                            &bounds,
+                            &opts,
+                        ),
+                        _ => subject_reconverged_fd_gradient(
+                            &x,
+                            params,
+                            &model,
+                            &pop.subjects[i],
+                            &etas[i],
+                            &bounds,
+                            &opts,
+                        ),
+                    };
+                    for (acc, value) in expected.iter_mut().zip(g) {
+                        *acc += 2.0 * value;
+                    }
+                }
+                let actual = if iov {
+                    population_gradient_sens_iov_mixed(
+                        &x, params, &model, &pop, &etas, &kappas, &bounds, &opts,
+                    )
+                } else {
+                    population_gradient_sens_mixed(&x, params, &model, &pop, &etas, &bounds, &opts)
+                };
+                assert_eq!(bits(&expected), bits(&actual));
+            }
+        }
+    }
+}
+
+#[test]
+fn inner_map_completes_each_subject_before_returning_its_buffers() {
+    let (model, pop) = fixture(false, false);
+    let params = &model.default_params;
+    let result = run_inner_loop_warm_map(
+        &model,
+        &pop,
+        params,
+        3,
+        1e-6,
+        None,
+        None,
+        0,
+        0,
+        |subject, ebe| {
+            (
+                subject.id.clone(),
+                ebe.eta.as_ptr() as usize,
+                ebe.h_matrix.as_ptr() as usize,
+            )
+        },
+    );
+    for (i, (id, eta_ptr, h_ptr)) in result.4.iter().enumerate() {
+        assert_eq!(id, &pop.subjects[i].id);
+        assert_eq!(
+            *eta_ptr,
+            result.0[i].as_ptr() as usize,
+            "eta buffer was copied after EBE"
+        );
+        assert_eq!(
+            *h_ptr,
+            result.1[i].as_ptr() as usize,
+            "Jacobian buffer was copied after EBE"
+        );
+    }
+}

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -827,9 +827,9 @@ pub fn find_ebe(
     // to re-sort + re-allocate on every call. The EventPkParams scratch
     // recycles the per-event Vec<PkParams> backing storage.
     //
-    // Both are built only when this subject takes the TV-cov event-driven
-    // analytical path — for the no-TV fast path the schedule is None and
-    // event_driven_predictions is never called.
+    // Event parameter storage is allocated lazily by per-event prediction paths.
+    // The schedule is built only when cacheable_schedule permits reuse; a static
+    // fast path needs neither event storage nor a merged schedule.
     let pk_scratch_cell = RefCell::new(pk::EventPkParams::default());
     let schedule = cacheable_schedule(model, subject);
     // Custom / time-varying residual-magnitude (#484/#576): η-independent, so

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1,6 +1,8 @@
 use crate::pk;
+#[cfg(test)]
+use crate::stats::likelihood::individual_nll_iov;
 use crate::stats::likelihood::{
-    individual_nll_into_with_schedule, individual_nll_iov, iov_occasion_groups,
+    individual_nll_into_with_schedule, individual_nll_iov_with_scratch, iov_occasion_groups,
 };
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
@@ -828,7 +830,7 @@ pub fn find_ebe(
     // Both are built only when this subject takes the TV-cov event-driven
     // analytical path — for the no-TV fast path the schedule is None and
     // event_driven_predictions is never called.
-    let pk_scratch_cell = RefCell::new(pk::EventPkParams::with_capacity_for(subject));
+    let pk_scratch_cell = RefCell::new(pk::EventPkParams::default());
     let schedule = cacheable_schedule(model, subject);
     // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
     // computed once per subject here — not inside `agrad`, which BFGS calls on
@@ -1200,6 +1202,9 @@ fn find_ebe_iov(
     }
 
     let omega_iov_ref = params.omega_iov.as_ref();
+    // One buffer set per EBE solve, shared by its serial objective/line-search/FD
+    // probes. Each probe rewrites every event; no parameter values are cached.
+    let pk_scratch = RefCell::new(pk::EventPkParams::default());
 
     let obj = |p: &[f64]| -> f64 {
         // Recover bsv_eta = psi - mu; kappas pass through unchanged.
@@ -1211,7 +1216,7 @@ fn find_ebe_iov(
         let kappas: Vec<Vec<f64>> = (0..k_occasions)
             .map(|k| p[n_eta + k * n_kappa..n_eta + (k + 1) * n_kappa].to_vec())
             .collect();
-        individual_nll_iov(
+        individual_nll_iov_with_scratch(
             model,
             subject,
             &params.theta,
@@ -1220,6 +1225,7 @@ fn find_ebe_iov(
             &params.omega,
             omega_iov_ref,
             &params.sigma.values,
+            &mut pk_scratch.borrow_mut(),
         )
     };
 
@@ -3366,15 +3372,54 @@ pub fn run_inner_loop_warm(
     InnerLoopStats,
     Vec<Vec<DVector<f64>>>,
 ) {
+    let (etas, h_matrices, stats, kappas, _) = run_inner_loop_warm_map(
+        model,
+        population,
+        params,
+        max_iter,
+        tol,
+        prev_etas,
+        mu_k,
+        min_obs,
+        restarts,
+        |_, _| (),
+    );
+    (etas, h_matrices, stats, kappas)
+}
+
+/// Finish subject-local work on the same worker immediately after its EBE solve,
+/// before the population barrier. The FOCE outer loop uses this to score the
+/// marginal without launching another subject pass. Results retain subject order.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub(crate) fn run_inner_loop_warm_map<T: Send>(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    max_iter: usize,
+    tol: f64,
+    prev_etas: Option<&[DVector<f64>]>,
+    mu_k: Option<&[f64]>,
+    min_obs: usize,
+    restarts: usize,
+    finish_subject: impl Fn(&Subject, &EbeResult) -> T + Sync,
+) -> (
+    Vec<DVector<f64>>,
+    Vec<DMatrix<f64>>,
+    InnerLoopStats,
+    Vec<Vec<DVector<f64>>>,
+    Vec<T>,
+) {
     use rayon::prelude::*;
 
-    let results: Vec<EbeResult> = population
+    let results: Vec<(EbeResult, T)> = population
         .subjects
         .par_iter()
         .enumerate()
         .map(|(i, subject)| {
             let init = prev_etas.map(|pe| pe[i].as_slice());
-            find_ebe(model, subject, params, max_iter, tol, init, mu_k, restarts)
+            let ebe = find_ebe(model, subject, params, max_iter, tol, init, mu_k, restarts);
+            let extra = finish_subject(subject, &ebe);
+            (ebe, extra)
         })
         .collect();
 
@@ -3382,18 +3427,27 @@ pub fn run_inner_loop_warm(
         n_unconverged: results
             .iter()
             .zip(population.subjects.iter())
-            .filter(|(r, s)| !r.converged && s.observations.len() >= min_obs.max(1))
+            .filter(|((r, _), s)| !r.converged && s.observations.len() >= min_obs.max(1))
             .count(),
-        n_fallback: results.iter().filter(|r| r.used_fallback).count(),
+        n_fallback: results.iter().filter(|(r, _)| r.used_fallback).count(),
         // No `min_obs` filter: a hard reject forces trial rejection even for a single
         // short-record subject, which the `n_unconverged` filter would otherwise drop.
-        n_start_rejected: results.iter().filter(|r| r.hard_reject).count(),
+        n_start_rejected: results.iter().filter(|(r, _)| r.hard_reject).count(),
     };
-    let eta_hats: Vec<DVector<f64>> = results.iter().map(|r| r.eta.clone()).collect();
-    let h_matrices: Vec<DMatrix<f64>> = results.iter().map(|r| r.h_matrix.clone()).collect();
-    let kappas: Vec<Vec<DVector<f64>>> = results.into_iter().map(|r| r.kappas).collect();
+    let mut eta_hats = Vec::with_capacity(results.len());
+    let mut h_matrices = Vec::with_capacity(results.len());
+    let mut kappas = Vec::with_capacity(results.len());
+    let mut extras = Vec::with_capacity(results.len());
+    for (result, extra) in results {
+        // Transfer the completed EBE buffers instead of cloning every subject's
+        // eta vector and prediction Jacobian at each outer evaluation.
+        eta_hats.push(result.eta);
+        h_matrices.push(result.h_matrix);
+        kappas.push(result.kappas);
+        extras.push(extra);
+    }
 
-    (eta_hats, h_matrices, stats, kappas)
+    (eta_hats, h_matrices, stats, kappas, extras)
 }
 
 #[cfg(test)]

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1,6 +1,8 @@
-use crate::estimation::inner_optimizer::{find_ebe, run_inner_loop_warm, InnerLoopStats};
+use crate::estimation::inner_optimizer::{
+    find_ebe, run_inner_loop_warm, run_inner_loop_warm_map, InnerLoopStats,
+};
 use crate::estimation::parameterization::{compute_mu_k, *};
-use crate::stats::likelihood::{foce_population_nll, foce_population_nll_iov};
+use crate::stats::likelihood::{foce_subject_nll, foce_subject_nll_iov};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 // `SymmetricEigen` is used only by this module's `#[cfg(test)]` code (the non-PD
@@ -705,8 +707,9 @@ pub(crate) fn max_scaled_deviation(a: &[f64], b: &[f64]) -> f64 {
 /// The population objective the outer loop actually minimises: [`pop_nll`] (FOCE/FOCEI),
 /// or the AGQ marginal when the stage's method is `agq`.
 ///
-/// **Every** production site that needs "the objective for *this* fit" must call this, not
-/// `pop_nll` — the objective closures, the reconverged-FD gradient, and the covariance
+/// Production sites needing "the objective for *this* fit" use this dispatcher, or
+/// [`run_inner_loop_and_nll`] when solving EBEs too — never call `pop_nll` directly.
+/// This includes the objective closures, reconverged-FD gradient, and covariance
 /// stencil alike. An AGQ fit whose covariance step differenced the *FOCE* objective would
 /// report standard errors for a likelihood it never optimised.
 ///
@@ -760,28 +763,58 @@ pub(crate) fn pop_nll(
     kappas: &[Vec<DVector<f64>>],
     interaction: bool,
 ) -> f64 {
+    let per_subject: Vec<f64> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map(|(i, subject)| {
+            subject_nll(
+                model,
+                subject,
+                params,
+                &eta_hats[i],
+                &h_matrices[i],
+                kappas.get(i).map_or(&[], Vec::as_slice),
+                interaction,
+            )
+        })
+        .collect();
+    // Preserve the existing subject-index summation order, including at width 1.
+    per_subject.iter().sum()
+}
+
+/// Shared subject dispatch for separate and fused population evaluations.
+fn subject_nll(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    eta: &DVector<f64>,
+    h_matrix: &DMatrix<f64>,
+    kappas: &[DVector<f64>],
+    interaction: bool,
+) -> f64 {
     if model.n_kappa > 0 {
         if let Some(ref iov) = params.omega_iov {
-            return foce_population_nll_iov(
+            return foce_subject_nll_iov(
                 model,
-                population,
+                subject,
                 &params.theta,
-                eta_hats,
-                h_matrices,
-                kappas,
+                eta,
+                h_matrix,
                 &params.omega,
-                iov,
                 &params.sigma.values,
                 interaction,
+                kappas,
+                iov,
             );
         }
     }
-    foce_population_nll(
+    foce_subject_nll(
         model,
-        population,
+        subject,
         &params.theta,
-        eta_hats,
-        h_matrices,
+        eta,
+        h_matrix,
         &params.omega,
         &params.sigma.values,
         // Live `block_sigma` off-diagonals (#847): this is the objective the
@@ -790,6 +823,73 @@ pub(crate) fn pop_nll(
         &params.residual_correlations,
         interaction,
     )
+}
+
+/// Continue from each EBE directly into its marginal contribution on the same
+/// worker. Only the population sum needs a barrier. AGQ keeps its separate
+/// quadrature evaluation; it must never receive the FOCE marginal instead.
+#[allow(clippy::type_complexity)]
+fn run_inner_loop_and_nll(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    options: &FitOptions,
+    prev_etas: Option<&[DVector<f64>]>,
+    mu_k: Option<&[f64]>,
+) -> (
+    Vec<DVector<f64>>,
+    Vec<DMatrix<f64>>,
+    InnerLoopStats,
+    Vec<Vec<DVector<f64>>>,
+    f64,
+) {
+    if options.agq_nodes().is_some() {
+        let (etas, h_matrices, stats, kappas) = run_inner_loop_warm(
+            model,
+            population,
+            params,
+            options.inner_maxiter,
+            options.inner_tol,
+            prev_etas,
+            mu_k,
+            options.min_obs_for_convergence_check as usize,
+            options.inner_restarts,
+        );
+        let nll = pop_nll_opts(
+            model,
+            population,
+            params,
+            &etas,
+            &h_matrices,
+            &kappas,
+            options,
+        );
+        return (etas, h_matrices, stats, kappas, nll);
+    }
+    let (etas, h_matrices, stats, kappas, contributions) = run_inner_loop_warm_map(
+        model,
+        population,
+        params,
+        options.inner_maxiter,
+        options.inner_tol,
+        prev_etas,
+        mu_k,
+        options.min_obs_for_convergence_check as usize,
+        options.inner_restarts,
+        |subject, ebe| {
+            subject_nll(
+                model,
+                subject,
+                params,
+                &ebe.eta,
+                &ebe.h_matrix,
+                &ebe.kappas,
+                options.interaction,
+            )
+        },
+    );
+    let nll = contributions.iter().sum();
+    (etas, h_matrices, stats, kappas, nll)
 }
 
 /// State passed through NLopt's user-data mechanism
@@ -992,18 +1092,14 @@ fn run_global_presearch(
         let params = unpack_params(&x, init_params);
         let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
         let cached_zero = vec![DVector::zeros(n_eta); n_subj];
-        let (ehs, hms, ebe_stats, kappas) = run_inner_loop_warm(
+        let (_, _, ebe_stats, _, nll) = run_inner_loop_and_nll(
             model,
             population,
             &params,
-            options.inner_maxiter,
-            options.inner_tol,
+            options,
             Some(&cached_zero),
             Some(&mu_k),
-            options.min_obs_for_convergence_check as usize,
-            options.inner_restarts,
         );
-        let nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
         let raw = 2.0 * nll + nn_reg.penalty_value(&params.theta);
         let guarded = ebe_guard_rejects(&ebe_stats, n_subj, raw, options.max_unconverged_frac);
@@ -1033,19 +1129,14 @@ fn run_global_presearch(
         let params = unpack_params(&x, init_params);
         let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
 
-        let (ehs, hms, ebe_stats, kappas) = run_inner_loop_warm(
+        let (_, hms, ebe_stats, _, nll) = run_inner_loop_and_nll(
             model,
             population,
             &params,
-            options.inner_maxiter,
-            options.inner_tol,
+            options,
             Some(&state.cached_etas),
             Some(&mu_k),
-            options.min_obs_for_convergence_check as usize,
-            options.inner_restarts,
         );
-
-        let nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
         let raw_ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta);
 
@@ -1689,18 +1780,14 @@ fn optimize_nlopt_once(
             }
         } else {
             let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
-            let (ehs, hms, ebe_stats, kappas) = run_inner_loop_warm(
+            let (ehs, hms, ebe_stats, kappas, nll) = run_inner_loop_and_nll(
                 model,
                 population,
                 &params,
-                options.inner_maxiter,
-                options.inner_tol,
+                options,
                 Some(&state.cached_etas),
                 Some(&mu_k),
-                options.min_obs_for_convergence_check as usize,
-                options.inner_restarts,
             );
-            let nll = pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options);
             (ehs, hms, ebe_stats, kappas, 2.0 * nll)
         };
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
@@ -2391,20 +2478,16 @@ fn optimize_bfgs(
     let f_only = |x: &[f64], prev_etas: &[DVector<f64>]| -> f64 {
         let params = unpack_params(x, init_params);
         let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
-        let (ehs, hms, _, kappas) = run_inner_loop_warm(
+        let (_, _, _, _, nll) = run_inner_loop_and_nll(
             model,
             population,
             &params,
-            options.inner_maxiter,
-            options.inner_tol,
+            options,
             Some(prev_etas),
             Some(&mu_k),
-            options.min_obs_for_convergence_check as usize,
-            options.inner_restarts,
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
-        let ofv = 2.0 * pop_nll_opts(model, population, &params, &ehs, &hms, &kappas, options)
-            + nn_reg.penalty_value(&params.theta);
+        let ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta);
         if ofv.is_finite() {
             ofv
         } else {
@@ -2418,18 +2501,15 @@ fn optimize_bfgs(
      -> (f64, Vec<f64>, Vec<DVector<f64>>, Vec<DMatrix<f64>>) {
         let params = unpack_params(x, init_params);
         let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
-        let (ehs, hms, _, kappas) = run_inner_loop_warm(
+        let (ehs, hms, _, kappas, nll) = run_inner_loop_and_nll(
             model,
             population,
             &params,
-            options.inner_maxiter,
-            options.inner_tol,
+            options,
             Some(prev_etas),
             Some(&mu_k),
-            options.min_obs_for_convergence_check as usize,
-            options.inner_restarts,
         );
-        let ofv = ofv_at_fixed(x, &ehs, &hms, &kappas);
+        let ofv = 2.0 * nll;
         // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x).
         let mut g = population_gradient(
             x,
@@ -3009,31 +3089,44 @@ pub(crate) fn population_gradient_sens_mixed(
     options: &FitOptions,
 ) -> Vec<f64> {
     let np = x.len();
-    let per_sub = crate::estimation::sens_outer_gradient::per_subject_packed_gradients(
-        model,
-        population,
-        init_params,
-        x,
-        ehs,
-        options.interaction,
-        None,
-    );
-    let filled: Vec<Vec<f64>> = per_sub
-        .into_par_iter()
+    let filled: Vec<Vec<f64>> = population
+        .subjects
+        .par_iter()
         .enumerate()
-        .map(|(i, gi)| match gi {
-            // Keep the exact analytic gradient for in-scope, finite subjects.
-            Some(g) if g.iter().all(|v| v.is_finite()) => g,
-            // Out-of-scope (or non-finite analytic) → reconverged per-subject FD.
-            _ => subject_reconverged_fd_gradient(
-                x,
-                init_params,
-                model,
-                &population.subjects[i],
-                &ehs[i],
-                bounds,
-                options,
-            ),
+        .map(|(i, subject)| {
+            // Complete the fallback on this worker as soon as its analytic
+            // result is known; do not wait for a second population-wide pass.
+            let gi = if options.interaction {
+                crate::estimation::sens_outer_gradient::subject_packed_gradient(
+                    model,
+                    subject,
+                    init_params,
+                    x,
+                    ehs[i].as_slice(),
+                )
+            } else {
+                crate::estimation::sens_outer_gradient::subject_packed_gradient_foce(
+                    model,
+                    subject,
+                    init_params,
+                    x,
+                    ehs[i].as_slice(),
+                )
+            };
+            match gi {
+                // Keep the exact analytic gradient for in-scope, finite subjects.
+                Some(g) if g.iter().all(|v| v.is_finite()) => g,
+                // Out-of-scope (or non-finite analytic) → reconverged per-subject FD.
+                _ => subject_reconverged_fd_gradient(
+                    x,
+                    init_params,
+                    model,
+                    subject,
+                    &ehs[i],
+                    bounds,
+                    options,
+                ),
+            }
         })
         .collect();
     let mut grad = vec![0.0f64; np];
@@ -3071,29 +3164,44 @@ pub(crate) fn population_gradient_sens_iov_mixed(
     options: &FitOptions,
 ) -> Vec<f64> {
     let np = x.len();
-    let per_sub = crate::estimation::sens_outer_gradient::per_subject_packed_gradients_iov(
-        model,
-        population,
-        init_params,
-        x,
-        ehs,
-        kappas,
-        options.interaction,
-    );
-    let filled: Vec<Vec<f64>> = per_sub
-        .into_par_iter()
+    let filled: Vec<Vec<f64>> = population
+        .subjects
+        .par_iter()
         .enumerate()
-        .map(|(i, gi)| match gi {
-            Some(g) if g.iter().all(|v| v.is_finite()) => g,
-            _ => subject_reconverged_fd_gradient_iov(
-                x,
-                init_params,
-                model,
-                &population.subjects[i],
-                &ehs[i],
-                bounds,
-                options,
-            ),
+        .map(|(i, subject)| {
+            let mut stacked: Vec<f64> = ehs[i].iter().copied().collect();
+            for kap in &kappas[i] {
+                stacked.extend(kap.iter().copied());
+            }
+            let gi = if options.interaction {
+                crate::estimation::sens_outer_gradient::subject_packed_gradient_iov(
+                    model,
+                    subject,
+                    init_params,
+                    x,
+                    &stacked,
+                )
+            } else {
+                crate::estimation::sens_outer_gradient::subject_packed_gradient_foce_iov(
+                    model,
+                    subject,
+                    init_params,
+                    x,
+                    &stacked,
+                )
+            };
+            match gi {
+                Some(g) if g.iter().all(|v| v.is_finite()) => g,
+                _ => subject_reconverged_fd_gradient_iov(
+                    x,
+                    init_params,
+                    model,
+                    subject,
+                    &ehs[i],
+                    bounds,
+                    options,
+                ),
+            }
         })
         .collect();
     let mut grad = vec![0.0f64; np];

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -9,6 +9,9 @@ use crate::estimation::covariance::{
 };
 use crate::estimation::parameterization::{compute_bounds, pack_params};
 
+#[path = "focei_pipeline_tests.rs"]
+mod pipeline;
+
 /// The guard-rejected objective (`guard_penalty_value`) must **integrate** the
 /// center-push gradient `g[i] = 100·(xs[i] − c[i])` the closures return alongside it —
 /// otherwise NLopt's More-Thuente line search cannot reconcile `f` and `∇f` and fails on

--- a/src/estimation/sir.rs
+++ b/src/estimation/sir.rs
@@ -477,10 +477,9 @@ pub fn run_sir_core(
     options: &FitOptions,
 ) -> Result<SirResult, String> {
     // #1212: the math kernel is public API in its own right, so it opens the fit-scoped ODE
-    // scope too rather than relying on its caller having done so. Called from `run_sir` or
-    // `fit()` this costs nothing — the threads already carry that override, which the scope
-    // detects — while a direct caller gets the tolerances they passed instead of the spec's
-    // parse-time ones.
+    // scope too rather than relying on its caller having done so. Inside `fit()` the current
+    // worker already carries that override, which the scope detects without leasing a second
+    // pool; a direct caller gets the tolerances it passed instead of the spec's parse-time ones.
     crate::api::with_fit_ode_scope(options, || {
         run_sir_core_scoped(
             model,

--- a/src/estimation/vi/elbo.rs
+++ b/src/estimation/vi/elbo.rs
@@ -269,6 +269,8 @@ pub fn stacked_prior(
 /// The two failure modes therefore get different treatment, and conflating them
 /// is exactly how a scope gap turns into silently wrong estimates.
 pub fn unsupported_data_term_reason(model: &CompiledModel) -> Option<String> {
+    #[cfg(not(feature = "survival"))]
+    let _ = model;
     // The data term is `obs_nll_subject_grad`'s NLL, and
     // `obs_nll_subject_from_preds` *skips* rows belonging to a non-Gaussian
     // endpoint (#905) — they are scored through `obs_records` instead. Fitting

--- a/src/estimation/vi/run_tests.rs
+++ b/src/estimation/vi/run_tests.rs
@@ -1220,7 +1220,7 @@ fn sigma_closed_form_falls_back_loudly_on_combined_error() {
 /// a model that reaches `−283` once `φ` is allowed to finish.
 #[test]
 fn param_criterion_is_vacuous_when_every_population_parameter_is_fixed() {
-    let (model, _population, params) = fixture();
+    let (_model, _population, params) = fixture();
     assert!(
         super::param_criterion_applies(&params),
         "a model with free θ/Ω/σ must keep the parameter-stability criterion"

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -5173,7 +5173,7 @@ fn infusion_into_non_input_rate_cmt_is_untouched_on_gated_engines() {
 
     for i in 0..obs.len() {
         assert!(plain[i] > 0.0, "obs {i}: reference is degenerate (zero)");
-        for (engine, got) in [
+        for (_engine, got) in [
             ("ode_predictions_with_states", ws_pred[i]),
             ("with_states.state", ws[i][1]),
             ("ode_dense_solve_states", dense[i][1]),
@@ -10588,11 +10588,14 @@ mod break_collision_1186 {
 // measured right on both signs.
 mod lag_arrival_read_1226 {
     use super::*;
+    #[cfg(feature = "survival")]
     use crate::types::{PkModel, MAX_PK_PARAMS, PK_IDX_CL, PK_IDX_F, PK_IDX_LAGTIME, PK_IDX_V};
 
     const DOSE_TIME: f64 = 7.9;
     const OBS_TIME: f64 = 8.2;
+    #[cfg(feature = "survival")]
     const CL: f64 = 1.0;
+    #[cfg(feature = "survival")]
     const V: f64 = 10.0;
 
     /// NONMEM's own `ARR = TDOS + ALAG1` column, printed at 17 significant digits so the
@@ -10613,8 +10616,10 @@ mod lag_arrival_read_1226 {
     const NM_AFTER_ADVAN1: [f64; 2] = [4.5384479528235588E+01, 1.3420678956342749E+02];
     /// `results/lag_arrival_read_before_advan13.tab`, `IPRED = A(1)/V` — the ODE twin of
     /// the analytic ADVAN1 run, at `TOL=9`. Multiplied by `V` to compare as an amount.
+    #[cfg(feature = "survival")]
     const NM_BEFORE_ADVAN13: [f64; 2] = [1.4538447943810009E+01, 1.3420678940629491E+01];
     /// `results/lag_arrival_read_after_advan13.tab`, same columns.
+    #[cfg(feature = "survival")]
     const NM_AFTER_ADVAN13: [f64; 2] = [4.5384479438102048E+00, 1.3420678940629784E+01];
 
     /// 1-cpt IV, one state, amount readout — the ferx twin of `ADVAN1 TRANS2` with no
@@ -10623,6 +10628,7 @@ mod lag_arrival_read_1226 {
     /// only compartment resolves to — and the same slot the analytic
     /// `predict_concentration` arm reads, so every engine below sees one lag from one
     /// number.
+    #[cfg(feature = "survival")]
     fn spec() -> OdeSpec {
         OdeSpec {
             solver_opts: OdeSolverOptions {
@@ -10634,6 +10640,7 @@ mod lag_arrival_read_1226 {
         }
     }
 
+    #[cfg(feature = "survival")]
     fn pk_flat(lag: f64) -> Vec<f64> {
         let mut p = vec![0.0; MAX_PK_PARAMS];
         p[PK_IDX_CL] = CL;
@@ -10649,6 +10656,7 @@ mod lag_arrival_read_1226 {
     /// victim dose lands with the compartment non-empty and the pre/post-dose reads are
     /// 45.38 vs 145.38. On a single-dose fixture the incoming side is `g(x⁻) = 0` and a
     /// pre-dose read of 0.0 is indistinguishable from "nothing has happened yet".
+    #[cfg(feature = "survival")]
     fn doses() -> Vec<DoseEvent> {
         vec![
             DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
@@ -10673,6 +10681,7 @@ mod lag_arrival_read_1226 {
 
     /// Central **amount** at `t` from the closed form: the first dose's residual plus the
     /// second dose iff it has already arrived.
+    #[cfg(feature = "survival")]
     fn closed_form(t: f64, lag: f64, post_dose: bool) -> f64 {
         let ke = CL / V;
         let second = if post_dose {
@@ -10683,6 +10692,7 @@ mod lag_arrival_read_1226 {
         100.0 * (-ke * (t - lag)).exp() + second
     }
 
+    #[cfg(feature = "survival")]
     const ENGINES: [&str; 6] = [
         "ode_predictions",
         "ode_predictions_with_states",

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -2015,9 +2015,8 @@ mod tests {
     // serialising against the rest of the binary, and adding a lock would hide the very
     // property they exist to check. Two things still follow. Assert from the thread that
     // should see the value (arming thread, or inside `pool.install`), since the *absence* of
-    // an override elsewhere is half of what is being pinned. And prefer values that tighten
-    // accuracy: `ode_override_pool` caches a pool per override for the life of the process,
-    // so an exotic one costs a set of worker threads that never go away.
+    // an override elsewhere is half of what is being pinned. Idle override pools are reused
+    // within a bounded worker cache; live leases retain independent fit budgets.
 
     /// The whole merge rule rests on this: `ode_solver_override` treats "equal to the
     /// `FitOptions` default" as "the caller expressed no opinion", which is only sound
@@ -2323,8 +2322,8 @@ mod tests {
 
     /// The pool table is keyed by the override, so two different settings must not land on one
     /// pool — that would hand a fit another's tolerance through the very mechanism meant to
-    /// keep them apart — and the same settings must reuse one, or a bootstrap's replicate fits
-    /// would each spawn an `N × 32 MiB` pool.
+    /// keep them apart. Simultaneous leases with the same settings must also remain distinct,
+    /// or a bootstrap's independently budgeted replicate fits would share one worker budget.
     #[test]
     fn the_override_pool_table_is_keyed_by_the_override() {
         let a = OdeSolverOverride {
@@ -2339,17 +2338,22 @@ mod tests {
         let pool_b = crate::api::ode_override_pool(b, 2).expect("pool b");
         let pool_a_again = crate::api::ode_override_pool(a, 2).expect("pool a again");
         assert!(
-            std::ptr::eq(pool_a, pool_a_again),
-            "the same override built a second pool instead of reusing its own"
+            pool_a.install(|| std::thread::current().id())
+                != pool_a_again.install(|| std::thread::current().id()),
+            "concurrent fits with the same override must have independent workers"
         );
         assert!(
-            !std::ptr::eq(pool_a, pool_b),
+            pool_a.install(|| std::thread::current().id())
+                != pool_b.install(|| std::thread::current().id()),
             "two different overrides share one pool, so its workers carry the wrong one"
         );
         // Width is part of the key too: a fit that pinned `threads` must not be handed a pool
         // of some other width.
         let narrow = crate::api::ode_override_pool(a, 1).expect("pool a, one thread");
-        assert!(!std::ptr::eq(pool_a, narrow));
+        assert!(
+            pool_a.install(|| std::thread::current().id())
+                != narrow.install(|| std::thread::current().id())
+        );
         assert_eq!(narrow.current_num_threads(), 1);
     }
 

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -337,6 +337,37 @@ impl OdeSolverOverride {
         *self == Self::default()
     }
 
+    /// Reject values that the model-file parser would reject before they can
+    /// reach a worker pool through the public Rust API.
+    pub(crate) fn validate(&self) -> Result<(), String> {
+        for (name, value) in [("ode_reltol", self.reltol), ("ode_abstol", self.abstol)] {
+            if let Some(value) = value {
+                if !value.is_finite() || value <= 0.0 {
+                    return Err(format!("{name} must be finite and positive, got {value}"));
+                }
+            }
+        }
+        if self.max_steps == Some(0) {
+            return Err("ode_max_steps must be positive, got 0".to_string());
+        }
+        Ok(())
+    }
+
+    /// Cache-key equality uses the float representation explicitly. Validation
+    /// keeps NaNs and signed zero out, while bit comparison makes the key's
+    /// behavior independent of `f64`'s partial equality rules.
+    pub(crate) fn same_pool_key(&self, other: &Self) -> bool {
+        fn bits(value: Option<f64>) -> Option<u64> {
+            value.map(f64::to_bits)
+        }
+        bits(self.reltol) == bits(other.reltol)
+            && bits(self.abstol) == bits(other.abstol)
+            && self.max_steps == other.max_steps
+            && self.method == other.method
+            && self.stiff_abort_after == other.stiff_abort_after
+            && self.auto_switch == other.auto_switch
+    }
+
     /// Merge onto a spec's baked options. Unset fields keep the baked value, so a model file's
     /// `[fit_options]` still wins wherever the caller expressed no opinion.
     pub(crate) fn apply_to(&self, base: OdeSolverOptions) -> OdeSolverOptions {
@@ -404,6 +435,16 @@ pub(crate) fn effective_solver_options(baked: OdeSolverOptions) -> OdeSolverOpti
 
 pub(crate) fn install_worker_ode_override(ov: OdeSolverOverride) {
     LOCAL_OVERRIDE.set(Some(Some(ov)));
+}
+
+/// True only on a worker that already carries this non-empty override. Call
+/// before arming a nested entry point on its caller thread.
+pub(crate) fn worker_carries_ode_override(ov: OdeSolverOverride) -> bool {
+    !ov.is_empty()
+        && LOCAL_OVERRIDE
+            .get()
+            .flatten()
+            .is_some_and(|current| current.same_pool_key(&ov))
 }
 
 /// Arms `ov` on this thread until the returned guard drops, restoring whatever was in force
@@ -2148,17 +2189,13 @@ mod tests {
         // still reads its own value — so the assertions all happen while all three arms and
         // one deliberately-empty arm are live at once.
         let (armed_tx, armed) = channel::<()>();
-        let (go_tx, go) = channel::<()>();
         let arms = [Some(1e-9), Some(1e-11), Some(1e-13), None];
 
         std::thread::scope(|s| {
             let mut releases = Vec::new();
             for want in arms {
-                let (release_tx, release) = (go_tx.clone(), {
-                    let (tx, rx) = channel::<()>();
-                    releases.push(tx);
-                    rx
-                });
+                let (tx, release) = channel::<()>();
+                releases.push(tx);
                 let armed_tx = armed_tx.clone();
                 s.spawn(move || {
                     let _guard = arm_ode_solver_override(OdeSolverOverride {
@@ -2174,7 +2211,6 @@ mod tests {
                         want.unwrap_or(baked.reltol),
                         "a concurrent fit's ODE settings reached this one"
                     );
-                    drop(release_tx);
                 });
             }
             for _ in arms {

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1370,6 +1370,7 @@ impl ThetaRefScope {
     }
 
     /// θ indices referenced so far in this scope.
+    #[cfg(feature = "nn")]
     fn recorded() -> Vec<usize> {
         REFERENCED_THETAS.with(|c| c.borrow().clone())
     }

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -12397,7 +12397,7 @@ fn test_clamp_in_individual_parameters() {
     let eta = vec![0.0];
     let mut covs = HashMap::new();
 
-    let mut cl_at = |wt: f64, covs: &mut HashMap<String, f64>| {
+    let cl_at = |wt: f64, covs: &mut HashMap<String, f64>| {
         covs.insert("WT".to_string(), wt);
         (parsed.model.pk_param_fn)(&theta, &eta, covs, 0.0).values[0]
     };

--- a/src/pk/iov_scratch_tests.rs
+++ b/src/pk/iov_scratch_tests.rs
@@ -243,3 +243,48 @@ fn iov_likelihood_with_scratch_matches_fresh_calls_at_changed_parameters() {
         assert_eq!(expected.to_bits(), actual.to_bits());
     }
 }
+
+#[test]
+fn reused_iov_predictions_match_dual2_eta_derivatives() {
+    let subj = subject();
+    let m = model(false);
+    let theta = [3., 20.];
+    let effects = [0.1, 0.3, -0.2];
+    let dual = crate::sens::provider::subject_sensitivities_iov(&m, &subj, &theta, &effects)
+        .expect("fixture must exercise Dual2, not FD fallback");
+    let mut scratch = EventPkParams::default();
+    let mut worst: f64 = 0.;
+    for axis in 0..effects.len() {
+        let h = 1e-5;
+        let mut plus = effects;
+        let mut minus = effects;
+        plus[axis] += h;
+        minus[axis] -= h;
+        let mut predict = |e: &[f64; 3]| {
+            predict_iov_with_scratch(
+                &m,
+                &subj,
+                &theta,
+                &e[..1],
+                &[vec![e[1]], vec![e[2]]],
+                &mut scratch,
+            )
+        };
+        let a = predict(&plus);
+        let b = predict(&minus);
+        for (j, obs) in dual.obs.iter().enumerate() {
+            let fd = (a[j] - b[j]) / (2. * h);
+            let analytic = obs.df_deta[axis];
+            assert!(fd.is_finite() && analytic.is_finite());
+            let error = (analytic - fd).abs() / (1. + fd.abs());
+            worst = worst.max(error);
+            // Measured worst scaled error: 1.76e-11 on Windows/nightly.
+            // 1e-9 leaves about 57x headroom for platform rounding.
+            assert!(
+                error < 1e-9,
+                "axis {axis}, obs {j}: Dual2={analytic}, FD={fd}"
+            );
+        }
+    }
+    eprintln!("scratch Dual2/FD worst scaled error: {worst:e}");
+}

--- a/src/pk/iov_scratch_tests.rs
+++ b/src/pk/iov_scratch_tests.rs
@@ -1,0 +1,245 @@
+use super::*;
+use crate::parser::model_parser::parse_model_string;
+use crate::stats::likelihood::{individual_nll_iov, individual_nll_iov_with_scratch};
+use std::collections::HashMap;
+
+fn model(ode: bool) -> CompiledModel {
+    let structural = if ode {
+        "ode(states=[central])\n[odes]\n init(central) = BASE\n d/dt(central) = -(CL/V)*central\n[scaling]\n y = central/V"
+    } else {
+        "pk one_cpt_iv(cl=CL, v=V)"
+    };
+    parse_model_string(&format!(
+        "[parameters]\n theta TVCL(3, 0.1, 30)\n theta TVV(20, 2, 200)\n omega ETA_CL ~ 0.04\n kappa KAPPA_CL ~ 0.03\n sigma PROP ~ 0.04\n[individual_parameters]\n CL = TVCL * (WT/70) * exp(ETA_CL + KAPPA_CL) * (1 + 0.001*TIME)\n V = TVV\n BASE = WT\n[structural_model]\n {structural}\n[error_model]\n DV ~ proportional(PROP)"
+    )).unwrap()
+}
+fn cov(wt: f64) -> HashMap<String, f64> {
+    HashMap::from([("WT".into(), wt)])
+}
+fn subject() -> Subject {
+    Subject {
+        id: "1".into(),
+        doses: vec![
+            DoseEvent::new(0., 100., 1, 0., false, 0.),
+            DoseEvent::new(24., 100., 1, 0., false, 0.),
+        ],
+        dose_occasions: vec![11, 22],
+        dose_covariates: vec![cov(75.), cov(105.)],
+        obs_times: vec![1., 3., 25., 27.],
+        observations: vec![1.; 4],
+        obs_cmts: vec![1; 4],
+        occasions: vec![11, 11, 22, 22],
+        obs_covariates: vec![cov(80.), cov(90.), cov(100.), cov(110.)],
+        covariates: cov(70.),
+        cens: vec![0; 4],
+        pk_only_times: vec![10.],
+        pk_only_covariates: vec![cov(95.)],
+        reset_times: vec![23.],
+        reset_covariates: vec![cov(120.)],
+        reset_occasions: vec![22],
+        ..Default::default()
+    }
+}
+fn bits(v: &[f64]) -> Vec<u64> {
+    v.iter().map(|x| x.to_bits()).collect()
+}
+fn pointers(s: &EventPkParams) -> [usize; 4] {
+    [
+        s.dose.as_ptr() as usize,
+        s.obs.as_ptr() as usize,
+        s.pk_only.as_ptr() as usize,
+        s.reset.as_ptr() as usize,
+    ]
+}
+
+#[test]
+fn lazy_event_scratch_matches_preallocated_predictions_and_reuses_storage() {
+    for ode in [false, true] {
+        let m = model(ode);
+        let subj = subject();
+        let mut lazy = EventPkParams::default();
+        let mut eager = EventPkParams::with_capacity_for(&subj);
+        let mut storage = None;
+        for eta in [0.1, -0.3, 0.1] {
+            let a = compute_predictions_with_tv_into(&m, &subj, &[3., 20.], &[eta, 0.], &mut lazy);
+            let b = compute_predictions_with_tv_into(&m, &subj, &[3., 20.], &[eta, 0.], &mut eager);
+            assert_eq!(bits(&a), bits(&b));
+            assert!(a.iter().all(|v| v.is_finite()));
+            if let Some(before) = storage {
+                assert_eq!(before, pointers(&lazy));
+            }
+            storage = Some(pointers(&lazy));
+        }
+    }
+}
+
+#[test]
+fn static_predictions_leave_event_scratch_unallocated() {
+    let m = parse_model_string(
+        "[parameters]\n theta TVCL(3, 0.1, 30)\n theta TVV(20, 2, 200)\n sigma PROP ~ 0.04\n[individual_parameters]\n CL = TVCL\n V = TVV\n[structural_model]\n pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n DV ~ proportional(PROP)"
+    ).unwrap();
+    let subj = Subject {
+        doses: vec![DoseEvent::new(0., 100., 1, 0., false, 0.)],
+        obs_times: vec![1., 3.],
+        observations: vec![1.; 2],
+        obs_cmts: vec![1; 2],
+        ..Default::default()
+    };
+    let mut scratch = EventPkParams::default();
+    let result = compute_predictions_with_tv_into(&m, &subj, &[3., 20.], &[], &mut scratch);
+    assert_eq!(result.len(), 2);
+    assert!(result.iter().all(|v| v.is_finite() && *v > 0.));
+    assert_eq!(
+        [
+            scratch.dose.capacity(),
+            scratch.obs.capacity(),
+            scratch.pk_only.capacity(),
+            scratch.reset.capacity()
+        ],
+        [0; 4]
+    );
+}
+
+#[test]
+fn iov_scratch_reuses_capacity_but_refreshes_every_event_snapshot() {
+    let subj = subject();
+    for ode in [false, true] {
+        let m = model(ode);
+        let mut scratch = EventPkParams::default();
+        let mut prior = None;
+        let mut storage = None;
+        for (cl, eta, k1, k2) in [
+            (3., 0.1, 0.3, -0.2),
+            (4., -0.3, -0.6, 0.5),
+            (3., 0.1, 0.3, -0.2),
+        ] {
+            let theta = [cl, 20.];
+            let kappas = vec![vec![k1], vec![k2]];
+            let fresh = predict_iov(&m, &subj, &theta, &[eta], &kappas);
+            let reused = predict_iov_with_scratch(&m, &subj, &theta, &[eta], &kappas, &mut scratch);
+            assert_eq!(bits(&fresh), bits(&reused));
+            assert!(reused.iter().all(|v| v.is_finite() && *v > 0.));
+            if let Some(before) = prior {
+                assert_ne!(before, bits(&reused));
+            }
+            prior = Some(bits(&reused));
+            if let Some(before) = storage {
+                assert_eq!(before, pointers(&scratch));
+            }
+            storage = Some(pointers(&scratch));
+            let expected_cl = |wt: f64, time: f64, k: f64| {
+                cl * (wt / 70.) * (eta + k).exp() * (1. + 0.001 * time)
+            };
+            for (j, wt) in [80., 90., 100., 110.].into_iter().enumerate() {
+                let k = if j < 2 { k1 } else { k2 };
+                approx::assert_relative_eq!(
+                    scratch.obs[j].cl(),
+                    expected_cl(wt, subj.obs_times[j], k),
+                    max_relative = 1e-13
+                );
+            }
+            approx::assert_relative_eq!(
+                scratch.dose[1].cl(),
+                expected_cl(105., 24., k2),
+                max_relative = 1e-13
+            );
+            approx::assert_relative_eq!(
+                scratch.pk_only[0].cl(),
+                expected_cl(95., 10., 0.),
+                max_relative = 1e-13
+            );
+            if ode {
+                approx::assert_relative_eq!(
+                    scratch.reset[0].cl(),
+                    expected_cl(120., 23., k2),
+                    max_relative = 1e-13
+                );
+            } else {
+                assert!(scratch.reset.is_empty());
+            }
+        }
+    }
+}
+
+#[test]
+fn iov_scratch_shrinks_and_clears_unused_event_vectors() {
+    let ode = model(true);
+    let analytical = model(false);
+    let mut subj = subject();
+    let mut scratch = EventPkParams::default();
+    let theta = [3., 20.];
+    let kappas = vec![vec![0.2], vec![-0.1]];
+    predict_iov_with_scratch(&ode, &subj, &theta, &[0.1], &kappas, &mut scratch);
+    assert_eq!(scratch.reset.len(), 1);
+    let capacity = scratch.obs.capacity();
+    subj.obs_times.truncate(1);
+    subj.observations.truncate(1);
+    subj.obs_cmts.truncate(1);
+    subj.obs_covariates.truncate(1);
+    subj.occasions.truncate(1);
+    subj.cens.truncate(1);
+    subj.pk_only_times.clear();
+    subj.pk_only_covariates.clear();
+    let actual =
+        predict_iov_with_scratch(&analytical, &subj, &theta, &[0.1], &kappas, &mut scratch);
+    assert_eq!(
+        bits(&actual),
+        bits(&predict_iov(&analytical, &subj, &theta, &[0.1], &kappas))
+    );
+    assert_eq!(scratch.obs.len(), 1);
+    assert_eq!(scratch.obs.capacity(), capacity);
+    assert!(scratch.pk_only.is_empty() && scratch.reset.is_empty());
+    // A Gaussian-only subject with no observations still gets a dose-side
+    // snapshot. Its observation, pk-only and unused reset storage must be empty.
+    subj.obs_times.clear();
+    subj.observations.clear();
+    subj.obs_cmts.clear();
+    subj.obs_covariates.clear();
+    subj.occasions.clear();
+    subj.cens.clear();
+    subj.doses = vec![DoseEvent::new(0., 100., 1, 0., false, 0.)];
+    subj.dose_occasions = vec![11];
+    subj.dose_covariates = vec![cov(75.)];
+    assert!(
+        predict_iov_with_scratch(&analytical, &subj, &theta, &[0.1], &kappas, &mut scratch)
+            .is_empty()
+    );
+    assert_eq!(scratch.dose.len(), 1);
+    assert!(scratch.obs.is_empty() && scratch.pk_only.is_empty() && scratch.reset.is_empty());
+}
+
+#[test]
+fn iov_likelihood_with_scratch_matches_fresh_calls_at_changed_parameters() {
+    let subj = subject();
+    let m = model(false);
+    let params = &m.default_params;
+    let mut scratch = EventPkParams::default();
+    for shift in [-0.3, 0.1, 0.5] {
+        let theta = [3. + shift, 20.];
+        let eta = [shift];
+        let kappas = vec![vec![shift * 2.], vec![-shift]];
+        let expected = individual_nll_iov(
+            &m,
+            &subj,
+            &theta,
+            &eta,
+            &kappas,
+            &params.omega,
+            params.omega_iov.as_ref(),
+            &params.sigma.values,
+        );
+        let actual = individual_nll_iov_with_scratch(
+            &m,
+            &subj,
+            &theta,
+            &eta,
+            &kappas,
+            &params.omega,
+            params.omega_iov.as_ref(),
+            &params.sigma.values,
+            &mut scratch,
+        );
+        assert!(actual.is_finite());
+        assert_eq!(expected.to_bits(), actual.to_bits());
+    }
+}

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -2556,9 +2556,9 @@ pub fn compute_predictions_with_tv(
 /// `Vec<PkParams>` on every call is the dominant allocator-pressure
 /// source on TV-cov datasets.
 ///
-/// The scratch buffer is **only used on the TV-cov analytical/ODE
-/// path**; the no-TV fast path doesn't touch it. Callers can pass the
-/// same scratch unconditionally — the no-TV path just ignores it.
+/// The scratch buffer is used by per-event analytical/ODE paths, including
+/// time-varying covariates, `TIME`, and resets. Static fast paths do not touch
+/// it. Callers can start with an empty buffer and reuse it unconditionally.
 pub fn compute_predictions_with_tv_into(
     model: &crate::types::CompiledModel,
     subject: &Subject,

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -875,6 +875,14 @@ pub fn compute_event_pk_params_into(
     out.pk_only.clear();
     out.reset.clear();
 
+    // Reserve only when this materializer is actually reached. Static prediction
+    // paths can keep an empty scratch buffer without allocating event snapshots.
+    // Exact reservations avoid geometric growth of these large PkParams values.
+    out.dose.reserve_exact(subject.doses.len());
+    out.obs.reserve_exact(subject.obs_times.len());
+    out.pk_only.reserve_exact(subject.pk_only_times.len());
+    out.reset.reserve_exact(subject.reset_times.len());
+
     if subject_needs_per_event_pk(model, subject) {
         for k in 0..subject.doses.len() {
             out.dose.push(pk_params_at_time(
@@ -1166,7 +1174,38 @@ pub fn predict_iov(
     eta_bsv: &[f64],
     kappas: &[Vec<f64>],
 ) -> Vec<f64> {
+    predict_iov_with_scratch(
+        model,
+        subject,
+        theta,
+        eta_bsv,
+        kappas,
+        &mut EventPkParams::default(),
+    )
+}
+
+/// IOV predictions with caller-owned per-event parameter storage. Every event
+/// is still evaluated at its current theta, eta, kappa, covariates and time;
+/// only allocation capacity is reused, never numerical values.
+pub(crate) fn predict_iov_with_scratch(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta_bsv: &[f64],
+    kappas: &[Vec<f64>],
+    scratch: &mut EventPkParams,
+) -> Vec<f64> {
     use std::collections::HashMap;
+    let EventPkParams {
+        dose: dose_params,
+        obs: obs_params,
+        pk_only: pk_only_params,
+        reset: reset_params,
+    } = scratch;
+    dose_params.clear();
+    obs_params.clear();
+    pk_only_params.clear();
+    reset_params.clear();
     // #905: the IOV value funnel is a structural peer of
     // `compute_predictions_with_tv_into_with_schedule` and needs the same declination —
     // an analytical subject with no Gaussian observation feeds the predictor nothing,
@@ -1202,43 +1241,42 @@ pub fn predict_iov(
         c
     };
 
-    let dose_params: Vec<PkParams> = (0..subject.doses.len())
-        .map(|d| {
-            let occ = subject.dose_occasions.get(d).copied().unwrap_or(0);
-            pk_params_at_time(
-                model,
-                theta,
-                &combined_for(occ),
-                subject.dose_cov(d),
-                subject.doses[d].time,
-            )
-        })
-        .collect();
-    let obs_params: Vec<PkParams> = (0..subject.obs_times.len())
-        .map(|j| {
-            let occ = subject.occasions.get(j).copied().unwrap_or(0);
-            pk_params_at_time(
-                model,
-                theta,
-                &combined_for(occ),
-                subject.obs_cov(j),
-                subject.obs_times[j],
-            )
-        })
-        .collect();
+    // Exact initial reservations preserve the convenience API's old footprint
+    // for short vectors; later probes keep these capacities without allocating.
+    dose_params.reserve_exact(subject.doses.len());
+    dose_params.extend((0..subject.doses.len()).map(|d| {
+        let occ = subject.dose_occasions.get(d).copied().unwrap_or(0);
+        pk_params_at_time(
+            model,
+            theta,
+            &combined_for(occ),
+            subject.dose_cov(d),
+            subject.doses[d].time,
+        )
+    }));
+    obs_params.reserve_exact(subject.obs_times.len());
+    obs_params.extend((0..subject.obs_times.len()).map(|j| {
+        let occ = subject.occasions.get(j).copied().unwrap_or(0);
+        pk_params_at_time(
+            model,
+            theta,
+            &combined_for(occ),
+            subject.obs_cov(j),
+            subject.obs_times[j],
+        )
+    }));
     // EVID=2 rows carry no occasion label → BSV eta with zero kappa.
     let pk_only_combined = combined_for(u32::MAX);
-    let pk_only_params: Vec<PkParams> = (0..subject.pk_only_times.len())
-        .map(|m| {
-            pk_params_at_time(
-                model,
-                theta,
-                &pk_only_combined,
-                subject.pk_only_cov(m),
-                subject.pk_only_times[m],
-            )
-        })
-        .collect();
+    pk_only_params.reserve_exact(subject.pk_only_times.len());
+    pk_only_params.extend((0..subject.pk_only_times.len()).map(|m| {
+        pk_params_at_time(
+            model,
+            theta,
+            &pk_only_combined,
+            subject.pk_only_cov(m),
+            subject.pk_only_times[m],
+        )
+    }));
 
     let mut preds = if model.is_algebraic() {
         // Compartment-free model (#811): nothing to integrate or superpose. The
@@ -1257,25 +1295,24 @@ pub fn predict_iov(
         // Built inside this arm because only the ODE engine re-seeds `init(...)`; the
         // algebraic and closed-form arms never read it, and `pk_params_at_time` runs the
         // full individual-parameter program once per reset per eta evaluation.
-        let reset_params: Vec<PkParams> = (0..subject.reset_times.len())
-            .map(|r| {
-                let t = subject.reset_times[r];
-                let combined = match reset_row_occasion(subject, r) {
-                    Some(occ) => combined_for(occ),
-                    None => pk_only_combined.clone(),
-                };
-                pk_params_at_time(model, theta, &combined, subject.reset_cov(r), t)
-            })
-            .collect();
+        reset_params.reserve_exact(subject.reset_times.len());
+        reset_params.extend((0..subject.reset_times.len()).map(|r| {
+            let t = subject.reset_times[r];
+            let combined = match reset_row_occasion(subject, r) {
+                Some(occ) => combined_for(occ),
+                None => pk_only_combined.clone(),
+            };
+            pk_params_at_time(model, theta, &combined, subject.reset_cov(r), t)
+        }));
         crate::ode::ode_predictions_event_driven(
             ode,
             subject,
             theta,
             &pk_only_combined,
-            &dose_params,
-            &obs_params,
-            &pk_only_params,
-            &reset_params,
+            dose_params.as_slice(),
+            obs_params.as_slice(),
+            pk_only_params.as_slice(),
+            reset_params.as_slice(),
         )
     } else if event_driven::supports_event_driven(model.pk_model) {
         // Resolve modeled-`RATE` doses (#324/#394) using each dose's per-occasion
@@ -1291,9 +1328,9 @@ pub fn predict_iov(
         event_driven::event_driven_predictions(
             model.pk_model,
             &resolved,
-            &dose_params,
-            &obs_params,
-            &pk_only_params,
+            dose_params.as_slice(),
+            obs_params.as_slice(),
+            pk_only_params.as_slice(),
         )
     } else {
         // Unreachable today: every `PkModel` variant has event-driven analytical
@@ -1329,7 +1366,7 @@ pub fn predict_iov(
             theta,
             eta_bsv,
             &amount_pk,
-            Some(&obs_params),
+            Some(obs_params.as_slice()),
             &mut preds,
         );
     }
@@ -2506,9 +2543,9 @@ pub fn compute_predictions_with_tv(
     theta: &[f64],
     eta: &[f64],
 ) -> Vec<f64> {
-    // Allocate-on-each-call wrapper. Hot loops should use
-    // `compute_predictions_with_tv_into` instead.
-    let mut scratch = EventPkParams::with_capacity_for(subject);
+    // Event snapshots allocate lazily, only on paths that materialize them.
+    // Hot loops should reuse the buffer via `compute_predictions_with_tv_into`.
+    let mut scratch = EventPkParams::default();
     compute_predictions_with_tv_into(model, subject, theta, eta, &mut scratch)
 }
 
@@ -2709,6 +2746,10 @@ pub fn compute_predictions_with_tv_into_with_schedule(
     apply_frem_prediction_override(model, subject, theta, eta, &mut preds);
     preds
 }
+
+#[cfg(test)]
+#[path = "iov_scratch_tests.rs"]
+mod iov_scratch_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -2482,6 +2482,33 @@ pub fn individual_nll_iov(
     omega_iov: Option<&OmegaMatrix>,
     sigma_values: &[f64],
 ) -> f64 {
+    individual_nll_iov_with_scratch(
+        model,
+        subject,
+        theta,
+        eta,
+        kappas,
+        omega,
+        omega_iov,
+        sigma_values,
+        &mut pk::EventPkParams::default(),
+    )
+}
+
+/// Inner-loop sibling that retains per-event PK buffer capacity across trial
+/// eta/kappa values. The public convenience function keeps its original API.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn individual_nll_iov_with_scratch(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    kappas: &[Vec<f64>],
+    omega: &OmegaMatrix,
+    omega_iov: Option<&OmegaMatrix>,
+    sigma_values: &[f64],
+    pk_scratch: &mut pk::EventPkParams,
+) -> f64 {
     if kappas.is_empty() {
         return individual_nll(model, subject, theta, eta, omega, sigma_values);
     }
@@ -2515,7 +2542,7 @@ pub fn individual_nll_iov(
 
     // Data NLL — single continuous prediction with per-event occasion kappa
     // (proper cross-occasion carryover; issue #104).
-    let preds = pk::predict_iov(model, subject, theta, eta, kappas);
+    let preds = pk::predict_iov_with_scratch(model, subject, theta, eta, kappas, pk_scratch);
     // FREM covariate pseudo-observations use the covariate sigma (EPSCOV), not
     // the PK residual error, so the FREM etas are sampled against the right
     // variance (mirrors the FOCE paths and the non-IOV individual_nll).

--- a/src/types.rs
+++ b/src/types.rs
@@ -6934,10 +6934,11 @@ pub struct FitOptions {
     pub mu_referencing: bool,
     /// Number of rayon worker threads used for the per-subject parallel loops
     /// (inner EBE search, SAEM MH steps, SIR weighting, likelihood reductions).
-    /// `None` (default) leaves rayon's global pool alone, which means one
-    /// worker per logical CPU. `Some(n)` runs the fit inside a scoped local
-    /// pool of `n` threads — so the setting is per-call, not process-wide,
-    /// and different fits can use different thread counts.
+    /// `None` or `Some(0)` uses available cores minus one, clamped to 1..8,
+    /// unless explicitly configured through `configure_global_thread_pool`.
+    /// `Some(n)` for positive `n` exclusively leases a pool of that width for
+    /// this call. Idle pools are reused within a bounded cache; concurrent fits
+    /// keep independent budgets even when their ODE overrides are identical.
     pub threads: Option<usize>,
     /// Number of independent optimizations to run from perturbed starting values.
     /// `1` (default) is a single run — no behaviour change. When `> 1`, runs are

--- a/tests/mixture_nonmem.rs
+++ b/tests/mixture_nonmem.rs
@@ -233,10 +233,6 @@ fn mixture_fit_matches_nonmem() {
 // the `mixture_iv_saem.ext` TABLE NO. 1 `-1000000000` row; the OFV is the IMP
 // pass's (TABLE NO. 2). SAEM samples the latent class each E-step (exactly the
 // ferx scheme), so the two engines' estimates and per-subject MIXEST agree.
-const NM_SAEM_TVCL1: f64 = 1.00205;
-const NM_SAEM_TVCL2: f64 = 2.73543;
-const NM_SAEM_TVV: f64 = 9.99346;
-const NM_SAEM_P1: f64 = 0.471245;
 const NM_SAEM_OFV_IMP: f64 = 300.8707;
 
 // Per-subject MIXEST from mixture_iv_saem.sdtab (NONMEM SAEM). Differs from the

--- a/tools/benchmark-pools.py
+++ b/tools/benchmark-pools.py
@@ -1,0 +1,97 @@
+"""Compare prebuilt pool_benchmark executables in ABBA order; stdlib only.
+
+Build examples/pool_benchmark.rs on both revisions with the same Cargo profile.
+Usage: python tools/benchmark-pools.py BASELINE_EXE MODIFIED_EXE OUTPUT_DIRECTORY [--reverse]
+No compilation runs while timings are collected. Each process has an untimed
+reference fit and a reported warmup round (0), excluded from the summary.
+"""
+import csv
+import hashlib
+import json
+from pathlib import Path
+import platform
+import statistics
+import subprocess
+import sys
+
+
+def main():
+    baseline, modified, output = map(Path, sys.argv[1:4])
+    if sys.argv[4:] not in ([], ["--reverse"]):
+        raise SystemExit("optional fourth argument: --reverse")
+    output.mkdir(parents=True, exist_ok=True)
+    records = []
+    signatures = {}
+    expected_cases = None
+    order = [
+        ("baseline", baseline, 3),
+        ("modified", modified, 3),
+        ("modified", modified, 4),
+        ("baseline", baseline, 4),
+    ]
+    if sys.argv[4:]:
+        order = [("modified", modified, 3), ("baseline", baseline, 3),
+                 ("baseline", baseline, 4), ("modified", modified, 4)]
+    for run, (label, binary, rounds) in enumerate(order):
+        print(f"Run {run + 1}/4: {label}, {rounds} measured rounds per case", flush=True)
+        completed = subprocess.run([str(binary.resolve()), label, str(rounds)],
+                                   capture_output=True, text=True, check=False)
+        (output / f"run-{run + 1}.log").write_text(
+            completed.stdout + completed.stderr, encoding="utf-8")
+        if completed.returncode:
+            raise RuntimeError(f"{label} failed; see run-{run + 1}.log")
+        lines = [line for line in completed.stdout.splitlines()
+                 if line.startswith("label,") or line.startswith(label + ",")]
+        rows = list(csv.DictReader(lines))
+        cases = {row["case"] for row in rows}
+        if expected_cases is None:
+            expected_cases = cases
+        if not cases or cases != expected_cases or len(rows) != len(cases) * (rounds + 1):
+            raise RuntimeError(f"Unexpected result count: {len(rows)}")
+        with (output / f"run-{run + 1}.csv").open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0]))
+            writer.writeheader()
+            writer.writerows(rows)
+        for row in rows:
+            case = row["case"]
+            signature = json.loads(row["signature"])
+            if signatures.setdefault(case, signature) != signature:
+                raise RuntimeError(f"Numerical mismatch across revisions for {case}")
+            if int(row["round"]) > 0:
+                records.append(row)
+    summaries = []
+    for case in signatures:
+        values = {label: [float(r["elapsed_ms"]) for r in records
+                          if r["case"] == case and r["label"] == label]
+                  for label in ("baseline", "modified")}
+        assert all(len(v) == 7 for v in values.values())
+        before, after = (statistics.median(values[label])
+                         for label in ("baseline", "modified"))
+        summaries.append({
+            "case": case, "baseline_ms": before, "modified_ms": after,
+            "speedup": before / after, "time_saved_percent": 100 * (1 - after / before),
+            "baseline_min_ms": min(values["baseline"]),
+            "baseline_max_ms": max(values["baseline"]),
+            "modified_min_ms": min(values["modified"]),
+            "modified_max_ms": max(values["modified"]),
+        })
+    with (output / "summary.csv").open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(summaries[0]))
+        writer.writeheader()
+        writer.writerows(summaries)
+    metadata = {
+        "platform": platform.platform(), "python": platform.python_version(),
+        "order": ", ".join(label for label, _, _ in order),
+        "measured_rounds_per_revision": 7, "all_signatures_bit_identical": True,
+        "binary_sha256": {str(p): hashlib.sha256(p.read_bytes()).hexdigest()
+                          for p in (baseline, modified)},
+    }
+    (output / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    print("\nAll objective/parameter/iteration signatures match across revisions.")
+    for r in summaries:
+        print(f"{r['case']}: {r['baseline_ms']:.2f} -> {r['modified_ms']:.2f} ms; "
+              f"{r['speedup']:.2f}x; {r['time_saved_percent']:.1f}% less time")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/profiling_alloc.rs
+++ b/tools/profiling_alloc.rs
@@ -1,0 +1,175 @@
+//! Example-only Rust allocation counter and sampled stacks. Never linked into the engine.
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
+use std::sync::{Mutex, OnceLock};
+
+pub struct Allocator;
+static ENABLED: AtomicBool = AtomicBool::new(false);
+static CALLS: AtomicU64 = AtomicU64::new(0);
+static BYTES: AtomicU64 = AtomicU64::new(0);
+static MAX_REQUEST: AtomicU64 = AtomicU64::new(0);
+static SAMPLE_BYTES: AtomicBool = AtomicBool::new(false);
+static REALLOCS: AtomicU64 = AtomicU64::new(0);
+static STRIDE: AtomicU64 = AtomicU64::new(0);
+static SAMPLES: AtomicU64 = AtomicU64::new(0);
+static BUCKETS: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
+static BUCKET_BYTES: [AtomicU64; 8] = [const { AtomicU64::new(0) }; 8];
+static STACKS: OnceLock<Mutex<HashMap<String, u64>>> = OnceLock::new();
+thread_local! { static CAPTURING: Cell<bool> = const { Cell::new(false) }; }
+
+fn record(bytes: usize, realloc: bool) {
+    if !ENABLED.load(Relaxed) {
+        return;
+    }
+    let _ = CAPTURING.try_with(|busy| {
+        if busy.get() {
+            return;
+        }
+        let n = CALLS.fetch_add(1, Relaxed).wrapping_add(1);
+        let previous_bytes = BYTES.fetch_add(bytes as u64, Relaxed);
+        MAX_REQUEST.fetch_max(bytes as u64, Relaxed);
+        if realloc {
+            REALLOCS.fetch_add(1, Relaxed);
+        }
+        let bucket = [32, 128, 512, 2048, 8192, 32768, 131072]
+            .iter()
+            .position(|&limit| bytes <= limit)
+            .unwrap_or(7);
+        BUCKETS[bucket].fetch_add(1, Relaxed);
+        BUCKET_BYTES[bucket].fetch_add(bytes as u64, Relaxed);
+        let stride = STRIDE.load(Relaxed);
+        if stride == 0 {
+            return;
+        }
+        let sample = if SAMPLE_BYTES.load(Relaxed) {
+            previous_bytes / stride != previous_bytes.wrapping_add(bytes as u64) / stride
+        } else {
+            n % stride == 0
+        };
+        if !sample {
+            return;
+        }
+        if SAMPLES.fetch_add(1, Relaxed) >= 512 {
+            return;
+        }
+        // Exclude profiler bookkeeping and prevent recursive stack sampling.
+        // GlobalAlloc must never unwind: abort if optional symbolization panics.
+        busy.set(true);
+        let captured = std::panic::catch_unwind(|| {
+            let trace = std::backtrace::Backtrace::force_capture().to_string();
+            let mut selected = Vec::new();
+            let mut include_location = false;
+            let mut frames = 0;
+            for line in trace.lines() {
+                if line.contains("ferx_core::") && frames < 10 {
+                    let trimmed = line.trim();
+                    selected.push(
+                        trimmed
+                            .split_once(": ")
+                            .map_or(trimmed, |(_, symbol)| symbol),
+                    );
+                    include_location = true;
+                    frames += 1;
+                } else if include_location && line.trim().starts_with("at ") {
+                    selected.push(line.trim());
+                    include_location = false;
+                } else {
+                    include_location = false;
+                }
+            }
+            let mut stack = selected.join("\n");
+            if stack.is_empty() {
+                stack = trace;
+            }
+            let mut stacks = STACKS
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *stacks.entry(stack).or_insert(0) += 1;
+        });
+        busy.set(false);
+        if captured.is_err() {
+            std::process::abort();
+        }
+    });
+}
+
+// SAFETY: every pointer/layout/size is forwarded unchanged to System. The
+// observer neither dereferences payloads nor changes allocation ownership.
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc(layout) };
+        if !p.is_null() {
+            record(layout.size(), false);
+        }
+        p
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let p = unsafe { System.alloc_zeroed(layout) };
+        if !p.is_null() {
+            record(layout.size(), false);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, p: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(p, layout) };
+    }
+    unsafe fn realloc(&self, p: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { System.realloc(p, layout, new_size) };
+        if !p.is_null() {
+            record(new_size, true);
+        }
+        p
+    }
+}
+
+pub fn start(stride: u64) {
+    ENABLED.store(false, Relaxed);
+    CALLS.store(0, Relaxed);
+    BYTES.store(0, Relaxed);
+    MAX_REQUEST.store(0, Relaxed);
+    REALLOCS.store(0, Relaxed);
+    SAMPLES.store(0, Relaxed);
+    STRIDE.store(stride, Relaxed);
+    for b in &BUCKETS {
+        b.store(0, Relaxed);
+    }
+    for b in &BUCKET_BYTES {
+        b.store(0, Relaxed);
+    }
+    STACKS
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clear();
+    ENABLED.store(true, Relaxed);
+}
+
+pub fn sample_bytes(on: bool) {
+    SAMPLE_BYTES.store(on, Relaxed);
+}
+
+pub fn stop() -> serde_json::Value {
+    ENABLED.store(false, Relaxed);
+    let mut stacks: Vec<_> = STACKS
+        .get()
+        .unwrap()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .iter()
+        .map(|(stack, &samples)| serde_json::json!({"stack": stack, "samples": samples}))
+        .collect();
+    stacks.sort_by_key(|v| std::cmp::Reverse(v["samples"].as_u64().unwrap()));
+    serde_json::json!({
+        "allocation_calls": CALLS.load(Relaxed), "requested_bytes": BYTES.load(Relaxed),
+        "max_request_bytes": MAX_REQUEST.load(Relaxed),
+        "realloc_calls": REALLOCS.load(Relaxed), "sample_stride": STRIDE.load(Relaxed),
+        "sample_basis": if SAMPLE_BYTES.load(Relaxed) { "requested_bytes" } else { "allocation_calls" },
+        "samples_capped": SAMPLES.load(Relaxed) > 512,
+        "allocation_size_buckets": BUCKETS.iter().map(|v| v.load(Relaxed)).collect::<Vec<_>>(),
+        "bytes_by_size_bucket": BUCKET_BYTES.iter().map(|v| v.load(Relaxed)).collect::<Vec<_>>(),
+        "bucket_upper_bytes": [32,128,512,2048,8192,32768,131072,u64::MAX], "stacks": stacks,
+    })
+}

--- a/tools/test-focei-profiles.py
+++ b/tools/test-focei-profiles.py
@@ -1,0 +1,81 @@
+"""Compare uninstrumented executables, then collect counts separately.
+
+Usage: python tools/test-focei-profiles.py BEFORE_TIME AFTER_TIME BEFORE_ALLOC AFTER_ALLOC OUTPUT
+Executables are built from examples/focei_profile.rs. Run from the repo root.
+"""
+import hashlib
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import sys
+import csv
+
+
+def main():
+    before_time, after_time, before_alloc, after_alloc, output = map(Path, sys.argv[1:])
+    output.mkdir(parents=True, exist_ok=True)
+    signatures = {}
+    reports = []
+
+    def run(binary, label, case, threads, repeats, mode, name, provider_timers):
+        target = output / (name + ".json")
+        env = dict(os.environ, FERX_PROFILE=str(int(provider_timers)))
+        result = subprocess.run([str(binary.resolve()), case, str(threads), str(repeats), mode, str(target)],
+                                env=env, text=True, capture_output=True)
+        (output / (name + ".log")).write_text(result.stdout + result.stderr, encoding="utf-8")
+        if result.returncode:
+            raise RuntimeError(f"{name} failed: {result.stderr}")
+        data = json.loads(target.read_text())
+        assert data["allocation_build"] == (mode in ("counts", "stacks", "byte_stacks"))
+        assert signatures.setdefault(case, data["signature"]) == data["signature"], f"Numerical mismatch: {name}"
+        reports.append(dict(label=label, **data))
+        return data
+
+    summary = []
+    for case in ("analytical", "iov", "stiff"):
+        for threads in (1, 4):
+            print(f"Timing {case}, {threads} threads (ABBA)", flush=True)
+            values = {"before": [], "after": []}
+            for i, (label, binary, repeats) in enumerate([
+                ("before", before_time, 3), ("after", after_time, 3),
+                ("after", after_time, 4), ("before", before_time, 4),
+            ]):
+                data = run(binary, label, case, threads, repeats, "time",
+                           f"timing-{case}-{threads}-{i+1}-{label}", False)
+                values[label].extend(row["elapsed_ms"] for row in data["measurements"])
+            assert len(values["before"]) == len(values["after"]) == 7
+            before, after = (statistics.median(values[label]) for label in ("before", "after"))
+            summary.append(dict(case=case, threads=threads, before_ms=before, after_ms=after,
+                                speedup=before / after,
+                                before_min_ms=min(values["before"]), before_max_ms=max(values["before"]),
+                                after_min_ms=min(values["after"]), after_max_ms=max(values["after"])))
+    # Instrumentation is never enabled in the timing comparisons above.
+    allocation_summary = []
+    for case in ("analytical", "iov", "stiff"):
+        print(f"Profiling {case}: counters and pointwise kernels", flush=True)
+        before = run(before_alloc, "before", case, 1, 1, "counts", f"counts-{case}-before", True)
+        after = run(after_alloc, "after", case, 1, 1, "counts", f"counts-{case}-after", True)
+        for label, binary in [("before", before_time), ("after", after_time)]:
+            run(binary, label, case, 1, 1, "kernels", f"kernels-{case}-{label}", False)
+        b = before["measurements"][0]["allocations"]
+        a = after["measurements"][0]["allocations"]
+        allocation_summary.append(dict(case=case, before_allocs=b["allocation_calls"],
+            after_allocs=a["allocation_calls"], before_bytes=b["requested_bytes"], after_bytes=a["requested_bytes"],
+            bytes_reduction_percent=100 * (1 - a["requested_bytes"] / b["requested_bytes"])))
+    for filename, rows in [("timing-summary.csv", summary), ("allocation-summary.csv", allocation_summary)]:
+        with (output / filename).open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=list(rows[0]))
+            writer.writeheader()
+            writer.writerows(rows)
+    metadata = {"signatures_match_across_versions_threads_and_instrumentation": True,
+                "timing_repeats_per_version": 7, "order_per_case": "before, after, after, before",
+                "hashes": {str(p): hashlib.sha256(p.read_bytes()).hexdigest()
+                           for p in (before_time, after_time, before_alloc, after_alloc)}}
+    (output / "metadata.json").write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary + allocation_summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Repeated fits with explicit thread counts rebuild Rayon workers. Concurrent fits
with explicit budgets need independent capacity, while unpinned fits with the
same ODE settings should share persistent workers. FOCE/FOCEI also traverses the
subject population separately for EBE solves, marginal scores, and mixed-gradient
fallbacks.

Follow-up to #1115 and #1212; motivated by comparison with nlmixr2est's reuse of
workers through inner and outer optimization.

## What changed

- Reuse exclusive pool leases for explicit widths and `PoolPlan` outer execution.
  Unpinned fits with identical ODE overrides share a persistent keyed pool, while
  default fits retain their existing shared pool.
- Bound ordinary idle retention across settings to twice the automatic worker
  budget (at most 16 workers per cache), retaining one most-recent wider pool so
  repeated 24/32-thread configurations still avoid worker rebuilds.
- Keep nested SIR work on the enclosing fit's matching override pool instead of
  creating a second full-width pool.
- Validate programmatic ODE tolerances before building a pool or entering a fit;
  cache float keys use their bit representation.
- Finish each subject's FOCE/FOCEI marginal immediately after its EBE solve.
  Keep ordered population sums and the separate AGQ/Laplace objective route.
- Complete mixed analytic/FD gradient fallbacks within the subject task and move
  EBE buffers instead of cloning them.
- Reuse IOV event-parameter capacity across likelihood probes and allocate static
  prediction scratch lazily. Recompute all event values at every parameter point.
- Add focused regressions and reproducible, uninstrumented benchmark examples;
  allocation instrumentation is confined to a manually enabled example build.

## Alternatives considered

Longer Rayon active waiting reduced a microbenchmark's wall time modestly while
increasing CPU consumption substantially; no idle-policy change is included.
First-order-only IOV seed preparation is deliberately excluded: it improved IOV
but its compiled binary showed a persistent stiff-ODE slowdown. That experiment
and its measurements are preserved outside this PR's committed diff.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed: no API/schema change | — |

## Breaking changes

- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields
- [ ] Public Rust API
- [x] None

Migration notes: none. Pool leases cover the callback/scoped work; `PoolPlan::install`
callers must not let unscoped spawned work outlive the callback. Current ferx-tools
consumers use joining parallel iterators and satisfy this contract.
Worker/ODE isolation does not make process-wide optimizer switches reentrant.

## Numerical validation

- [x] Full Warfarin FOCEI fits converge on current main `c877b9a9` and this PR:
  both take 57 iterations with identical printed OFV, theta, omega, and sigma.
- [x] All 34 selected integration tests pass, including all four Warfarin
  NONMEM covariance checks, IOV/reset anchors, and stiff-method comparisons.
- [x] Compared against current main `c877b9a9` using identical harnesses and
  compiler profiles, plus earlier controlled research against `0596fbb9`.
- [x] Fixed-workload fit signatures match bit-for-bit across retained changes,
  thread counts, and instrumented/uninstrumented builds: OFV, theta, sigma,
  omega, omega_iov, and iteration count.

Full Warfarin comparison (300-iteration limit, four threads, no covariance):

```text
                         current main             PR
converged                true                     true
iterations               57                       57
OFV                      -286.004219506046525     -286.004219506046525
theta CL                 0.13269539439330955      0.13269539439330955
theta V                  7.737705029131656        7.737705029131656
theta KA                 0.8107965492777247       0.8107965492777247
```

The new reused-buffer Dual2/central-FD test measured worst scaled error
`1.76e-11`; its bound is `1e-9` (about 57x rounding headroom). The fixture contains
two doses/occasions, changing covariates, TIME, pk-only records, and a reset, and
asserts that the analytic provider is selected.

## Performance

- [x] Current-main comparison completed, seven measured rounds per variant,
  ABBA order, same `ci-test` profile on Windows/Core Ultra 7 155U:

| Pool benchmark | Main median | PR median | Speedup |
|---|---:|---:|---:|
| Short 1-thread fits | 354.63 ms | 374.33 ms | 0.95x |
| Short 4-thread fits | 259.12 ms | 227.45 ms | 1.14x |
| Default fits | 268.29 ms | 297.91 ms | 0.90x |
| Analytical batch | 154.71 ms | 145.04 ms | 1.07x |
| ODE batch | 4834.02 ms | 977.50 ms | **4.95x** |
| ODE 4-thread fits | 985.63 ms | 1064.48 ms | 0.93x |

- [x] Allocation traffic: analytical requested bytes 48,939,724 → 37,309,940
  (23.8% less); IOV 1,192,011,780 → 632,261,884 (47.0% less); stiff
  23,823,279 → 21,777,015 (8.6% less). These are cumulative requests, not RSS.
- [x] Slower/mixed controls are disclosed. A separate 20-sample confirmation
  of the three profiling fixtures used ABBA then BAAB, five fits per process:

| Profile fixture | Threads | Main median | PR median | Speedup |
|---|---:|---:|---:|---:|
| Analytical | 1 | 96.55 ms | 94.24 ms | 1.02x |
| Analytical | 4 | 44.96 ms | 52.30 ms | 0.86x |
| IOV | 1 | 522.70 ms | 535.32 ms | 0.98x |
| IOV | 4 | 251.43 ms | 234.02 ms | 1.07x |
| Stiff | 1 | 369.64 ms | 373.41 ms | 0.99x |
| Stiff | 4 | 161.32 ms | 168.94 ms | 0.95x |

Small-workload timing directions vary between sweeps (analytical four-thread
was 1.07x in the first clean sweep versus 0.86x in confirmation); all confirmation
ranges overlap, with large outliers on this shared host. The stiff four-thread
control remains slower in both clean sweeps (0.92x and 0.95x). Excluding the
first-order experiment therefore does **not** establish that every retained
workload is faster. The trade-off is the robust batch-capacity correction and
lower allocation traffic; these control timings merit reviewer attention and a
representative release-build check, rather than a universal speed claim.

An initial current-main timing sweep overlapped a compiler process and is
excluded from the evidence above. No compiler was observed during the clean
comparison/confirmation. Objective/parameter/iteration signatures match in all
comparisons, including the slower controls.

These are medians of bounded fits, not universal or time-to-convergence gains.
Timing builds have no allocation hook or provider timers. The PR does not claim
the excluded first-order IOV experiment's 1.8–1.9x gain.

Reproduce with `examples/pool_benchmark.rs`, `examples/focei_profile.rs`,
`tools/benchmark-pools.py`, and `tools/test-focei-profiles.py`, building both
revisions with the same optimized profile. The allocator helper is maintainer
instrumentation; its Codecov exclusion is by role, not a coverage workaround.

## Tests

- [x] Unit regressions added for lease reuse/exclusivity, shared unpinned pools,
  stable settings keys, wide-pool retention, panic recovery, nested SIR scope,
  invalid Rust API overrides, fused objectives/fallbacks,
  buffer ownership, event refresh, and Dual2/FD parity.
- [x] CI patch coverage: **99.24%**, above the 90% gate; core and endpoint
  coverage jobs pass. Both debug-assertion suites pass. All applicable CI checks
  are green; the full slow-test job is intentionally skipped by PR policy.
- [x] Mutation: disabling idle-pool retrieval makes the worker-reuse test fail.
- [x] Mutation: disabling shared lookup, wide retention, nested-scope detection,
  and override validation makes six cache tests and two routing tests fail.
- [x] Mutation: omitting observation-buffer clearing makes the new reused-buffer
  parity test fail on its second probe (8 snapshots where 4 are required).
- [x] Final restored-code Windows unit suite: 4194 passed, 23 ignored,
  and only the pre-existing steady-state failure described below. Both mutation
  targets pass after restoration. All 34 selected integration tests pass.

The previous Windows full suite has a separately reproduced pre-existing
`ss_input_rate_over_capacity_deep_saturation_declines` failure; it must be
reported separately from new regressions, not hidden by skipping it.

## Example

- [x] Not applicable: internal performance changes with no new API/DSL surface.
  The new Rust examples are maintainer benchmark harnesses.

## Docs

- [x] `docs/model-file/fit-options.qmd` documents worker reuse, limits, and scope.
- [x] New pages: none; no sidebar changes required.
- [x] `CHANGELOG.md` has Unreleased performance entries.

## Checklist

- [x] Full `tools/preflight.sh` green on final source: fmt, all five check
  feature sets, all-targets Clippy, Rustdoc, docs lint, and public API.
  The API working copy was normalized from CRLF to LF to avoid a Windows
  newline-only false diff; the committed API baseline is unchanged.
- [x] Generic sensitivity/value formulas stay differentiable; the new FD check
  exercises the Dual2 route rather than a fallback.
- [x] Version bump not needed: no breaking change.

## Docs & examples

### ferx-site

No new DSL, fit option, model example, or dataset. No site or data mirror change.

### ferx-book

No new estimator, DSL feature, or fit option. No book change required.

### Example execution

- [x] No cross-repo example execution step required for this internal change.
  Convergence/reference validation is tracked separately above.

## Reviewer hints

Review `src/api/pool_cache.rs` for exclusive lifetimes and bounded idle retention;
`src/estimation/outer_optimizer.rs` for objective routing, the factor of two in
gradients, and ordered sums; and `src/pk/mod.rs` for clearing/refilling all event
vectors. The benchmark helpers can be read separately from production changes.

## Open questions

The first-order IOV experiment is deferred. The retained changes correct batch
worker budgets and reduce allocations, but smaller single-fit timing is mixed
and the rebased stiff control is slower. Review the disclosed trade-off before
making a broad release-performance claim. CI test/coverage completion is tracked
in the checks; this PR does not merge automatically.
