### PR TITLE
ci(coverage): run debug_assert guards under the coverage profile [closes #1248]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,53 @@ jobs:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # The guards-OFF lane, and the counterweight to `[profile.ci-cov]` (#1293 review
+  # of #1248). Both coverage jobs now build with `debug-assertions` and
+  # `overflow-checks` ON, which is what makes the guards' condition lines coverable
+  # — but it also meant that, for one commit, NO per-PR job ran the crate the way a
+  # user's release build behaves. The remaining `ci-test` runs are scheduled,
+  # manual, or post-merge, so a release-only regression could have merged green.
+  #
+  # That is not abstract. `continuous_value()` (`src/types.rs`) and
+  # `max_scaled_deviation()` (`src/estimation/outer_optimizer.rs`) each have two
+  # correct behaviours: a misuse guard that fires where `debug_assert!` is live, and
+  # a NaN fallback that is what users actually get. Under `ci-cov` only the panic
+  # arm runs. This job is where the other arm is checked before merge.
+  #
+  # Cheap, and deliberately narrower than the coverage jobs: `--lib` only, on the
+  # `ci,markov,nn` union of production cfgs. It runs in parallel with the two
+  # coverage jobs and is shorter than either, so it adds no wall-clock to the
+  # critical path. It does NOT restore guards-off `tests/` binaries — that is the
+  # 120-odd binary compile, and `slow-tests.yml` plus the nightly coverage job
+  # still run those on `ci-test` with the guards off.
+  #
+  # Commands live in `tools/preflight.sh` (group `release-semantics`) for the same
+  # reason as `Check`/`Clippy`/`Format` (#1157), and they arm the INVERSE canary —
+  # `FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1`, which fails the run if `debug_assert!`
+  # turns out to be live here after all. Without it the whole lane would rest on
+  # `ci-fast` never acquiring `debug-assertions`: it would silently become a second
+  # copy of the coverage jobs, green throughout.
+  release-semantics:
+    name: Tests (release semantics)
+    runs-on: ubuntu-latest
+    # Stable, like the coverage jobs: no nightly-only code, and `rust-cache` keys on
+    # the rustc version, so nightly would cold-rebuild the dep graph daily.
+    env:
+      RUSTUP_TOOLCHAIN: stable
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install stable toolchain
+        run: rustup toolchain install stable --profile minimal
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Own key: uninstrumented `ci-fast` shares artifacts with neither the
+          # plain `ci` (check/clippy) caches nor the instrumented `ci-cov` ones.
+          shared-key: ci-release-semantics
+
+      - name: cargo test --lib with debug-assertions OFF (via tools/preflight.sh)
+        run: tools/preflight.sh release-semantics
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,9 +115,17 @@ jobs:
       # `src/nn`, `src/estimation/nn_theta_gradient` and the feature-gated branches
       # of the shared modules (parser, sens provider, io/output) live there — for
       # `nn` that is the bulk of the surface.
+      #
+      # `--profile ci-cov` and `FERX_REQUIRE_DEBUG_ASSERTIONS=1`: see the same pair
+      # on `Tests + coverage (core)` below. This job carries the feature set —
+      # `ci,markov,nn` — that the retired `Tests (debug-assertions)` job's second
+      # command existed for, so the guards in `src/survival`, `src/markov`,
+      # `src/categorical` and `src/nn` are live exactly here (#1248, folding #344).
       - name: Generate TTE/CTMM endpoint coverage report
+        env:
+          FERX_REQUIRE_DEBUG_ASSERTIONS: "1"
         run: |
-          cargo llvm-cov --no-fail-fast --no-default-features --features ci,markov,nn --profile ci-fast \
+          cargo llvm-cov --no-fail-fast --no-default-features --features ci,markov,nn --profile ci-cov \
             --lib \
             --test agq \
             --test categorical_convergence \
@@ -146,64 +154,6 @@ jobs:
           flags: survival,markov,nn
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  # #344. Every other test job in this file builds with `--profile ci-test` or
-  # `--profile ci-fast`, and both `inherits = "release"` — so `debug-assertions`
-  # is OFF and all 177 `debug_assert!` guards in the crate compile to nothing.
-  # They are invariant checks that CI was not running.
-  #
-  # That was not theoretical. An off-by-one in `compute_max_stack`
-  # (`src/parser/model_parser.rs`) tripped its own `debug_assert!` for any
-  # expression containing an `if`, and four lib tests panicked under the dev
-  # profile while CI stayed green through the whole thing (fixed in #342; this
-  # job closes the blind spot that hid it).
-  #
-  # Deliberately a SEPARATE job rather than flipping `ci-test`: that profile
-  # exists so the population-fit tests run at release speed, and this repo is
-  # compile-bound (93% LLVM, #969/#971), so the cheap way to get the guards
-  # executed is one extra UNOPTIMISED build — not a second optimised one.
-  # Measured locally on the dev profile: 80s of tests for `--features ci` (4035
-  # tests) and 198s for `--features ci,markov,nn` (4366), all green — turning the
-  # guards on surfaced no latent failure, so this job starts green.
-  #
-  # The commands live in `tools/preflight.sh` (group `debug-assertions`) for the
-  # same reason as `Check`/`Clippy`/`Format` (#1157) — one list, so the local gate
-  # and the CI gate cannot drift. It is the one group that is opt-in locally: it
-  # runs a suite rather than a compile, so a no-argument `tools/preflight.sh`
-  # stays a pre-push habit and this job is where it has to be green.
-  #
-  # Note that "no `--profile` flag" is an invariant held by ABSENCE, and this job
-  # would be a no-op again — silently, with every test green — if a
-  # `[profile.dev] debug-assertions = false` or a
-  # `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` ever appeared. So the group's
-  # commands arm `debug_assertion_canary` (`src/lib_tests.rs`) via
-  # `env FERX_REQUIRE_DEBUG_ASSERTIONS=1`, and that canary fails the run if
-  # `debug_assert!` turns out to compile to nothing. Do NOT set that variable at
-  # the workflow or job level: every other job legitimately runs with the guards
-  # off, and arming it there would fail them for doing the right thing.
-  debug-assertions:
-    name: Tests (debug-assertions)
-    runs-on: ubuntu-latest
-    # Stable, not the workflow-level nightly: `--features ci,markov,nn` has no
-    # nightly-only code, and stable's rustc holds for ~6 weeks against nightly's
-    # daily bump — `rust-cache` keys on `rustc -vV`, so nightly here would cold-
-    # rebuild the dep graph every day for no gate. Same reasoning as the coverage
-    # jobs. `tools/preflight.sh` honours an inherited `RUSTUP_TOOLCHAIN`.
-    env:
-      RUSTUP_TOOLCHAIN: stable
-    steps:
-      - uses: actions/checkout@v7
-      - name: Install stable toolchain
-        run: rustup toolchain install stable --profile minimal
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          # Own key: the dev profile shares no artifacts with the `ci` (check /
-          # clippy) caches or with the instrumented coverage ones.
-          shared-key: ci-debug-assertions
-
-      - name: cargo test --lib with debug-assertions on (via tools/preflight.sh)
-        run: tools/preflight.sh debug-assertions
 
   clippy:
     name: Clippy
@@ -421,7 +371,7 @@ jobs:
         # both RUNS the base suite and is the per-PR patch gate; the full
         # `ci,slow-tests` run is nightly (the `coverage` job above) and the
         # feature-gated endpoints are the `endpoints` job. Builds with
-        # `--profile ci-fast` (no fat LTO *and* no local ThinLTO — ~31% off the
+        # `--profile ci-cov` (no fat LTO *and* no local ThinLTO — ~31% off the
         # lib compile, #969) to stay within the PR wall-clock; the fast Tier-1/2
         # fits here tolerate the ThinLTO-off fit slowdown that the nightly
         # `coverage`/`slow-tests` jobs avoid by staying on `ci-test`. `--tests`
@@ -440,7 +390,25 @@ jobs:
         # instrumented build, so no third cache key and no second `ferx-core`
         # compile. The bare `--features ci` has to become `ferx-core/ci` because
         # `ci` is not a feature of the members.
-        run: cargo llvm-cov --workspace --tests --no-fail-fast --no-default-features --features ferx-core/ci --profile ci-fast --lcov --output-path lcov.info
+        #
+        # `--profile ci-cov` is `ci-fast` plus `debug-assertions`/`overflow-checks`
+        # (#1248). Two things follow. (1) The ~180 `debug_assert!` guards RUN here,
+        # which is what retired the separate `Tests (debug-assertions)` job: that job
+        # was `--lib` on `ci,markov,nn`, a strict subset of this `--tests` run plus
+        # the endpoints one, and it cost 32–42 min — the critical path, ~2x this job.
+        # (2) Their condition lines stop being permanently-missed patch lines, which
+        # is #1248 itself: measured 63 lines flipping 0 -> >0 in `--lib` scope alone.
+        #
+        # `FERX_REQUIRE_DEBUG_ASSERTIONS=1` arms `debug_assertion_canary`
+        # (`src/lib_tests.rs`). Without it BOTH of those properties would rest on the
+        # absence of a mistake — a `[profile.ci-cov] debug-assertions = false`, or the
+        # profile silently reverting to `ci-fast`, would leave every test green and
+        # every guard dead, which is the shape of #344 all over again. Set it on the
+        # jobs that build `ci-cov` and nowhere else: every other job legitimately runs
+        # with the guards off, and arming it there fails them for doing the right thing.
+        env:
+          FERX_REQUIRE_DEBUG_ASSERTIONS: "1"
+        run: cargo llvm-cov --workspace --tests --no-fail-fast --no-default-features --features ferx-core/ci --profile ci-cov --lcov --output-path lcov.info
 
       - name: Upload to Codecov (fast flag)
         uses: codecov/codecov-action@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,3 +150,44 @@ lto = false
 [profile.ci-fast]
 inherits = "ci-test"
 lto = "off"
+
+
+# Used by the two per-PR *coverage* jobs only (`Tests + coverage (core)` and
+# `Tests + coverage (TTE/CTMM endpoints)`). Everything `ci-fast` gives them, plus
+# the `debug_assert!` guards actually live. This is #1248, and it subsumes #344.
+#
+# WHY A PROFILE RATHER THAN A FLIPPED `ci-fast`. `ci-fast` is not CI-only despite
+# its name — `tools/vi-nuts-anchor/run.sh` and `tools/vi-emvi-comparison/run.sh`
+# build `target/ci-fast/ferx` with it to produce NUMERICAL anchors. Flipping it
+# would put the guards (and the `#[cfg(debug_assertions)]` MR ODE-twin verifier in
+# `pk/modified_release.rs`) into those runs, which is not what a maintainer timing
+# an anchor asked for. A separate profile keeps that surface untouched.
+#
+# NAME COLLISION, deliberate and harmless: `coverage-pr`'s `rust-cache` entry is
+# also called `ci-cov`. Different namespaces (a cargo profile vs a cache key) for
+# the same pair of jobs; neither reads the other.
+#
+# It costs no extra compile in CI. Both coverage jobs already carry coverage
+# `RUSTFLAGS` and their own `rust-cache` keys (`ci-cov`, `ci-cov-endpoints`), so
+# their artifacts were never shared with any other job; this renames the profile
+# they build under rather than adding a build. Measured locally (15 cores, stable,
+# `--features ci`), clean lib rebuild: `ci-fast` 92 s / 98 s vs `ci-cov` 93 s / 87 s
+# — the within-profile spread exceeds the between-profile difference.
+#
+# `debug-assertions` — measured `--workspace --tests`: 133 s off, 133 s on; `--lib`
+# 5.76 s → 6.45 s. Free, because these profiles are release-optimised. Do NOT read
+# the 577 s figure in `pk/modified_release.rs` as the cost of turning its verifier
+# on: that was measured on the unoptimised `dev` profile, where the fits are two
+# orders slower.
+#
+# `overflow-checks` — NOT inherited from `debug-assertions`. Cargo defaults it per
+# profile (true for `dev`, false for `release`), so a `release`-derived profile that
+# sets only `debug-assertions = true` still compiles with `-C overflow-checks=off`
+# (verified via `cargo build -v`). It is set explicitly here because it is the one
+# thing the retired `Tests (debug-assertions)` job had that the coverage jobs did
+# not, and folding it in is what let that job go. Measured cost: `--workspace
+# --tests` 133 s → 147 s, 5732 passed / 0 failed.
+[profile.ci-cov]
+inherits = "ci-fast"
+debug-assertions = true
+overflow-checks = true

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -265,13 +265,15 @@ after each major feature) and not yet on GitHub — a known gap to formalize.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented on `--profile ci-cov` — runs the Tier-1/2 suite with the `debug_assert!` guards live *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Clippy`, `Format`, `Public API baseline` (diffs `api/ferx-core-public-api.txt`); **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
+| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented on `--profile ci-cov` — runs the Tier-1/2 suite with the `debug_assert!` guards live *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Tests (release semantics)` (`--lib` on the **`ci-fast`** profile, so the guards are compiled out and release overflow semantics are exercised — see below), `Clippy`, `Format`, `Public API baseline` (diffs `api/ferx-core-public-api.txt`); **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
 | `slow-tests.yml` | nightly 06:00 UTC, manual, push to `main` touching estimation paths | Tier-3 fits to convergence (`--features ci,slow-tests --release`, `--no-fail-fast`) |
 | `docs.yml` | push to `main` touching `docs/**` | `quarto render` → deploy to `gh-pages` |
 | `release.yml` | tag `v*` or manual | GitHub release with generated notes |
 
 > Note: `RAYON_NUM_THREADS=1` is pinned in CI so cargo owns the test
 > parallelism on 2-core runners. Don't remove it.
+
+#### Both build modes, every PR {#both-build-modes}
 
 **Why the coverage jobs build `ci-cov`.** `release`, `ci-test` and `ci-fast` all
 leave `debug-assertions` off, so each of the ~180 `debug_assert!` guards in the
@@ -327,11 +329,33 @@ quietly reverted to `ci-fast` would neuter it with every test still green. Do no
 set that variable anywhere else: every other job legitimately runs with the
 guards off.
 
-One consequence to know when writing tests: a `#[cfg(not(debug_assertions))]`
-test **no longer runs in any CI job**. It does not fail there — it silently stops
-existing, which is worse. If a function has one behaviour under a live guard and
-another without, assert both (`catch_unwind` plus `cfg!(debug_assertions)`)
-rather than gating the test off; `src/types_tests.rs` has the pattern.
+#### The guards-off lane {#the-guards-off-lane}
+
+Turning the guards on for both coverage jobs would have
+left *no* per-PR job running the crate the way a user's release build behaves —
+guards compiled out, overflow wrapping. The remaining `ci-test` runs are
+scheduled, manual or post-merge, so a release-only regression could merge green.
+`Tests (release semantics)` is the counterweight: `--lib` on `ci,markov,nn` under
+`ci-fast`, in parallel with the coverage jobs and shorter than either, so it adds
+no wall-clock. It does not restore guards-off `tests/` binaries — those still run
+guards-off in `slow-tests.yml` and the nightly coverage job.
+
+Each lane arms a canary in the direction it cares about:
+`FERX_REQUIRE_DEBUG_ASSERTIONS=1` on the coverage jobs,
+`FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1` on the release lane. Without the second, the
+release lane would silently become a duplicate of the coverage jobs the moment
+`ci-fast` acquired `debug-assertions` — green throughout.
+
+#### Writing tests that span both modes {#tests-across-both-modes}
+
+**Do not gate a test on
+`#[cfg(not(debug_assertions))]`**. It does not fail under a guarded profile — it
+silently stops existing, which is worse. If a function has one behaviour under a
+live guard and another without (a misuse `debug_assert!` plus a NaN fallback, say),
+assert **both** with `catch_unwind` plus `cfg!(debug_assertions)`, so the test is
+meaningful in either lane; `src/types_tests.rs` has the pattern. Do not swap the
+panic hook to silence the expected panic — `set_hook` is process-global and races
+with the parallel harness badly enough to silence the whole process.
 
 ### 8.3 CI workflows (ferx-r)
 

--- a/docs/development/sdlc.qmd
+++ b/docs/development/sdlc.qmd
@@ -265,7 +265,7 @@ after each major feature) and not yet on GitHub — a known gap to formalize.
 
 | Workflow | Trigger | Jobs |
 |----------|---------|------|
-| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented — runs the Tier-1/2 suite *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Tests (debug-assertions)` (`--lib` on the **dev** profile, so `debug_assert!` guards actually run — see below), `Clippy`, `Format`, `Public API baseline` (diffs `api/ferx-core-public-api.txt`); **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
+| `ci.yml` | PR + push to `main` | `Check` (compile-only, incl. the `survival` / `markov` / `slow-tests` feature combos), `Tests + coverage (core)` (`--tests --features ci`, instrumented on `--profile ci-cov` — runs the Tier-1/2 suite with the `debug_assert!` guards live *and* produces the patch-coverage report), `Tests + coverage (TTE/CTMM endpoints)` (`--features ci,markov`, only the endpoint test binaries), `Clippy`, `Format`, `Public API baseline` (diffs `api/ferx-core-public-api.txt`); **`Tests + coverage (full, slow-tests)`** on weekly schedule / manual |
 | `slow-tests.yml` | nightly 06:00 UTC, manual, push to `main` touching estimation paths | Tier-3 fits to convergence (`--features ci,slow-tests --release`, `--no-fail-fast`) |
 | `docs.yml` | push to `main` touching `docs/**` | `quarto render` → deploy to `gh-pages` |
 | `release.yml` | tag `v*` or manual | GitHub release with generated notes |
@@ -273,16 +273,41 @@ after each major feature) and not yet on GitHub — a known gap to formalize.
 > Note: `RAYON_NUM_THREADS=1` is pinned in CI so cargo owns the test
 > parallelism on 2-core runners. Don't remove it.
 
-**Why a separate `Tests (debug-assertions)` job.** Every other test job builds
-with `--profile ci-test` or `--profile ci-fast`, and both `inherits = "release"`
-— so `debug-assertions` is off and each of the ~180 `debug_assert!` guards in the
-crate compiles to nothing. They were invariant checks CI never ran: an
-off-by-one in `compute_max_stack` tripped its own `debug_assert!` for any
-expression containing an `if`, and four lib tests panicked under the dev profile
-while CI stayed green (fixed in #342; the blind spot in #344). The fix is a
-separate job, not a flipped profile — `ci-test` exists so the fits run at release
-speed. Its commands live in `tools/preflight.sh` under the `debug-assertions`
-group; run them locally with
+**Why the coverage jobs build `ci-cov`.** `release`, `ci-test` and `ci-fast` all
+leave `debug-assertions` off, so each of the ~180 `debug_assert!` guards in the
+crate compiles to nothing. That cost two separate things:
+
+1. The guards were invariant checks CI never ran. An off-by-one in
+   `compute_max_stack` tripped its own `debug_assert!` for any expression
+   containing an `if`, and four lib tests panicked under the dev profile while CI
+   stayed green (fixed in #342; the blind spot in #344).
+2. `llvm-cov` still emits a coverage region for a guard's condition even when the
+   macro expands to nothing — a region that can never execute. Every multi-line
+   `debug_assert!` therefore contributed guaranteed-missed lines to the ≥90%
+   patch gate, unreachable by any test. On #1136 that put the ceiling at
+   **49/56 = 87.5%** against a 90% gate (#1248).
+
+`[profile.ci-cov]` — `ci-fast` plus `debug-assertions` and `overflow-checks` —
+fixes both at once, and the two per-PR coverage jobs build under it. It replaced
+the standalone `Tests (debug-assertions)` job #344 had added, which cost 32–42
+min: the CI critical path, roughly twice the next-longest job. Measured on a
+15-core machine with `--features ci`:
+
+| | guards off (`ci-fast`) | `debug-assertions` | `+ overflow-checks` (`ci-cov`) |
+|---|---|---|---|
+| `--workspace --tests` | 133 s | 133 s | 147 s |
+| `--lib` | 5.76 s | 6.45 s | — |
+| clean lib compile | 92 s / 98 s | 93 s / 87 s | — |
+
+so the guards are essentially free on a release-optimised profile, and 63
+condition lines flip from zero-hit to covered in `--lib` scope alone. A separate
+profile rather than a flipped `ci-fast`, because `ci-fast` is not CI-only —
+`tools/vi-nuts-anchor/run.sh` and `tools/vi-emvi-comparison/run.sh` build
+numerical anchors with it. It adds no CI compile: both coverage jobs already
+carry coverage `RUSTFLAGS` and their own cache keys, so nothing was shared with
+another job anyway.
+
+Run the same thing locally with
 
 ```bash
 tools/preflight.sh debug-assertions
@@ -292,17 +317,21 @@ That group is the one `tools/preflight.sh` skips when you pass no arguments: it
 runs a test suite rather than a compile, so it is minutes rather than seconds.
 Name it when you want it.
 
-Its commands carry `env FERX_REQUIRE_DEBUG_ASSERTIONS=1`, which arms a canary
-(`debug_assertion_canary` in `src/lib_tests.rs`) that fails the run if `debug_assert!`
-turns out to compile to nothing after all. Without it the gate would rest on the
-*absence* of a `--profile` flag, and a `[profile.dev] debug-assertions = false`
-or a `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment would neuter the
-whole job with every test still green. Do not set that variable anywhere else:
-every other job legitimately runs with the guards off.
+Its commands, and the coverage steps in `ci.yml`, carry
+`FERX_REQUIRE_DEBUG_ASSERTIONS=1`, which arms a canary (`debug_assertion_canary`
+in `src/lib_tests.rs`) that fails the run if `debug_assert!` turns out to compile
+to nothing after all. Without it the gate would rest on the *absence* of a
+mistake, and a `[profile.ci-cov] debug-assertions = false`, a
+`CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS` in the environment, or a `--profile` that
+quietly reverted to `ci-fast` would neuter it with every test still green. Do not
+set that variable anywhere else: every other job legitimately runs with the
+guards off.
 
-What this does **not** fix: `debug_assert!` condition lines are still permanently
-zero-hit regions in the Codecov reports, because every coverage job uses a
-release-derived profile. See #1248.
+One consequence to know when writing tests: a `#[cfg(not(debug_assertions))]`
+test **no longer runs in any CI job**. It does not fail there — it silently stops
+existing, which is worse. If a function has one behaviour under a live guard and
+another without, assert both (`catch_unwind` plus `cfg!(debug_assertions)`)
+rather than gating the test off; `src/types_tests.rs` has the pattern.
 
 ### 8.3 CI workflows (ferx-r)
 
@@ -362,8 +391,7 @@ FOCE/FOCEI and HMC gradients come from hand-rolled analytic `Dual2` sensitivitie
 (`sens/`), and models outside the provider's scope fall back to finite differences.
 
 In fact there is no nightly-only code left, which is why the three coverage jobs
-in `ci.yml` — and `Tests (debug-assertions)` — override `RUSTUP_TOOLCHAIN` to
-**stable**: stable's rustc version
+in `ci.yml` override `RUSTUP_TOOLCHAIN` to **stable**: stable's rustc version
 holds for ~6 weeks against nightly's daily bump, keeping their instrumented build
 cache warm. `rust-toolchain.toml` still pins nightly as the default, and `Check` /
 `Clippy` / `Format` run on it.

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -2186,10 +2186,12 @@ fn test_max_scaled_deviation_reports_degenerate_input_as_nan() {
     // there, it silently stops existing in the only jobs that ran it
     // (`outer_optimizer.rs:692` went from 1 hit to 0). Assert whichever the current
     // build promises instead.
-    let prev = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
+    //
+    // The panic hook is left alone deliberately, so the expected panic prints under
+    // a guarded profile. Swapping in a silent hook and restoring it is process-
+    // global and races with the parallel harness — see `guard_fired` in
+    // `src/types_tests.rs` for the interleaving that silences the whole process.
     let mismatched = std::panic::catch_unwind(|| max_scaled_deviation(&[1.0, 10.0], &[1.0]));
-    std::panic::set_hook(prev);
     if cfg!(debug_assertions) {
         assert!(
             mismatched.is_err(),

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -2176,12 +2176,34 @@ fn test_max_scaled_deviation_reports_degenerate_input_as_nan() {
 
     // A length mismatch is a bug, not a shorter comparison: it reports NaN rather
     // than silently comparing the common prefix (which here would read 0.0 —
-    // "still at init" — and hide the real 9.0 deviation). Only exercisable where
-    // the `debug_assert_eq!` guarding the same invariant is compiled out; the
-    // release behaviour is the one that matters, since that is what CI and users
-    // run.
-    #[cfg(not(debug_assertions))]
-    assert!(max_scaled_deviation(&[1.0, 10.0], &[1.0]).is_nan());
+    // "still at init" — and hide the real 9.0 deviation).
+    //
+    // Both behaviours are correct and which one you get is a property of the
+    // profile: the `debug_assert_eq!` guarding the same invariant fires where it is
+    // live, and the NaN fallback is what a release build (and a user) gets. This
+    // was `#[cfg(not(debug_assertions))]` until #1248 pointed the coverage jobs at
+    // `ci-cov`, where the guards ARE live — a cfg-gated assertion does not fail
+    // there, it silently stops existing in the only jobs that ran it
+    // (`outer_optimizer.rs:692` went from 1 hit to 0). Assert whichever the current
+    // build promises instead.
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let mismatched = std::panic::catch_unwind(|| max_scaled_deviation(&[1.0, 10.0], &[1.0]));
+    std::panic::set_hook(prev);
+    if cfg!(debug_assertions) {
+        assert!(
+            mismatched.is_err(),
+            "the `debug_assert_eq!` on the length invariant did not fire, even \
+             though this build has debug-assertions on"
+        );
+    } else {
+        assert!(
+            mismatched
+                .expect("no guard in a release-derived build")
+                .is_nan(),
+            "a length mismatch must report NaN once the guard is compiled out"
+        );
+    }
 }
 
 /// Regression test for the original issue #55 symptom: SLSQP optimizing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,26 +71,28 @@ pub use types::*;
 #[cfg(feature = "survival")]
 pub use api::{predict_categorical, predict_survival, SurvivalPredictionResult};
 
-/// Positive proof that the `debug_assert!` guards in this crate are LIVE (#344).
+/// Positive proof that the `debug_assert!` guards in this crate are LIVE
+/// (#344, #1248).
 ///
-/// Every other test job builds with `ci-test`/`ci-fast`, both of which
-/// `inherits = "release"`, so all ~180 `debug_assert!`s compile to nothing. The
-/// `Tests (debug-assertions)` job exists to run them, and it does that by simply
-/// omitting `--profile` — the dev default has them on.
+/// `release`, `ci-test` and `ci-fast` all leave `debug-assertions` off, so all ~180
+/// `debug_assert!`s compile to nothing there. `[profile.ci-cov]` turns them on, and
+/// the two per-PR coverage jobs build under it — which both runs the guards and
+/// stops their condition lines being regions that can never execute, the
+/// permanently-missed patch lines of #1248.
 ///
-/// That is an invariant held by *absence*, which is the fragile kind. Nothing in the
-/// command string distinguishes a build with the guards live from one without: a
-/// `[profile.dev] debug-assertions = false` in `Cargo.toml`, or a
-/// `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` in the workflow environment, would
-/// neuter the whole job while all 4366 tests, all nine preflight-contract tests and
-/// both `cargo test` commands stayed green. The gate would then be exactly the no-op
-/// it was filed to replace.
+/// That is an invariant held by *absence*, which is the fragile kind. Nothing in a
+/// test result distinguishes a build with the guards live from one without: a
+/// `[profile.ci-cov] debug-assertions = false` in `Cargo.toml`, a
+/// `CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS=false` in the workflow environment, or a
+/// `--profile` that quietly reverted to `ci-fast` would neuter the whole thing while
+/// all 4366 tests and every preflight-contract test stayed green. The gate would
+/// then be exactly the no-op #344 was filed to replace.
 ///
-/// So the group arms this canary through its own argument vector
-/// (`env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test …`, visible in
-/// `tools/preflight.sh --list` and asserted by
-/// `tests/preflight_owns_the_fast_gates.rs`), and the canary fails the run when the
-/// guards turn out to be dead.
+/// So each caller arms this canary explicitly — `FERX_REQUIRE_DEBUG_ASSERTIONS=1`,
+/// on the coverage steps in `ci.yml` and in the argument vector of
+/// `tools/preflight.sh`'s `debug-assertions` group (visible in `--list`, and
+/// asserted by `tests/preflight_owns_the_fast_gates.rs`) — and the canary fails the
+/// run when the guards turn out to be dead.
 #[cfg(test)]
 #[path = "lib_tests.rs"]
 mod debug_assertion_canary;

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -1,19 +1,21 @@
 //! Positive proof that the `debug_assert!` guards in this crate are LIVE (#344).
 //!
 //! Sibling test file rather than an inline `#[cfg(test)] mod`, for the ordinary
-//! reason (`CLAUDE.md`'s sibling-`*_tests.rs` pattern) and for one specific to what
-//! this module does: the interior of a `debug_assert!` is, by construction,
-//! unreachable under a release-derived profile. Inline in `src/lib.rs` those two
-//! lines are permanently-missed patch lines in every Codecov job — the exact defect
-//! filed as #1248 — and they took this PR's own patch gate to 9/11 = 81.81%. No
-//! test can cover them; they are a measurement artefact, not a coverage gap. Here
-//! they are simply not measured, which is how the other 53 `*_tests.rs` files in
-//! this repo are already treated.
+//! reason (`CLAUDE.md`'s sibling-`*_tests.rs` pattern) and for one that used to be
+//! specific to what this module does: the interior of a `debug_assert!` is, by
+//! construction, unreachable under a release-derived profile, so inline in
+//! `src/lib.rs` those two lines were permanently-missed patch lines in every
+//! Codecov job — the defect filed as #1248, which took this file's own PR to
+//! 9/11 = 81.81%. #1248 has since been fixed at the source: the coverage jobs build
+//! `[profile.ci-cov]`, where the guards are live and their lines are ordinary
+//! covered lines. The sibling layout stays for the ordinary reason.
 
-/// The env var `tools/preflight.sh`'s `debug-assertions` group sets. Deliberately
-/// opt-*in*: every other job legitimately runs with the guards off, so an
-/// unconditional assertion here would fail `Tests + coverage (core)` and both
-/// coverage jobs for doing exactly what they are supposed to do.
+/// The env var that demands the guards be live. Set by `tools/preflight.sh`'s
+/// `debug-assertions` group and by the two coverage jobs in `ci.yml`, which since
+/// #1248 build `[profile.ci-cov]`. Deliberately opt-*in*: the `Check`/`Clippy` jobs
+/// and any `ci-fast` build legitimately run with the guards off, so an
+/// unconditional assertion here would fail them for doing exactly what they are
+/// supposed to do.
 const DEMAND: &str = "FERX_REQUIRE_DEBUG_ASSERTIONS";
 
 #[test]
@@ -46,10 +48,11 @@ fn debug_assert_guards_run_when_the_gate_demands_them() {
     assert!(
         !demanded || evaluated,
         "{DEMAND} is set — this run came from `tools/preflight.sh debug-assertions` \
-         or the `Tests (debug-assertions)` CI job — but `debug_assert!` compiled to \
-         nothing, so every guard in the crate is dead and the job is green for no \
-         reason. Something switched debug-assertions off for the dev profile: a \
-         `[profile.dev] debug-assertions = false` in Cargo.toml, or a \
-         `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS` in the environment (#344)."
+         or one of the two coverage jobs in ci.yml — but `debug_assert!` compiled to \
+         nothing, so every guard in the crate is dead and the run is green for no \
+         reason. Something switched debug-assertions off for the profile being \
+         built: a `[profile.ci-cov] debug-assertions = false` in Cargo.toml, a \
+         `CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS` in the environment, or a \
+         `--profile` that reverted to `ci-fast` (#344, #1248)."
     );
 }

--- a/src/lib_tests.rs
+++ b/src/lib_tests.rs
@@ -18,6 +18,18 @@
 /// supposed to do.
 const DEMAND: &str = "FERX_REQUIRE_DEBUG_ASSERTIONS";
 
+/// The mirror image, for the `Tests (release semantics)` lane. That job exists to
+/// run the Tier-1 suite the way a *user's* build behaves — guards compiled out, no
+/// overflow checks — because #1248 moved both coverage jobs onto `ci-cov` and would
+/// otherwise have left no per-PR job exercising release semantics at all (raised by
+/// review on PR #1293). Its value is entirely in being the OTHER mode, so it needs
+/// the same protection from the opposite direction: if `ci-fast` ever acquired
+/// `debug-assertions`, the lane would silently become a duplicate of the coverage
+/// jobs, every test would stay green, and the release-only arms of
+/// `sim_outcome_category_and_count_continuous_value_is_nan` and friends would go
+/// unchecked again — the #344 failure shape with the sign flipped.
+const FORBID: &str = "FERX_REQUIRE_NO_DEBUG_ASSERTIONS";
+
 #[test]
 fn debug_assert_guards_run_when_the_gate_demands_them() {
     let demanded = std::env::var_os(DEMAND).is_some();
@@ -54,5 +66,28 @@ fn debug_assert_guards_run_when_the_gate_demands_them() {
          built: a `[profile.ci-cov] debug-assertions = false` in Cargo.toml, a \
          `CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS` in the environment, or a \
          `--profile` that reverted to `ci-fast` (#344, #1248)."
+    );
+
+    // The opposite gate, same shape: `!forbidden || !evaluated`, so the only run
+    // this can fail is one that asked for release semantics and got the guards.
+    let forbidden = std::env::var_os(FORBID).is_some();
+    assert!(
+        !forbidden || !evaluated,
+        "{FORBID} is set — this run came from `tools/preflight.sh release-semantics` \
+         or the `Tests (release semantics)` CI job, whose whole purpose is to exercise \
+         the crate the way a user's release build behaves — but `debug_assert!` IS \
+         live, so this lane is now a duplicate of the coverage jobs and nothing on \
+         the PR checks the guards-off arms. Something switched debug-assertions ON \
+         for the profile being built: a `[profile.ci-fast] debug-assertions = true` \
+         in Cargo.toml, a `CARGO_PROFILE_CI_FAST_DEBUG_ASSERTIONS` in the \
+         environment, or a `--profile` that drifted to `ci-cov` (#1293)."
+    );
+
+    // Both set at once is a caller error, not a profile problem: no build can
+    // satisfy both, so it would fail whichever way the profile went and the
+    // diagnostics above would each blame the manifest.
+    assert!(
+        !(demanded && forbidden),
+        "{DEMAND} and {FORBID} are both set; they are contradictory demands."
     );
 }

--- a/src/pk/modified_release.rs
+++ b/src/pk/modified_release.rs
@@ -806,10 +806,17 @@ pub(crate) fn mr_scope<'a>(
 ///     regimen on the same id — the case CLAUDE.md's non-degeneracy rule says
 ///     must always be checked, and the one superposition most needs checked.
 ///
-/// The gate is also `#[cfg(debug_assertions)]`, and every profile CI builds tests
-/// with inherits `release`, so none of this runs in CI or in a user's fit — that
-/// is the already-tracked #344. Treat the gate as a local development aid, not as
-/// the reason admitting a closed form is safe.
+/// The gate is `#[cfg(debug_assertions)]`. That used to mean it ran nowhere but a
+/// local dev build — the already-tracked #344 — but since #1248 the two per-PR
+/// coverage jobs build `[profile.ci-cov]`, where the guards are live, so it DOES
+/// now run in CI. Measured when that landed: `--workspace --tests` took 133 s with
+/// the gate off and 133 s with it on, because `ci-cov` is release-optimised. Do not
+/// read the 577 s figure below as its cost in CI — that was the unoptimised `dev`
+/// profile, where the fits are two orders slower.
+///
+/// It still does not run in a user's fit (release has the guards off), and the
+/// memo-key weaknesses listed above are unchanged, so it remains a development aid
+/// rather than the reason admitting a closed form is safe.
 #[cfg(debug_assertions)]
 type MrVerifyKey = (usize, String, Vec<i32>);
 

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -32,16 +32,18 @@ fn sim_outcome_category_and_count_variants_construct() {
 /// silently stops existing, in the only jobs that ran it. Measured at the time:
 /// three tests, and `src/types.rs:3490` and `:3494` went from 2 hits to 0.
 ///
-/// The panic hook is swapped for a silent one so an expected panic does not print
-/// a backtrace into the test log. `set_hook` is process-global, so a genuinely
-/// unexpected panic in a *concurrent* test could lose its message for the duration
-/// of this call; that is the accepted cost, and the hook is restored immediately.
+/// The panic hook is left ALONE, so under a guarded profile each expected panic
+/// prints its message to the test log. That noise is deliberate. The obvious
+/// tidier version — `take_hook`, install a silent one, restore — is not merely
+/// racy in the "a concurrent failure loses its message" sense: `set_hook` is
+/// process-global and these expected-panic paths can run concurrently in the same
+/// lib-test process, so the interleaving where A takes the normal hook, B takes
+/// the *silent* hook A installed, A restores normal and B restores silent leaves
+/// the whole process permanently silenced. Restoring immediately does not help;
+/// only a shared lock would, and three expected panic messages are cheaper than
+/// that machinery. Raised by review on PR #1293.
 fn guard_fired(f: impl FnOnce() -> f64) -> Result<f64, ()> {
-    let prev = std::panic::take_hook();
-    std::panic::set_hook(Box::new(|_| {}));
-    let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-    std::panic::set_hook(prev);
-    out.map_err(|_| ())
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).map_err(|_| ())
 }
 
 /// `continuous_value()` on the non-Gaussian outcomes: the misuse guard fires where

--- a/src/types_tests.rs
+++ b/src/types_tests.rs
@@ -18,30 +18,79 @@ fn sim_outcome_category_and_count_variants_construct() {
     );
 }
 
-/// `continuous_value()` returns NAN for the non-Gaussian outcomes. The
-/// misuse `debug_assert` fires in debug builds, so this is asserted only when
-/// debug-assertions are off — the profile CI and coverage use (`ci-test`,
-/// which inherits `release`), where the NAN branch is actually taken.
-#[test]
-#[cfg(not(debug_assertions))]
-fn sim_outcome_category_and_count_continuous_value_is_nan() {
-    assert!(SimOutcome::Category { state: 3 }
-        .continuous_value()
-        .is_nan());
-    assert!(SimOutcome::Count { count: 9 }.continuous_value().is_nan());
+/// Calls `f` and reports whether the misuse `debug_assert!` inside it fired.
+///
+/// `continuous_value()` on a non-Gaussian outcome has two correct behaviours and
+/// which one you get is a property of the profile: with the guards live it panics,
+/// with them compiled out it returns NaN. Both matter — the guard is the developer
+/// signal, the NaN is what a release user actually gets — so the tests below assert
+/// whichever the current build promises rather than switching themselves off.
+///
+/// They used to be `#[cfg(not(debug_assertions))]`, which was correct while every
+/// CI profile inherited `release`. #1248 moved the coverage jobs onto `ci-cov`,
+/// where the guards ARE live, and a `cfg`-gated test does not fail there — it
+/// silently stops existing, in the only jobs that ran it. Measured at the time:
+/// three tests, and `src/types.rs:3490` and `:3494` went from 2 hits to 0.
+///
+/// The panic hook is swapped for a silent one so an expected panic does not print
+/// a backtrace into the test log. `set_hook` is process-global, so a genuinely
+/// unexpected panic in a *concurrent* test could lose its message for the duration
+/// of this call; that is the accepted cost, and the hook is restored immediately.
+fn guard_fired(f: impl FnOnce() -> f64) -> Result<f64, ()> {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    std::panic::set_hook(prev);
+    out.map_err(|_| ())
 }
 
-/// The TTE `Event` outcome likewise has no continuous value. Same profile
-/// caveat as above (the debug-assert fires in debug builds).
+/// `continuous_value()` on the non-Gaussian outcomes: the misuse guard fires where
+/// `debug_assert!` is live, and the NAN branch is taken where it is not.
 #[test]
-#[cfg(all(feature = "survival", not(debug_assertions)))]
+fn sim_outcome_category_and_count_continuous_value_is_nan() {
+    for out in [
+        SimOutcome::Category { state: 3 },
+        SimOutcome::Count { count: 9 },
+    ] {
+        let got = guard_fired(|| out.continuous_value());
+        if cfg!(debug_assertions) {
+            assert!(
+                got.is_err(),
+                "{out:?}: the misuse `debug_assert!` in continuous_value() did not \
+                 fire, even though this build has debug-assertions on"
+            );
+        } else {
+            assert!(
+                got.expect("no guard in a release-derived build").is_nan(),
+                "{out:?}: continuous_value() must return NAN once the guard is \
+                 compiled out"
+            );
+        }
+    }
+}
+
+/// The TTE `Event` outcome likewise has no continuous value. Same two behaviours
+/// as above.
+#[test]
+#[cfg(feature = "survival")]
 fn sim_outcome_event_continuous_value_is_nan() {
-    assert!(SimOutcome::Event {
+    let out = SimOutcome::Event {
         time: 1.0,
         observed: true,
+    };
+    let got = guard_fired(|| out.continuous_value());
+    if cfg!(debug_assertions) {
+        assert!(
+            got.is_err(),
+            "the misuse `debug_assert!` for the Event outcome did not fire"
+        );
+    } else {
+        assert!(
+            got.expect("no guard in a release-derived build").is_nan(),
+            "continuous_value() on an Event outcome must return NAN once the guard \
+             is compiled out"
+        );
     }
-    .continuous_value()
-    .is_nan());
 }
 
 /// `effective_cov_inner_tol` resolves the covariance-step reconvergence tolerance:

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -1,5 +1,5 @@
-//! Guard: the `Check`, `Clippy`, `Format`, `Rustdoc` and `Tests (debug-assertions)` jobs
-//! in `.github/workflows/ci.yml` must run their cargo commands **through
+//! Guard: the `Check`, `Clippy`, `Format` and `Rustdoc` jobs in
+//! `.github/workflows/ci.yml` must run their cargo commands **through
 //! `tools/preflight.sh`**, and that script must actually fail when a gate fails (#1157).
 //!
 //! The point of the script is not documentation — it is that CI executes the same list a
@@ -11,7 +11,7 @@
 //! `--features ci,nn,slow-tests` had been failing to compile for an entire commit,
 //! because the local run and the CI run were not the same set.
 //!
-//! Four invariants:
+//! Five invariants:
 //!
 //!  1. Those jobs contain **no inline `run: cargo …` step**, and neither skip
 //!     themselves (`if:`) nor tolerate failure (`continue-on-error`). Each is a way for
@@ -20,9 +20,18 @@
 //!  3. A failing command makes the script exit non-zero **from every position in the
 //!     list**, not just the last one.
 //!  4. A no-argument run is `ALL_GROUPS` minus `OPT_IN_GROUPS`, and every opt-in group
-//!     is named by a job in `ci.yml` (#344). An opt-in group exists because it runs a
-//!     test suite rather than a compile — `debug-assertions` is the only one — and the
-//!     failure it invites is a gate that runs in neither place.
+//!     is either named by a job in `ci.yml` or pinned by (5). An opt-in group exists
+//!     because it runs a test suite rather than a compile — `debug-assertions` is the
+//!     only one — and the failure it invites is a gate that runs in neither place.
+//!  5. The two per-PR coverage jobs build a profile whose `debug-assertions` is on,
+//!     and arm the canary that proves it (#1248). This is where the `debug-assertions`
+//!     group's property lives now: #344 gave it a job of its own, and #1248 retired
+//!     that job in favour of `[profile.ci-cov]`, since the guards being dead cost not
+//!     just an unrun invariant but a permanently-missed block of patch lines.
+//!
+//! (5) is why (4) has an exception rather than a second delegating job: the coverage
+//! jobs run `cargo llvm-cov`, so they cannot call a preflight group without running
+//! the suite a third time — which is the 32–42 min that retiring the job saved.
 //!
 //! (3) is not hypothetical. The first version of the script returned a status from `run`
 //! and propagated it through a group function and a `case … esac || { …; exit 1; }` —
@@ -90,6 +99,46 @@ fn all_groups() -> Vec<String> {
 /// rather than a compile, so they are named explicitly or run by CI.
 fn opt_in_groups() -> Vec<String> {
     script_array("OPT_IN_GROUPS")
+}
+
+/// Does `[profile.<name>]` in Cargo.toml resolve to `debug-assertions = true`?
+///
+/// Resolves `inherits` transitively, because that is exactly how the guards get
+/// turned off by accident: `ci-cov` inherits `ci-fast` inherits `ci-test`
+/// inherits `release`, and a profile that says nothing takes its parent's answer.
+/// A missing `[profile.<name>]` section means a built-in profile, and the only
+/// built-in with the guards on is `dev`.
+fn profile_has_guards_on(name: &str) -> bool {
+    let src = std::fs::read_to_string(repo_root().join("Cargo.toml")).expect("read Cargo.toml");
+    let mut current = name.to_string();
+    // Bounded: a cycle in `inherits` is a Cargo error, but this test must not hang
+    // on a malformed manifest either.
+    for _ in 0..16 {
+        let header = format!("\n[profile.{current}]\n");
+        let Some(start) = src.find(&header) else {
+            // No section of its own — a built-in profile.
+            return current == "dev";
+        };
+        let rest = &src[start + header.len()..];
+        let body = &rest[..rest.find("\n[").unwrap_or(rest.len())];
+
+        let value = |key: &str| -> Option<String> {
+            body.lines()
+                .filter_map(|l| l.split_once('='))
+                .find(|(k, _)| k.trim() == key)
+                .map(|(_, v)| v.trim().trim_matches('"').to_string())
+        };
+        if let Some(v) = value("debug-assertions") {
+            return v == "true";
+        }
+        match value("inherits") {
+            Some(parent) => current = parent,
+            // A custom profile MUST declare `inherits`, so this is unreachable via
+            // a valid manifest; treat it as "not established" rather than true.
+            None => return false,
+        }
+    }
+    panic!("`inherits` chain from profile `{name}` did not terminate");
 }
 
 fn ci_yml() -> String {
@@ -209,12 +258,13 @@ fn the_fast_gate_jobs_delegate_to_preflight_and_never_inline_cargo() {
         ("clippy", "clippy"),
         ("fmt", "fmt"),
         ("rustdoc", "rustdoc"),
-        // #344. This one is a TEST job, not a compile/lint gate, and it is the
-        // only group a no-argument `tools/preflight.sh` skips — so the workflow
-        // is the only place it is guaranteed to run. That makes delegation
-        // matter more here, not less: an inline `cargo test` in the job would be
-        // a command no developer can reproduce with a documented local call.
-        ("debug-assertions", "debug-assertions"),
+        // NOT `debug-assertions`. It had a job of its own under #344; #1248
+        // retired it, because `[profile.ci-cov]` puts the guards inside the two
+        // coverage jobs that had to run anyway. Those jobs cannot delegate here —
+        // they run `cargo llvm-cov`, not a preflight group — so the invariant for
+        // this group is pinned by `the_debug_assertions_group_builds_a_profile_\
+        // with_the_guards_on` and `the_coverage_jobs_build_the_guarded_profile`
+        // below instead.
     ] {
         let body = job_body(&yml, job);
         let cmds = run_commands(&body);
@@ -553,14 +603,15 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
         docs.join("\n  ")
     );
 
-    // The `debug-assertions` group is a gate ONLY because it builds on the default
-    // dev profile (#344). Every named profile in this repo — `release`, `ci-test`,
-    // `ci-fast` — has `debug-assertions` off, `ci-test`/`ci-fast` by inheriting
-    // `release`, so a `--profile`/`--release` flag added to one of these commands
-    // would leave two `cargo test` lines in the list, still run 4000-odd tests,
-    // still take minutes, and compile every `debug_assert!` in the crate back down
-    // to nothing. That is the exact shape of the neutered gate this test exists for:
-    // the command list cannot show it, only its flags can.
+    // The `debug-assertions` group is a gate only while the profile it names
+    // actually has the guards on. Before #1248 that was expressed as a BAN on
+    // `--profile`, because the dev default was the only place `debug_assert!` was
+    // live and every named profile in the repo inherited `release`. #1248 added
+    // `[profile.ci-cov]` — `ci-fast` plus `debug-assertions`/`overflow-checks` —
+    // and pointed both this group and the two coverage jobs at it, so the ban
+    // would now reject the correct command. The property is the same one either
+    // way, so assert it directly against Cargo.toml instead of by proxy: whatever
+    // profile the command selects must be one whose guards are on.
     let dbg = listed_commands("debug-assertions");
     assert!(
         !dbg.is_empty(),
@@ -568,30 +619,51 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
     );
     for cmd in &dbg {
         assert!(
-            !cmd.contains("--profile") && !cmd.contains("--release"),
-            "`{cmd}` selects an explicit profile. Every named profile in this repo \
-             inherits `release`, where `debug-assertions = false`, so the guards this \
-             group exists to execute would compile to nothing while the job stayed \
-             green (#344). Drop the flag; the dev default is the gate."
-        );
-        assert!(
             cmd.contains("cargo test "),
             "`{cmd}` is in the `debug-assertions` group but does not RUN anything. \
              A `cargo check`/`clippy` line compiles the assertions and never \
              evaluates them, which is the blind spot, not the fix (#344)."
         );
 
-        // The POSITIVE half, and the one the flag check above cannot supply.
-        // Rejecting `--profile` only rules out the ways of turning the guards off
-        // that are VISIBLE in the command string. Two are not: `[profile.dev]
-        // debug-assertions = false` in Cargo.toml, and a
-        // `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS=false` in the workflow environment.
-        // Either would leave
-        // this group's two commands intact, run all 4366 tests, and keep every
-        // assertion in this file green while the job verified nothing —
+        // `--release` names a profile whose `debug-assertions` is off by
+        // definition, and no `--profile` at all means the dev default, which is
+        // fine but is NOT what CI measures under any more.
+        assert!(
+            !cmd.contains("--release"),
+            "`{cmd}` builds `release`, where `debug-assertions = false`, so every \
+             guard this group exists to execute compiles to nothing while the run \
+             stays green (#344)."
+        );
+        let profile = cmd
+            .split_whitespace()
+            .skip_while(|w| *w != "--profile")
+            .nth(1)
+            .unwrap_or_else(|| {
+                panic!(
+                    "`{cmd}` selects no `--profile`, so it builds `dev`. That was the \
+                     #344 gate, but since #1248 the guards are measured under \
+                     `ci-cov` — the profile the coverage jobs use. Build the same \
+                     thing CI does, so a local green means what CI means."
+                )
+            });
+        assert!(
+            profile_has_guards_on(profile),
+            "`{cmd}` builds `--profile {profile}`, but `[profile.{profile}]` in \
+             Cargo.toml does not resolve to `debug-assertions = true`. Every profile \
+             in this repo inherits `release` unless it says otherwise, so this group \
+             would run 4000-odd tests, take minutes, and compile every \
+             `debug_assert!` in the crate back down to nothing (#344, #1248)."
+        );
+
+        // The POSITIVE half, and the one the profile check above cannot supply.
+        // Reading Cargo.toml rules out the ways of turning the guards off that are
+        // visible in the manifest. One is not: a
+        // `CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS=false` in the environment would
+        // leave this group's two commands intact, run all 4366 tests, and keep
+        // every assertion in this file green while the group verified nothing —
         // an invariant held by absence is exactly what #344 was filed about.
-        // `debug_assertion_canary` (`src/lib_tests.rs`) closes that, but only when armed,
-        // so the arming has to be pinned as tightly as the flags are.
+        // `debug_assertion_canary` (`src/lib_tests.rs`) closes that, but only when
+        // armed, so the arming has to be pinned as tightly as the profile is.
         //
         // `starts_with`, not `contains`: it must be the argv-leading `env` form, so
         // `run` echoes it and `--list` tells the truth about what will run.
@@ -812,9 +884,36 @@ fn the_default_run_is_every_group_that_is_not_opt_in_and_ci_runs_the_rest() {
     // exactly these commands, so that check would have been self-satisfying. Applied
     // to the whole document rather than one job body on purpose: moving the group
     // between jobs is fine, running it nowhere is not.
+    //
+    // ONE documented exception, `debug-assertions` (#1248). Its property — the
+    // `debug_assert!` guards are live where CI measures — moved out of a
+    // delegating job and into `[profile.ci-cov]`, which the two coverage jobs
+    // build under. Those jobs run `cargo llvm-cov`, so they cannot call a
+    // preflight group without running the suite a third time, which is the cost
+    // retiring the job was about. The exception is not a hole: it is discharged
+    // by `the_coverage_jobs_build_the_guarded_profile`, and this list is checked
+    // against that test's existence so the two cannot drift apart.
+    const PINNED_BY_PROFILE: &[&str] = &["debug-assertions"];
+
     let yml = ci_yml();
     let executed = run_commands(&yml);
     for g in &opt_in {
+        if PINNED_BY_PROFILE.contains(&g.as_str()) {
+            let src = std::fs::read_to_string(
+                repo_root()
+                    .join("tests")
+                    .join("preflight_owns_the_fast_gates.rs"),
+            )
+            .expect("read this test file");
+            assert!(
+                src.contains("fn the_coverage_jobs_build_the_guarded_profile("),
+                "group `{g}` is exempted from the delegation rule on the grounds that \
+                 `the_coverage_jobs_build_the_guarded_profile` pins it instead — and \
+                 that test no longer exists. Either restore it or drop `{g}` from \
+                 PINNED_BY_PROFILE, but do not leave the gate resting on a comment."
+            );
+            continue;
+        }
         let want = format!("tools/preflight.sh {g}");
         assert!(
             executed.iter().any(|c| c == &want),
@@ -822,6 +921,76 @@ fn the_default_run_is_every_group_that_is_not_opt_in_and_ci_runs_the_rest() {
              is a gate that nothing executes. Naming it in a comment does not count — \
              this reads the `run:` steps.\nrun steps found:\n  {}",
             executed.join("\n  ")
+        );
+    }
+}
+
+/// #1248: the guards run where the coverage is measured.
+///
+/// This is the successor to #344's `Tests (debug-assertions)` job, and it pins
+/// both halves of why that job could go. Every `cargo llvm-cov` invocation whose
+/// report feeds the per-PR **patch** gate must build a profile whose
+/// `debug-assertions` is on, so that (a) the ~180 guards are executed at all, and
+/// (b) their condition lines stop being regions that can never run — permanently
+/// missed patch lines against a 90% gate, which is #1248 itself.
+///
+/// The nightly `coverage` job is deliberately out of scope: it uploads the `slow`
+/// flag, which `codecov.yml` excludes from the patch status, and it stays on
+/// `ci-test` so its 5-60 min Tier-3 fits keep the ThinLTO speedup (#969).
+#[test]
+fn the_coverage_jobs_build_the_guarded_profile() {
+    let yml = ci_yml();
+
+    for job in ["coverage-pr", "endpoints"] {
+        let body = job_body(&yml, job);
+        let cov: Vec<String> = run_commands(&body)
+            .into_iter()
+            .filter(|c| c.contains("cargo llvm-cov"))
+            .collect();
+        assert!(
+            !cov.is_empty(),
+            "job `{job}` runs no `cargo llvm-cov` — it is supposed to be a coverage \
+             job. Did the job key change?"
+        );
+
+        for cmd in &cov {
+            let profile = cmd
+                .split_whitespace()
+                .skip_while(|w| *w != "--profile")
+                .nth(1)
+                .unwrap_or_else(|| panic!("job `{job}`: `{cmd}` names no `--profile` at all"));
+            assert!(
+                profile_has_guards_on(profile),
+                "job `{job}` measures coverage under `--profile {profile}`, which does \
+                 not resolve to `debug-assertions = true` in Cargo.toml. Every \
+                 `debug_assert!` in the crate then compiles to nothing, so its \
+                 invariant goes unchecked (#344) AND its condition lines become \
+                 regions that can never execute — guaranteed-missed patch lines \
+                 against the 90% Codecov gate that no test can ever cover (#1248)."
+            );
+        }
+
+        // The canary, for the same reason the preflight group arms it: reading
+        // Cargo.toml cannot see a `CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS=false` in
+        // the environment, and without the canary that would leave every test green
+        // while the guards were dead — #344's failure shape exactly.
+        //
+        // Comment lines are stripped first, and that is load-bearing rather than
+        // tidy: both jobs carry a comment block explaining this very variable, so a
+        // plain `body.contains(...)` is satisfied by the prose and passes with the
+        // `env:` key deleted. Verified by deleting it — the check was green. This
+        // file already warns about the same trap one test up; it caught me anyway.
+        let arms_canary = body
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.starts_with('#'))
+            .any(|l| l.starts_with("FERX_REQUIRE_DEBUG_ASSERTIONS:"));
+        assert!(
+            arms_canary,
+            "job `{job}` builds a guarded profile but never arms \
+             `debug_assertion_canary` (`src/lib_tests.rs`), so nothing in the run \
+             verifies that `debug_assert!` is actually live. Set \
+             `FERX_REQUIRE_DEBUG_ASSERTIONS: \"1\"` on the coverage step."
         );
     }
 }

--- a/tests/preflight_owns_the_fast_gates.rs
+++ b/tests/preflight_owns_the_fast_gates.rs
@@ -21,17 +21,24 @@
 //!     list**, not just the last one.
 //!  4. A no-argument run is `ALL_GROUPS` minus `OPT_IN_GROUPS`, and every opt-in group
 //!     is either named by a job in `ci.yml` or pinned by (5). An opt-in group exists
-//!     because it runs a test suite rather than a compile — `debug-assertions` is the
-//!     only one — and the failure it invites is a gate that runs in neither place.
-//!  5. The two per-PR coverage jobs build a profile whose `debug-assertions` is on,
-//!     and arm the canary that proves it (#1248). This is where the `debug-assertions`
-//!     group's property lives now: #344 gave it a job of its own, and #1248 retired
-//!     that job in favour of `[profile.ci-cov]`, since the guards being dead cost not
-//!     just an unrun invariant but a permanently-missed block of patch lines.
+//!     because it runs a test suite rather than a compile, and the failure it invites
+//!     is a gate that runs in neither place.
+//!  5. **Both modes are exercised per PR.** The two coverage jobs build a profile whose
+//!     `debug-assertions` is ON and arm the canary proving it (#1248); the
+//!     `release-semantics` group builds one where they are OFF and arms the inverse
+//!     canary (#1293). Each is asserted against Cargo.toml, resolving `inherits`.
 //!
-//! (5) is why (4) has an exception rather than a second delegating job: the coverage
-//! jobs run `cargo llvm-cov`, so they cannot call a preflight group without running
-//! the suite a third time — which is the 32–42 min that retiring the job saved.
+//! (5) is a pair, and the pairing is the point. #344 gave the guards a job of their own;
+//! #1248 retired it in favour of `[profile.ci-cov]`, since dead guards cost not just an
+//! unrun invariant but a permanently-missed block of patch lines. That fix, alone, left
+//! no per-PR job running the crate the way a user's build behaves — several tests assert
+//! one thing under a live guard and another without one, so a mode that no job builds is
+//! a set of assertions nothing checks. Hence the mirror lane, and hence both directions
+//! being pinned here rather than resting on nobody editing a profile.
+//!
+//! (5) is also why (4) has an exception rather than a third delegating job: the coverage
+//! jobs run `cargo llvm-cov`, so they cannot call a preflight group without running the
+//! suite again — which is the 32–42 min that retiring #344's job saved.
 //!
 //! (3) is not hypothetical. The first version of the script returned a status from `run`
 //! and propagated it through a group function and a `case … esac || { …; exit 1; }` —
@@ -688,6 +695,53 @@ fn load_bearing_flags_and_feature_coverage_survive_in_the_command_list() {
         dbg.join("\n  ")
     );
 
+    // The mirror lane (#1293). `release-semantics` is worth having ONLY while it is
+    // the other mode: guards compiled out, release overflow semantics, the way a
+    // user's build behaves. If it ever drifted onto a guarded profile it would
+    // become a second copy of the coverage jobs and the release-only arms of
+    // `continuous_value()` / `max_scaled_deviation()` would go unchecked on PRs
+    // again — green throughout, which is why this is asserted rather than assumed.
+    let rel = listed_commands("release-semantics");
+    assert!(
+        !rel.is_empty(),
+        "the `release-semantics` group lists no commands"
+    );
+    for cmd in &rel {
+        assert!(
+            cmd.contains("cargo test "),
+            "`{cmd}` is in the `release-semantics` group but does not RUN anything."
+        );
+        let profile = cmd
+            .split_whitespace()
+            .skip_while(|w| *w != "--profile")
+            .nth(1)
+            .unwrap_or_else(|| {
+                panic!(
+                    "`{cmd}` selects no `--profile`, so it builds `dev` — which has \
+                     the guards ON and no optimisation, i.e. neither of the two things \
+                     this lane exists to provide (#1293)."
+                )
+            });
+        assert!(
+            !profile_has_guards_on(profile),
+            "`{cmd}` builds `--profile {profile}`, which resolves to \
+             `debug-assertions = true` in Cargo.toml. This lane exists to be the \
+             guards-OFF half of the pair; on a guarded profile it duplicates the \
+             coverage jobs and nothing on the PR exercises release semantics (#1293)."
+        );
+
+        // The runtime half, same argument as the canary arming above: reading
+        // Cargo.toml cannot see a `CARGO_PROFILE_CI_FAST_DEBUG_ASSERTIONS=true` in
+        // the environment.
+        assert!(
+            cmd.starts_with("env FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1 cargo "),
+            "`{cmd}` does not arm the inverse canary. Prefix it with \
+             `env FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1` (in the argument vector, so \
+             `--list` shows it): without it `debug_assertion_canary` in \
+             src/lib_tests.rs cannot tell this lane from a guarded one (#1293)."
+        );
+    }
+
     // Union of every `--features` value in the check group.
     let check = listed_commands("check");
     let mut features: Vec<String> = Vec::new();
@@ -763,7 +817,7 @@ fn preflight_is_executable_and_lists_every_group() {
     // commands are actually *enforced* is
     // `a_failing_gate_fails_the_script_from_every_position`; `--list` executes nothing and
     // can never show it.
-    let expected: [(&str, usize); 7] = [
+    let expected: [(&str, usize); 8] = [
         ("fmt", 1),        // cargo fmt --all -- --check
         ("check", 5),      // ci · ci,survival,slow-tests · ci,markov · ci,nn,slow-tests · members
         ("clippy", 2),     // ferx-core --all-targets · members
@@ -776,6 +830,12 @@ fn preflight_is_executable_and_lists_every_group() {
         // dropping it would leave those guards exactly as dead as they are in
         // every release-profile job.
         ("debug-assertions", 2),
+        // #1293: one line, `--lib` on the `ci,markov,nn` union. Deliberately not a
+        // matrix like its guards-on twin above — this lane exists to exercise
+        // release semantics, and the union of the production cfgs is enough for
+        // that, where the twin needs both sets because it is chasing guards that
+        // live inside feature-gated modules.
+        ("release-semantics", 1),
     ];
 
     // Every group `--list` actually walks must have an entry above. The loop below

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -69,13 +69,17 @@ ALL_GROUPS=(fmt check clippy rustdoc docs public-api debug-assertions)
 # that RUNS the unit suite is a different order of cost (its own profile hash,
 # so its own full build, and then the tests), and folding it into the default
 # would turn `tools/preflight.sh` from a pre-push habit into a coffee break. So
-# it is opt-in by name — `tools/preflight.sh debug-assertions` — and CI runs it
-# as its own job, which is where it has to be green.
+# it is opt-in by name — `tools/preflight.sh debug-assertions` — and CI covers the
+# same ground inside its coverage jobs, which is where it has to be green.
 #
-# `--help` and `--list` still enumerate it, and
-# `tests/preflight_owns_the_fast_gates.rs` pins both this array and the fact that
-# the corresponding CI job delegates here, so an opt-in group cannot quietly
-# become a group that nothing ever runs.
+# It is also the one group with NO dedicated CI job of its own since #1248 retired
+# `Tests (debug-assertions)`. The property it checks did not go away with the job:
+# it moved into `[profile.ci-cov]`, which both coverage jobs build under. So the
+# guard test asserts the PROFILE here rather than a job name — see
+# `tests/preflight_owns_the_fast_gates.rs`.
+#
+# `--help` and `--list` still enumerate it, and that test pins this array, so an
+# opt-in group cannot quietly become a group that nothing ever runs.
 OPT_IN_GROUPS=(debug-assertions)
 
 is_opt_in() {
@@ -112,11 +116,12 @@ Groups: ${ALL_GROUPS[*]}
 Default: ${DEFAULT_GROUPS[*]}  (in that order)
 
 Opt-in, i.e. NOT in a no-argument run: ${OPT_IN_GROUPS[*]}. \`debug-assertions\`
-RUNS the Tier-1 suite on the default \`dev\` profile (#344). Every other test job
-builds with \`ci-test\`/\`ci-fast\`, which \`inherits = "release"\` — so every
-\`debug_assert!\` in the crate is compiled to nothing and its invariant goes
-unchecked. It is a build plus a test run rather than seconds of compile, so you
-name it when you want it; CI runs it on every PR.
+RUNS the Tier-1 suite on \`--profile ci-cov\` (#344, #1248) — \`ci-fast\` plus
+\`debug-assertions\`/\`overflow-checks\`, the profile the two coverage jobs build
+under. \`release\`, \`ci-test\` and \`ci-fast\` all leave the guards off, so every
+\`debug_assert!\` compiles to nothing there and its invariant goes unchecked. It
+is a build plus a test run rather than seconds of compile, so you name it when
+you want it; CI covers the same ground inside its coverage jobs on every PR.
 
 NOT covered by the DEFAULT set: the test jobs. \`cargo check --tests\` COMPILES
 the test targets but runs nothing, so \`Tests + coverage (core)\` can still go red
@@ -360,35 +365,38 @@ group_public_api() {
 }
 
 group_debug_assertions() {
-  CI_JOB="Tests (debug-assertions)"
-  # #344. Every OTHER test job in this repo builds with `--profile ci-test` or
-  # `--profile ci-fast`, both of which `inherits = "release"` — so
-  # `debug-assertions` is OFF and all 177 `debug_assert!` guards in the crate are
-  # compiled to nothing. They are invariant checks that CI was not running.
+  CI_JOB="Tests + coverage (core) / Tests + coverage (TTE/CTMM endpoints)"
+  # #344, as folded into #1248. The `debug_assert!` guards used to be dead in
+  # every CI job: `ci-test` and `ci-fast` both `inherits = "release"`, so all ~180
+  # of them compiled to nothing. That was not theoretical — a real off-by-one in
+  # `compute_max_stack` (`src/parser/model_parser.rs`) tripped its own
+  # `debug_assert!` on any expression containing an `if`, and four lib tests
+  # panicked under the dev profile while CI stayed green through the whole thing
+  # (fixed in #342).
   #
-  # That is not theoretical: a real off-by-one in `compute_max_stack`
-  # (`src/parser/model_parser.rs`) tripped its own `debug_assert!` on any
-  # expression containing an `if`, and four lib tests panicked under the dev
-  # profile while CI stayed green through the whole thing. It was fixed in #342;
-  # the CI blind spot that hid it is what this group closes.
+  # #344 closed that with a dedicated `Tests (debug-assertions)` job on the DEV
+  # profile. #1248 retired that job and put the guards where the coverage is
+  # measured instead, via `[profile.ci-cov]` (`ci-fast` + `debug-assertions` +
+  # `overflow-checks`). Two reasons, both measured:
   #
-  # The DEFAULT (dev) profile, deliberately — no `--profile` flag:
+  #  * the dev-profile job cost 32-42 min of CI, the critical path and ~2x the
+  #    next-longest job, while `ci-cov` costs essentially nothing on top of the
+  #    coverage jobs that had to run anyway (`--workspace --tests`: 133 s with the
+  #    guards off, 133 s with `debug-assertions`, 147 s with `overflow-checks` too);
+  #  * on a release-derived profile the guards' condition lines are regions that
+  #    can never execute, so every multi-line `debug_assert!` was permanently-missed
+  #    patch lines against the 90% Codecov gate (#1248). Running them under the
+  #    coverage profile flips 63 such lines from 0 to >0 in `--lib` scope alone.
   #
-  #  * it is the profile the bug actually reproduced under, so this gate is the
-  #    literal repro rather than an approximation of it;
-  #  * it also turns on `overflow-checks`, which `release` leaves off, so integer
-  #    overflow panics instead of wrapping silently — a second class of guard the
-  #    other jobs cannot see;
-  #  * a `ci-test`-with-debug-assertions profile would be a distinct profile hash
-  #    and therefore a whole extra OPTIMISED build of the lib, which in this
-  #    compile-bound repo (93% of the build is LLVM, #969/#971) costs far more
-  #    than the unoptimised tests do. Measured here on the dev profile: 80s of
-  #    tests for `ci` (4035) and 198s for `ci,markov,nn` (4366), all green.
+  # So this group now builds `--profile ci-cov` — the SAME profile CI measures
+  # under — rather than the dev default. It is also why the group is much cheaper
+  # than it was: release-optimised fits, not unoptimised ones.
   #
-  # `--lib` only: Tier-1 unit tests. The `tests/` binaries are run by
-  # `Tests + coverage (core)`, and compiling 120-odd of them again under a second
-  # profile is the cost this group is shaped to avoid. Tier-1 is also where the
-  # guards live — `debug_assert!` sits next to the invariant, in `src/`.
+  # `--lib` only: Tier-1 unit tests, which is where the guards live
+  # (`debug_assert!` sits next to the invariant, in `src/`). CI additionally runs
+  # them across the `tests/` binaries, because its coverage jobs pass `--tests`
+  # anyway; compiling 120-odd of those locally is the cost this group avoids.
+  #
   # `env FERX_REQUIRE_DEBUG_ASSERTIONS=1` in the ARGUMENT VECTOR, not as a shell
   # assignment prefix and not an `export` up in this function. Both of those would
   # reach the child just the same, but `run` echoes `$*`, so only this form appears
@@ -399,20 +407,22 @@ group_debug_assertions() {
   # `debug_assert!` turns out to compile to nothing. Without it this whole group is
   # an invariant held by ABSENCE — nothing in `cargo test --lib --features ci`
   # distinguishes a build with the guards live from one without, so a
-  # `[profile.dev] debug-assertions = false` or a `CARGO_PROFILE_DEV_DEBUG_ASSERTIONS`
-  # in the environment would neuter it with every test still green. The canary is
-  # opt-in precisely because every OTHER job legitimately runs with the guards off.
-  run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --no-default-features --features ci
+  # `[profile.ci-cov] debug-assertions = false`, a stray
+  # `CARGO_PROFILE_CI_COV_DEBUG_ASSERTIONS`, or a `--profile` that quietly reverted
+  # to `ci-fast` would neuter it with every test still green. The canary is opt-in
+  # precisely because every OTHER job legitimately runs with the guards off.
+  run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --profile ci-cov \
+    --no-default-features --features ci
 
   # The feature-gated surface, for the same non-nesting reason `check` is a matrix
   # rather than one line: `--features ci` compiles neither `src/survival`,
   # `src/markov`, `src/categorical` nor `src/nn`, and all four carry
-  # `debug_assert!`s. Without this line their guards would be as dead in this job
-  # as they are in every other one. `markov` implies `survival`, so
-  # `ci,markov,nn` is the union of the production cfgs — the same set `clippy` and
-  # `rustdoc` take, and for the same reason.
-  run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --no-default-features \
-    --features ci,markov,nn
+  # `debug_assert!`s. Without this line their guards would be as dead here as they
+  # were in every job before #1248. `markov` implies `survival`, so `ci,markov,nn`
+  # is the union of the production cfgs — the same set `clippy` and `rustdoc` take,
+  # and for the same reason. In CI this half is the endpoints coverage job.
+  run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --profile ci-cov \
+    --no-default-features --features ci,markov,nn
 }
 
 # ── Drive ───────────────────────────────────────────────────────────────────

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -60,7 +60,7 @@ export RUSTUP_TOOLCHAIN="${RUSTUP_TOOLCHAIN:-nightly}"
 # current user's numeric group IDs, and it wins. The first draft used it and
 # every group name silently became a GID — `unknown group 'check' — expected one
 # of: 20 12 61 ...`.
-ALL_GROUPS=(fmt check clippy rustdoc docs public-api debug-assertions)
+ALL_GROUPS=(fmt check clippy rustdoc docs public-api debug-assertions release-semantics)
 
 # Groups that are NOT in the default selection.
 #
@@ -69,18 +69,27 @@ ALL_GROUPS=(fmt check clippy rustdoc docs public-api debug-assertions)
 # that RUNS the unit suite is a different order of cost (its own profile hash,
 # so its own full build, and then the tests), and folding it into the default
 # would turn `tools/preflight.sh` from a pre-push habit into a coffee break. So
-# it is opt-in by name — `tools/preflight.sh debug-assertions` — and CI covers the
-# same ground inside its coverage jobs, which is where it has to be green.
+# they are opt-in by name — `tools/preflight.sh debug-assertions` — and CI runs
+# each of them, which is where they have to be green.
 #
-# It is also the one group with NO dedicated CI job of its own since #1248 retired
+# The two are a PAIR, and the pairing is the point: `debug-assertions` builds
+# `ci-cov` (guards live), `release-semantics` builds `ci-fast` (guards compiled
+# out, release overflow semantics). Several tests assert one thing under a live
+# guard and another without one, so a mode nothing builds is a set of assertions
+# nothing checks — which is exactly what #1248 briefly did to the guards-off side
+# before review caught it (#1293).
+#
+# `debug-assertions` is the one group with NO dedicated CI job, since #1248 retired
 # `Tests (debug-assertions)`. The property it checks did not go away with the job:
 # it moved into `[profile.ci-cov]`, which both coverage jobs build under. So the
-# guard test asserts the PROFILE here rather than a job name — see
+# guard test asserts the PROFILE for it rather than a job name.
+# `release-semantics` does have a job, because no coverage job builds `ci-fast`
+# any more. Both directions are pinned in
 # `tests/preflight_owns_the_fast_gates.rs`.
 #
-# `--help` and `--list` still enumerate it, and that test pins this array, so an
+# `--help` and `--list` still enumerate them, and that test pins this array, so an
 # opt-in group cannot quietly become a group that nothing ever runs.
-OPT_IN_GROUPS=(debug-assertions)
+OPT_IN_GROUPS=(debug-assertions release-semantics)
 
 is_opt_in() {
   local candidate="$1" g
@@ -123,11 +132,17 @@ under. \`release\`, \`ci-test\` and \`ci-fast\` all leave the guards off, so eve
 is a build plus a test run rather than seconds of compile, so you name it when
 you want it; CI covers the same ground inside its coverage jobs on every PR.
 
+\`release-semantics\` is its mirror: the same Tier-1 suite on \`--profile ci-fast\`,
+where the guards are compiled out and overflow wraps — the way a user's build
+behaves. Both matter, and neither substitutes for the other: several tests assert
+one thing under a live guard and another without it. CI runs this one as
+\`Tests (release semantics)\`.
+
 NOT covered by the DEFAULT set: the test jobs. \`cargo check --tests\` COMPILES
 the test targets but runs nothing, so \`Tests + coverage (core)\` can still go red
 after a green preflight. The default set gates compilation and lint, not
-behaviour. Two exceptions: \`docs\`, whose gate IS its test run (a filesystem walk
-over \`docs/\`, not a fit), and the opt-in \`debug-assertions\` above.
+behaviour. Three exceptions: \`docs\`, whose gate IS its test run (a filesystem walk
+over \`docs/\`, not a fit), and the two opt-in suites above.
 EOF
 }
 
@@ -422,6 +437,39 @@ group_debug_assertions() {
   # is the union of the production cfgs — the same set `clippy` and `rustdoc` take,
   # and for the same reason. In CI this half is the endpoints coverage job.
   run env FERX_REQUIRE_DEBUG_ASSERTIONS=1 cargo test --lib --profile ci-cov \
+    --no-default-features --features ci,markov,nn
+}
+
+group_release_semantics() {
+  CI_JOB="Tests (release semantics)"
+  # The guards-OFF half of the pair, and the reason it exists is #1293 review
+  # feedback on #1248. Pointing both coverage jobs at `ci-cov` fixed the coverage
+  # ceiling but left NO per-PR job running the crate with `debug_assertions = false`
+  # and release overflow semantics — which is what a user actually runs. Before
+  # #1248 the coverage jobs themselves were that lane; afterwards the only
+  # guards-off runs were the scheduled/post-merge `ci-test` ones, so a release-only
+  # regression could merge green.
+  #
+  # It bites hardest on the tests #1248 rewrote. `continuous_value()` and
+  # `max_scaled_deviation()` each have two correct behaviours — panic under a live
+  # guard, NaN fallback without one — and the NaN arm is the documented user
+  # behaviour. Under `ci-cov` only the panic arm runs.
+  #
+  # `--lib` on `ci,markov,nn`: the union of the production cfgs, the same set
+  # `clippy` and `rustdoc` take and for the same non-nesting reason. That covers
+  # every `src/` unit test, which is where a `cfg!(debug_assertions)` split lives.
+  # It does NOT restore guards-off `tests/` binaries — those cost the 120-odd
+  # binary compile this lane is shaped to avoid, and `slow-tests.yml` plus the
+  # nightly coverage job still run them on `ci-test` with the guards off.
+  #
+  # `ci-fast`, explicitly rather than by omission: the point is release semantics,
+  # and the dev default would give neither those nor the optimisation.
+  #
+  # `env FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1` arms the INVERSE canary
+  # (`src/lib_tests.rs`). Without it the lane's value rests on `ci-fast` never
+  # acquiring `debug-assertions`, and if it did this job would quietly become a
+  # second copy of the coverage jobs with every test still green.
+  run env FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1 cargo test --lib --profile ci-fast \
     --no-default-features --features ci,markov,nn
 }
 


### PR DESCRIPTION
## Why

`debug_assert!` condition lines are emitted by `llvm-cov` as coverage regions that **can never be executed**: every Codecov-producing job built a release-derived profile, where the macro expands to nothing but the region is still emitted. They were therefore permanently-missed patch lines, and they lowered the ceiling of the ≥90% patch gate for any PR that added a guard. On #1136 the ceiling was **49/56 = 87.5%** — unreachable by any test — and that PR merged red with the arithmetic written into its body.

This is the second half of #344. The first half (*the guards never run in CI*) was fixed by #1245, which added a `Tests (debug-assertions)` job on the dev profile that uploads no coverage. `src/**/*_tests.rs` contributes zero patch lines (no `SF:` record at all), so "add more tests" was never a route out of it.

## What changed

One new profile, and both per-PR coverage jobs build under it:

```toml
[profile.ci-cov]
inherits = "ci-fast"
debug-assertions = true
overflow-checks = true
```

**Measured** (15 cores, stable, `--features ci`) — the issue asked for cost measured rather than assumed:

| | guards off (`ci-fast`) | `debug-assertions` | `+ overflow-checks` (`ci-cov`) |
|---|---|---|---|
| `--workspace --tests` | 133 s, 5727 passed | **133 s**, 5732 passed | 147 s, 5732 passed, 0 failed |
| `--lib` | 5.76 s, 4232 passed | 6.45 s, 4237 passed | — |
| clean lib compile (×2) | 92 s / 98 s | 93 s / 87 s | — |
| `debug_assert` lines 0 → >0 | — | **63** (`--lib` scope alone) | — |

The guards are free because these profiles are release-optimised; the within-profile compile spread exceeds the between-profile difference. Zero-hit lines inside guard spans drop 90 → 37 in `--lib` scope (the residue is panic-arm message lines, which a guard that never fires cannot cover — that part is irreducible).

This was also the first time the ~180 guards have ever run against the `tests/` binaries — #1245's job is `--lib` only. No latent failure.

**The `Tests (debug-assertions)` job is retired.** Its two commands were `--lib` on `ci` and on `ci,markov,nn`, a strict subset of what `Tests + coverage (core)` (`--workspace --tests`) and `Tests + coverage (TTE/CTMM endpoints)` (`--lib`, `ci,markov,nn`) now run. Measured on three `main` runs it cost **32–42 min**: the CI critical path, ~2× the next-longest job.

| job | 34238183362 | 34209580799 | 34184960371 |
|---|---|---|---|
| `Tests (debug-assertions)` | 42m | 32m | 42m |
| `Tests + coverage (core)` | 18m | 18m | 15m |
| `Tests + coverage (TTE/CTMM endpoints)` | 16m | 15m | 12m |

`overflow-checks` was the only thing that job had which the coverage jobs did not, which is why it is set explicitly. It is **not** derived from `debug-assertions` — Cargo defaults it per profile, and a `release`-derived profile setting only `debug-assertions = true` still compiles with `-C overflow-checks=off` (verified with `cargo build -v`).

`tools/preflight.sh debug-assertions` now builds `ci-cov` too, so the local gate matches CI. Its test phase drops from 80 s + 198 s (dev) to **11.6 s + 16.3 s**.

### The guards-OFF lane (added in review)

Retiring the job and guarding both coverage jobs left **no per-PR job running the crate the way a user's release build behaves** — guards compiled out, overflow wrapping. The remaining `ci-test` runs are scheduled, manual or post-merge, so a release-only regression could have merged green. Caught by @roninsightrx's review; the first push of this PR had that hole.

It bites hardest on the three tests this PR rewrote: their NaN-fallback arms are the documented *user* behaviour, and under `ci-cov` only the panic arm runs.

`Tests (release semantics)` is the counterweight — `--lib` on the `ci,markov,nn` union under `ci-fast`, delegating to a new `tools/preflight.sh release-semantics` group. It runs in parallel with the coverage jobs and is shorter than either, so it should add no wall-clock. It deliberately does **not** restore guards-off `tests/` binaries: that is the 120-odd binary compile, and `slow-tests.yml` plus the nightly coverage job still run those on `ci-test` with the guards off. Say if you want the integration tier back too.

Each lane now arms a canary in its own direction — `FERX_REQUIRE_DEBUG_ASSERTIONS=1` on the coverage jobs, `FERX_REQUIRE_NO_DEBUG_ASSERTIONS=1` on the release lane. The second matters for the same reason as the first: without it the release lane silently becomes a duplicate of the coverage jobs the moment `ci-fast` acquires `debug-assertions`, green throughout.

### Three tests that would have silently disappeared

`src/types_tests.rs` (×2) and `src/estimation/outer_optimizer_tests.rs` (×1) were `#[cfg(not(debug_assertions))]` **on purpose**, asserting the release-only fallback behind a misuse guard — "the profile CI and coverage use", as the comment said. Under `ci-cov` they do not fail; they stop existing, in the only jobs that ran them. Caught by diffing the two lcov reports: `types.rs:3490`/`:3494` went 2 hits → 0 and `outer_optimizer.rs:692` went 1 → 0, the only three lines in the crate to regress.

They now assert **both** behaviours (`catch_unwind` + `cfg!(debug_assertions)`), so the guard firing is checked as well as the NaN fallback, and they run under either profile. `docs/development/sdlc.qmd` warns against the `cfg`-gated shape for the same reason.

## Alternatives considered

- **Flip `ci-fast` itself** (the issue's option 1). Rejected: `ci-fast` is not CI-only despite the name — `tools/vi-nuts-anchor/run.sh` and `tools/vi-emvi-comparison/run.sh` build `target/ci-fast/ferx` with it for numerical anchor runs, and this would put the guards and the `#[cfg(debug_assertions)]` MR ODE-twin verifier into them. A separate profile adds **no** CI compile: both coverage jobs already carry coverage `RUSTFLAGS` and their own `rust-cache` keys, so their artifacts were never shared with any other job — this renames the profile they build under.
- **Instrument the `Tests (debug-assertions)` job** (option 2). Dead on arrival: at 32–42 min it is already the critical path, and instrumenting it would make that worse.
- **`codecov.yml` exclusion** (option 3). No line-level ignore exists for the patch status.
- **Accept as policy** (option 4). Fixes nothing; the ceiling stays.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

CI-only. No estimation, PK, or stats code is touched; the full `--workspace --tests` suite is bit-identical in outcome (5727 → 5732 passed, the delta being the three tests that now run under both profiles plus the canary).

## Performance
- [x] Faster — CI critical path `32–42m` (before) → **`~28m`** (measured on this PR), by retiring a job whose work is now a 0–14 s addition to jobs that had to run anyway.

**Correction.** An earlier draft of this body said `~18m`, extrapolated from local hardware before any CI run of the new profile existed. The measured figure on this PR is ~28 min. Two runs of the same commit, cold and warm:

| job | run 1 (cold: new profile hash ⇒ full rebuild) | run 2 (warm) |
|---|---|---|
| `Tests + coverage (core)` | 21m | 28m |
| `Tests + coverage (TTE/CTMM endpoints)` | 28m | 16m |

They swap between runs, which is the ~5 min run-to-run variance this repo already documents (#969) — so read the pair as "critical path ≈ 28 min", not as either column. `Tests (release semantics)` runs in parallel and is shorter than both, so it should not extend that; the number to check on this PR's run is whether it does.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

`the_coverage_jobs_build_the_guarded_profile` (new) pins that every `cargo llvm-cov` feeding the patch gate builds a profile resolving to `debug-assertions = true`, and that the job arms `FERX_REQUIRE_DEBUG_ASSERTIONS`. The guard test's **ban** on `--profile` in the `debug-assertions` group — correct while every named profile inherited `release` — becomes a **positive** check against Cargo.toml, resolving `inherits` transitively.

**Mutation-tested, each mutation reddening its own side:**

| mutation | result |
|---|---|
| `[profile.ci-cov] debug-assertions = false` | 2 tests fail |
| coverage job reverted to `--profile ci-fast` | fails, names `coverage-pr` |
| `FERX_REQUIRE_DEBUG_ASSERTIONS` deleted from the job | fails |
| preflight group drops `--profile ci-cov` | fails |
| canary armed on `ci-fast` / on `ci-cov` | **fails** / passes |
| release lane drifted to `--profile ci-cov` | fails |
| inverse canary arming deleted | fails |
| inverse canary on `ci-cov` / on `ci-fast` | **fails** / passes |

One of these found a real hole rather than confirming a belief: the canary check was first written as `body.contains("FERX_REQUIRE_DEBUG_ASSERTIONS")`, and **passed with the `env:` key deleted** — the comment block explaining the variable satisfied it. This file already warns about exactly that trap one test above; it caught me anyway. It now reads non-comment lines only, and the comment says so.

## Example
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated for user-visible changes — `docs/development/sdlc.qmd` §8.2 rewritten: why the coverage jobs build `ci-cov`, the measurement table, and the `#[cfg(not(debug_assertions))]` warning for test authors
- [x] `CHANGELOG.md` — N/A (CI only)

Stale prose corrected where the old arrangement was asserted as fact: `src/lib.rs`, `src/lib_tests.rs`, `tools/preflight.sh`, and `src/pk/modified_release.rs`, whose comment said its `#[cfg(debug_assertions)]` ODE-twin verifier "never runs in CI — that is the already-tracked #344". It does now, at 0 s measured cost; the 577 s figure in that file is the unoptimised dev profile and is explicitly flagged as not the CI cost.

## Checklist
- [x] `tools/preflight.sh` green — `preflight OK — fmt check clippy rustdoc docs public-api`
- [x] `tools/preflight.sh debug-assertions` green — 4238 + 4577 passed, 0 failed, canary armed
- [x] `tools/preflight.sh release-semantics` green — inverse canary armed
- [x] Not touching the `Dual2` sensitivity path
- [x] No version bump needed

## Reviewer hints

Focus on the retirement of `Tests (debug-assertions)` — that is the part beyond the issue's scope, and it undoes a decision made in #1245 three days ago. The claim is subset-plus-`overflow-checks`; if you disagree that the coverage jobs' `--tests`/`--lib` runs across `ci` and `ci,markov,nn` cover it, that is the thing to push on.

Second: whether `Tests (release semantics)` is targeted *enough*. It restores guards-off coverage for every `src/` unit test but not for the `tests/` binaries, which ran guards-off before this PR. I judged the integration tier's guards-off risk low (the only `#[cfg(debug_assertions)]` production code is the MR ODE-twin verifier, a dev aid) and the compile cost high, but that is a judgement call and the reviewer's to overrule.

The panic-hook swap raised in review is **gone**, not mitigated: both sites now leave the hook alone and accept three expected panic messages in the log. The interleaving described (A takes normal, B takes A's silent hook, A restores normal, B restores silent ⇒ process permanently silenced) is real and immediate restoration does not fix it.

Skimmable: the comment churn in `ci.yml`, `preflight.sh` and `sdlc.qmd`.

## Open questions

The nightly full-coverage job stays on `ci-test` (guards off) deliberately — it uploads the `slow` flag, which `codecov.yml` excludes from the patch status, and its 5–60 min Tier-3 fits want the ThinLTO speedup (#969). Codecov merges flags by summing hits, so its guards-off report cannot un-cover what `fast` covers. Say if you would rather it were consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPbLmymWZEmMWKmgJDN6yK
