### PR TITLE
perf(sens): use partial Hessians in analytic outer gradients [closes #829]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,8 +371,9 @@ section of the SDLC for the versioning policy).
   silently scoring the declared value — `[saem, focei]` is fine, `[focei, imp]` needs `FIX`.
 
 ### Performance
-- Transit and inverse-Gaussian analytical FOCEI gradients with one or two IIV-bearing
-  PK parameters now omit the unused Hessian block among IIV-free parameters (#829).
+- Generic analytical FOCEI gradients with exactly four or six differentiated PK
+  parameters, one or two of them IIV-bearing, now omit the unused Hessian block
+  among IIV-free parameters (#829).
 - Allocate per-event PK scratch storage only when the prediction path needs it,
   reducing allocation traffic for static-model FOCE/FOCEI fits (#1283).
 - IOV inner optimization reuses per-event PK parameter buffers across likelihood

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,8 @@ section of the SDLC for the versioning policy).
   silently scoring the declared value — `[saem, focei]` is fine, `[focei, imp]` needs `FIX`.
 
 ### Performance
+- Transit and inverse-Gaussian analytical FOCEI gradients with one or two IIV-bearing
+  PK parameters now omit the unused Hessian block among IIV-free parameters (#829).
 - Allocate per-event PK scratch storage only when the prediction path needs it,
   reducing allocation traffic for static-model FOCE/FOCEI fits (#1283).
 - IOV inner optimization reuses per-event PK parameter buffers across likelihood

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -7,8 +7,8 @@
 //!   * `∂f/∂η`, `∂²f/∂η²`,
 //!   * `∂f/∂θ`, `∂²f/∂η∂θ`
 //!
-//! built by seeding the PK parameters as [`Dual2`] variables
-//! through the closed-form PK solution (exact `∂f/∂pk`, `∂²f/∂pk²`) and then
+//! built by seeding the PK parameters as [`Dual2`] or mixed-order [`DualMixed`]
+//! variables through the closed-form PK solution (exact `∂f/∂pk`, `∂²f/∂pk²`) and then
 //! applying the **closed-form η/θ chain rule**: the model exposes the relation
 //! `pk_i = tv_i·exp(Σ_k sel[i,k]·η_k)`, so
 //!
@@ -33,6 +33,7 @@
 
 use super::dual1::Dual1;
 use super::dual2::Dual2;
+use super::dual_mixed::DualMixed;
 use super::num::PkNum;
 use super::one_cpt::{one_cpt_conc_g, one_cpt_ig_conc_g, one_cpt_transit_conc_g};
 use super::three_cpt::three_cpt_conc_g;
@@ -552,6 +553,20 @@ fn analytical_supported_core(model: &CompiledModel) -> bool {
 /// arm. **Keep these three in step** — raising this constant without adding the matching
 /// `const_dispatch!` arms would re-open the misreport below.
 const MAX_CLOSED_FORM_SLOTS: usize = 9;
+
+/// Largest IIV-bearing row count specialised with [`DualMixed`] on the static
+/// analytical provider. `NA = 1/2` covers the common one- and two-IIV transit
+/// and inverse-Gaussian shapes while bounding release compile cost; wider-IIV
+/// models retain the exact full `Dual2` path.
+const ANALYTIC_MIXED_NA_CAP: usize = 2;
+
+// The static dispatch below enumerates `NA = 1, 2` explicitly.
+const _: () = assert!(ANALYTIC_MIXED_NA_CAP == 2);
+
+#[cfg(test)]
+thread_local! {
+    static MIXED_ANALYTIC_RUNS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 /// Whether the model's differentiated-slot count fits the closed-form dispatch tables.
 ///
@@ -1179,6 +1194,20 @@ pub(crate) fn seed_dim_from_slots(slots: &[usize]) -> [Option<usize>; N_PK] {
     for (i, &slot) in slots.iter().enumerate() {
         if slot < N_PK {
             seed_dim[slot] = Some(i);
+        }
+    }
+    seed_dim
+}
+
+/// PK slot → permuted dual axis for a `pd` whose rows follow `slots` order.
+/// `axis_of[i]` is the dual axis assigned to differentiated row `i`; mixed-order
+/// outer jets use this to place IIV-bearing rows first.
+fn seed_dim_from_slots_with_axes(slots: &[usize], axis_of: &[usize]) -> [Option<usize>; N_PK] {
+    debug_assert_eq!(slots.len(), axis_of.len());
+    let mut seed_dim = [None; N_PK];
+    for (i, &slot) in slots.iter().enumerate() {
+        if slot < N_PK {
+            seed_dim[slot] = Some(axis_of[i]);
         }
     }
     seed_dim
@@ -5389,8 +5418,16 @@ fn subject_sensitivities_impl(
         }
     };
 
+    let mixed_eligible = matches!(
+        model.pk_model,
+        PkModel::OneCptTransit | PkModel::TwoCptTransit | PkModel::OneCptIg | PkModel::TwoCptIg
+    ) && matches!(slots.len(), 4 | 6);
+
     // Dispatch on the differentiated-parameter count so the dual width is
-    // right-sized. `pk_indices.len()` ≤ `N_PK` (the fixed PK slot table).
+    // right-sized. The hand-written explicit kernels remain on their existing
+    // path; they already avoid generic dual arithmetic. Eligible transit/IG
+    // shapes use `DualMixed<NA, N>`, dropping only the IIV-free Hessian block
+    // that FOCEI never consumes (issue #829).
     // Analytic Form C readout program (#650), if this model has one; the
     // `analytical_supported` gate guarantees it is `Single` + dual-evaluable and
     // does not read the depot amount, so `run_obs` can serve it exactly.
@@ -5398,16 +5435,92 @@ fn subject_sensitivities_impl(
         .analytic_readout
         .as_ref()
         .and_then(|ar| ar.program.as_ref());
-    let mut sens = const_dispatch!(
-        slots.len();
-        1, 2, 3, 4, 5, 6, 7, 8, 9;
-        |N| Some(SubjectSens {
-            obs: run_obs::<N>(
-                &seed_dim, &pk, oral, two_cpt, three_cpt, transit, two_cpt_transit, ig,
-                two_cpt_ig, explicit_kind, subject, &pd, n_eta, n_theta, readout,
-            ),
-        })
-    )?;
+    macro_rules! full {
+        () => {
+            const_dispatch!(
+                slots.len();
+                1, 2, 3, 4, 5, 6, 7, 8, 9;
+                |N| Some(SubjectSens {
+                    obs: run_obs::<N, N, true>(
+                        &seed_dim,
+                        &pk,
+                        oral,
+                        two_cpt,
+                        three_cpt,
+                        transit,
+                        two_cpt_transit,
+                        ig,
+                        two_cpt_ig,
+                        explicit_kind,
+                        subject,
+                        &pd,
+                        None,
+                        n_eta,
+                        n_theta,
+                        readout,
+                    ),
+                })
+            )
+        };
+    }
+    let mut sens = if mixed_eligible {
+        // IIV-bearing rows have a nonzero η derivative. Put them on the leading
+        // dual axes so `DualMixed<NA, N>` retains exactly the Hessian rows used
+        // by the η/θ chain. This planning runs only for transit/IG candidates;
+        // the common explicit-kernel path pays no added per-subject scan.
+        let mut is_iiv = [false; MAX_CLOSED_FORM_SLOTS];
+        let mut axis_buf = [0usize; MAX_CLOSED_FORM_SLOTS];
+        let mut na = 0usize;
+        for i in 0..slots.len() {
+            if pd.dp_deta[i].iter().any(|&v| v != 0.0) {
+                is_iiv[i] = true;
+                axis_buf[i] = na;
+                na += 1;
+            }
+        }
+        let mut next = na;
+        for i in 0..slots.len() {
+            if !is_iiv[i] {
+                axis_buf[i] = next;
+                next += 1;
+            }
+        }
+        let axis_of = &axis_buf[..slots.len()];
+        let mixed_seed_dim = seed_dim_from_slots_with_axes(&slots, axis_of);
+        macro_rules! mixed {
+            ($na:literal, $n:literal) => {
+                Some(SubjectSens {
+                    obs: run_obs::<$na, $n, false>(
+                        &mixed_seed_dim,
+                        &pk,
+                        oral,
+                        two_cpt,
+                        three_cpt,
+                        transit,
+                        two_cpt_transit,
+                        ig,
+                        two_cpt_ig,
+                        None,
+                        subject,
+                        &pd,
+                        Some((axis_of, &is_iiv[..slots.len()])),
+                        n_eta,
+                        n_theta,
+                        readout,
+                    ),
+                })
+            };
+        }
+        match (slots.len(), na) {
+            (4, 1) => mixed!(1, 4),
+            (4, 2) => mixed!(2, 4),
+            (6, 1) => mixed!(1, 6),
+            (6, 2) => mixed!(2, 6),
+            _ => full!(),
+        }
+    } else {
+        full!()
+    }?;
     // Analytic `[initial_conditions]` impulse (#524): layer `A₀ · kernel(t, pk)`
     // and its exact `(θ, η)` jet onto every observation BEFORE scaling — the same
     // insertion order as the f64 `pk::add_analytical_init`. Dispatched on the
@@ -5614,12 +5727,84 @@ fn apply_ltbs_transform_inner(out: &mut [ObsGrad], log_transform: bool) {
     }
 }
 
-/// Per-observation value/grad/Hessian chain at a right-sized dual width `N`
-/// (= number of differentiated PK parameters). `seed_dim[s]` is the compact dual
-/// axis for PK slot `s` (`None` = constant); `pd` rows are in compact-axis order,
-/// so the chain reads `g[i]`/`h[i][j]` directly (identity dims).
+/// Chain one compact PK-space jet into the `(η, θ)` blocks consumed by FOCEI.
+/// `axis_of[i]` maps `pd` row `i` to its dual axis. `has_hessian_row[i]`
+/// identifies rows retained by a mixed-order jet; omitted rows are valid because
+/// their `dp_deta` is identically zero.
 #[allow(clippy::too_many_arguments)]
-fn run_obs<const N: usize>(
+fn chain_pk_outer_jet<const N: usize>(
+    f: f64,
+    grad: &[f64; N],
+    hess_at: impl Fn(usize, usize) -> f64,
+    axis_of: &[usize],
+    has_hessian_row: &[bool],
+    pd: &crate::sens::ode_provider::ParamDerivs,
+    n_eta: usize,
+    n_theta: usize,
+) -> ObsSens {
+    debug_assert_eq!(axis_of.len(), has_hessian_row.len());
+    debug_assert_eq!(axis_of.len(), pd.dp_deta.len());
+    let n_indiv = axis_of.len();
+    let mut df_deta = vec![0.0; n_eta];
+    let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
+    let mut df_dtheta = vec![0.0; n_theta];
+    let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
+
+    for i in 0..n_indiv {
+        let gi = grad[axis_of[i]];
+        for k in 0..n_eta {
+            df_deta[k] += gi * pd.dp_deta[i][k];
+        }
+        for m in 0..n_theta {
+            df_dtheta[m] += gi * pd.dp_dtheta[i][m];
+        }
+    }
+    for k in 0..n_eta {
+        for l in 0..n_eta {
+            let mut acc = 0.0;
+            for i in 0..n_indiv {
+                if has_hessian_row[i] {
+                    for j in 0..n_indiv {
+                        acc +=
+                            hess_at(axis_of[i], axis_of[j]) * pd.dp_deta[i][k] * pd.dp_deta[j][l];
+                    }
+                }
+                acc += grad[axis_of[i]] * pd.d2p_deta2[i][k][l];
+            }
+            d2f_deta2[k * n_eta + l] = acc;
+        }
+    }
+    for k in 0..n_eta {
+        for m in 0..n_theta {
+            let mut acc = 0.0;
+            for i in 0..n_indiv {
+                if has_hessian_row[i] {
+                    for j in 0..n_indiv {
+                        acc +=
+                            hess_at(axis_of[i], axis_of[j]) * pd.dp_deta[i][k] * pd.dp_dtheta[j][m];
+                    }
+                }
+                acc += grad[axis_of[i]] * pd.d2p_detadtheta[i][k][m];
+            }
+            d2f_deta_dtheta[k * n_theta + m] = acc;
+        }
+    }
+
+    ObsSens {
+        f,
+        df_deta,
+        d2f_deta2,
+        df_dtheta,
+        d2f_deta_dtheta,
+        ..Default::default()
+    }
+}
+
+/// Per-observation value/grad/Hessian chain at a right-sized dual width `N`
+/// (= number of differentiated PK parameters) and retained Hessian-row count
+/// `NA`. `seed_dim[s]` maps each PK slot to its compact, possibly permuted axis.
+#[allow(clippy::too_many_arguments)]
+fn run_obs<const NA: usize, const N: usize, const ALLOW_EXPLICIT: bool>(
     seed_dim: &[Option<usize>; N_PK],
     pk: &crate::types::PkParams,
     oral: bool,
@@ -5632,10 +5817,18 @@ fn run_obs<const N: usize>(
     explicit_kind: Option<ExKind>,
     subject: &Subject,
     pd: &crate::sens::ode_provider::ParamDerivs,
+    mixed_axes: Option<(&[usize], &[bool])>,
     n_eta: usize,
     n_theta: usize,
     readout: Option<&crate::parser::model_parser::OdeOutputProgram>,
 ) -> Vec<ObsSens> {
+    #[cfg(test)]
+    if !ALLOW_EXPLICIT {
+        MIXED_ANALYTIC_RUNS.with(|runs| runs.set(runs.get() + 1));
+    }
+    let identity_axes = std::array::from_fn::<_, N, _>(|i| i);
+    let full_hessian_rows = [true; N];
+    let (axis_of, is_iiv) = mixed_axes.unwrap_or((&identity_axes, &full_hessian_rows));
     let (cl, v1, q, v2, ka, f_bio, q3, v3) = (
         pk.cl(),
         pk.v(),
@@ -5658,11 +5851,11 @@ fn run_obs<const N: usize>(
     // Analytic Form C readout (#650): the PK-parameter dual vector (indexed by PK
     // slot, so `eval_output_g` can pull `V`, binding constants, … via its
     // `indiv_to_pk` plan) and reusable scratch. Subject-static, so built once.
-    let ro_pk_duals: Option<[Dual2<N>; N_PK]> =
-        readout.map(|_| ro_pk_dual_array::<Dual2<N>>(seed_dim, pk));
-    let mut ro_state: Vec<Dual2<N>> = Vec::new();
-    let mut ro_vars: Vec<Dual2<N>> = Vec::new();
-    let mut ro_stack: Vec<Dual2<N>> = Vec::new();
+    let ro_pk_duals: Option<[DualMixed<NA, N>; N_PK]> =
+        readout.map(|_| ro_pk_dual_array::<DualMixed<NA, N>>(seed_dim, pk));
+    let mut ro_state: Vec<DualMixed<NA, N>> = Vec::new();
+    let mut ro_vars: Vec<DualMixed<NA, N>> = Vec::new();
+    let mut ro_stack: Vec<DualMixed<NA, N>> = Vec::new();
     let mut out = Vec::with_capacity(subject.obs_times.len());
     for (obs_i, &t_obs) in subject.obs_times.iter().enumerate() {
         // Reset segment: the most recent EVID=3/4 reset at or before this
@@ -5673,9 +5866,9 @@ fn run_obs<const N: usize>(
         // floor and is kept (`dose.time >= reset_floor`).
         let reset_floor = reset_floor_at(subject, t_obs);
 
-        // `(f, ∂f/∂pk, ∂²f/∂pk²)` in the compact `0..N` layout — from the explicit
-        // kernels when applicable, else the generic `Dual2<N>` path.
-        let (fval, g, h): (f64, [f64; N], [[f64; N]; N]) = if let Some(kind) = explicit_kind {
+        // Build the compact PK-space jet from the explicit kernel when available,
+        // otherwise by propagating the selected dual type through the closed form.
+        let jet = if let (true, Some(kind)) = (ALLOW_EXPLICIT, explicit_kind) {
             let mut gv = [0.0; N];
             let mut hv = [[0.0; N]; N];
             let mut val = 0.0;
@@ -5689,14 +5882,19 @@ fn run_obs<const N: usize>(
                     &mut hv,
                 );
             }
-            (val, gv, hv)
+            let mut retained = [[0.0; N]; NA];
+            retained.copy_from_slice(&hv[..NA]);
+            DualMixed {
+                value: val,
+                grad: gv,
+                hess: retained,
+            }
         } else {
-            // Seed only the differentiated PK params as `Dual2<N>` and superpose the
+            // Seed only the differentiated PK params and superpose the
             // dose contributions restricted to the current reset segment; `elapsed`
             // carries the lagtime shift and the SS pre-arrival tail wrap.
-            let seeded = SeededPkDuals::<Dual2<N>>::seed(seed_dim, pk);
-            let fd = superpose_doses(&seeded, flags, subject, t_obs, reset_floor);
-            (fd.value, fd.grad, fd.hess)
+            let seeded = SeededPkDuals::<DualMixed<NA, N>>::seed(seed_dim, pk);
+            superpose_doses(&seeded, flags, subject, t_obs, reset_floor)
         };
 
         // Match production's `conc.max(0.0)` clamp (`pk/mod.rs`): when the closed
@@ -5705,10 +5903,10 @@ fn run_obs<const N: usize>(
         // `max(f, 0)` is also 0 there. Returning the raw negative `f` and its
         // derivatives would make the analytic gradient inconsistent with the
         // objective it differentiates (PR #381 review finding #5).
-        let (fval, g, h) = if fval < 0.0 {
-            (0.0, [0.0; N], [[0.0; N]; N])
+        let jet = if jet.value < 0.0 {
+            DualMixed::constant(0.0)
         } else {
-            (fval, g, h)
+            jet
         };
 
         // Analytic Form C readout (#650): replace the central concentration jet with
@@ -5717,13 +5915,8 @@ fn run_obs<const N: usize>(
         // an additive term layers on); the readout's `∂y/∂pk` / `∂²y/∂pk²` then ride the
         // same `pd` chain to `(θ, η)` below. Covariates come from the per-observation
         // snapshot (a per-row `FREE`-style flag).
-        let conc = Dual2::<N> {
-            value: fval,
-            grad: g,
-            hess: h,
-        };
         let y = apply_readout_jet(
-            conc,
+            jet,
             readout,
             ro_pk_duals.as_ref(),
             subject,
@@ -5732,60 +5925,16 @@ fn run_obs<const N: usize>(
             &mut ro_vars,
             &mut ro_stack,
         );
-        let (fval, g, h) = (y.value, y.grad, y.hess);
-
-        let mut df_deta = vec![0.0; n_eta];
-        let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
-        let mut df_dtheta = vec![0.0; n_theta];
-        let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
-
-        // Chain ∂f/∂p, ∂²f/∂p² (exact, from the seeded PK Dual2 in compact layout)
-        // with ∂p/∂(θ,η) (from `pd`, analytical or FD fallback):
-        //   ∂f/∂η_k      = Σ_i g[i]·pᵢ,η_k
-        //   ∂²f/∂η_k∂η_l = Σ_ij H[i][j]·pᵢ,η_k·pⱼ,η_l + Σ_i g[i]·pᵢ,η_kη_l
-        // and likewise with θ in one slot. Compact axis `i` ↔ `pd` row `i`.
-        for i in 0..N {
-            let gi = g[i];
-            for k in 0..n_eta {
-                df_deta[k] += gi * pd.dp_deta[i][k];
-            }
-            for m in 0..n_theta {
-                df_dtheta[m] += gi * pd.dp_dtheta[i][m];
-            }
-        }
-        for k in 0..n_eta {
-            for l in 0..n_eta {
-                let mut acc = 0.0;
-                for i in 0..N {
-                    for j in 0..N {
-                        acc += h[i][j] * pd.dp_deta[i][k] * pd.dp_deta[j][l];
-                    }
-                    acc += g[i] * pd.d2p_deta2[i][k][l];
-                }
-                d2f_deta2[k * n_eta + l] = acc;
-            }
-        }
-        for k in 0..n_eta {
-            for m in 0..n_theta {
-                let mut acc = 0.0;
-                for i in 0..N {
-                    for j in 0..N {
-                        acc += h[i][j] * pd.dp_deta[i][k] * pd.dp_dtheta[j][m];
-                    }
-                    acc += g[i] * pd.d2p_detadtheta[i][k][m];
-                }
-                d2f_deta_dtheta[k * n_theta + m] = acc;
-            }
-        }
-
-        out.push(ObsSens {
-            f: fval,
-            df_deta,
-            d2f_deta2,
-            df_dtheta,
-            d2f_deta_dtheta,
-            ..Default::default()
-        });
+        out.push(chain_pk_outer_jet(
+            y.value,
+            &y.grad,
+            |i, j| y.hess[i][j],
+            axis_of,
+            is_iiv,
+            pd,
+            n_eta,
+            n_theta,
+        ));
     }
     out
 }

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -555,13 +555,15 @@ fn analytical_supported_core(model: &CompiledModel) -> bool {
 const MAX_CLOSED_FORM_SLOTS: usize = 9;
 
 /// Largest IIV-bearing row count specialised with [`DualMixed`] on the static
-/// analytical provider. `NA = 1/2` covers the common one- and two-IIV transit
-/// and inverse-Gaussian shapes while bounding release compile cost; wider-IIV
-/// models retain the exact full `Dual2` path.
+/// analytical provider. `NA = 1/2` covers common four- and six-parameter generic
+/// closed-form walks while bounding release compile cost; wider-IIV models
+/// retain the exact full `Dual2` path.
 const ANALYTIC_MIXED_NA_CAP: usize = 2;
+const ANALYTIC_MIXED_N: [usize; 2] = [4, 6];
 
-// The static dispatch below enumerates `NA = 1, 2` explicitly.
+// The static dispatch below enumerates `NA = 1, 2` and `N = 4, 6` explicitly.
 const _: () = assert!(ANALYTIC_MIXED_NA_CAP == 2);
+const _: () = assert!(ANALYTIC_MIXED_N[0] == 4 && ANALYTIC_MIXED_N[1] == 6);
 
 #[cfg(test)]
 thread_local! {
@@ -5418,14 +5420,11 @@ fn subject_sensitivities_impl(
         }
     };
 
-    let mixed_eligible = matches!(
-        model.pk_model,
-        PkModel::OneCptTransit | PkModel::TwoCptTransit | PkModel::OneCptIg | PkModel::TwoCptIg
-    ) && matches!(slots.len(), 4 | 6);
+    let mixed_eligible = explicit_kind.is_none() && ANALYTIC_MIXED_N.contains(&slots.len());
 
     // Dispatch on the differentiated-parameter count so the dual width is
     // right-sized. The hand-written explicit kernels remain on their existing
-    // path; they already avoid generic dual arithmetic. Eligible transit/IG
+    // path; they already avoid generic dual arithmetic. Eligible generic-walk
     // shapes use `DualMixed<NA, N>`, dropping only the IIV-free Hessian block
     // that FOCEI never consumes (issue #829).
     // Analytic Form C readout program (#650), if this model has one; the
@@ -5441,7 +5440,7 @@ fn subject_sensitivities_impl(
                 slots.len();
                 1, 2, 3, 4, 5, 6, 7, 8, 9;
                 |N| Some(SubjectSens {
-                    obs: run_obs::<N, N, true>(
+                    obs: run_obs::<N, N, false>(
                         &seed_dim,
                         &pk,
                         oral,
@@ -5488,9 +5487,11 @@ fn subject_sensitivities_impl(
         let axis_of = &axis_buf[..slots.len()];
         let mixed_seed_dim = seed_dim_from_slots_with_axes(&slots, axis_of);
         macro_rules! mixed {
-            ($na:literal, $n:literal) => {
+            ($na:literal, $n:literal) => {{
+                let axis_of: &[usize; $n] = axis_buf[..$n].try_into().expect("N-sized axes");
+                let is_iiv: &[bool; $n] = is_iiv[..$n].try_into().expect("N-sized row mask");
                 Some(SubjectSens {
-                    obs: run_obs::<$na, $n, false>(
+                    obs: run_obs::<$na, $n, true>(
                         &mixed_seed_dim,
                         &pk,
                         oral,
@@ -5503,20 +5504,24 @@ fn subject_sensitivities_impl(
                         None,
                         subject,
                         &pd,
-                        Some((axis_of, &is_iiv[..slots.len()])),
+                        Some((axis_of, is_iiv)),
                         n_eta,
                         n_theta,
                         readout,
                     ),
                 })
-            };
+            }};
         }
-        match (slots.len(), na) {
-            (4, 1) => mixed!(1, 4),
-            (4, 2) => mixed!(2, 4),
-            (6, 1) => mixed!(1, 6),
-            (6, 2) => mixed!(2, 6),
-            _ => full!(),
+        if na == 0 || na > ANALYTIC_MIXED_NA_CAP {
+            full!()
+        } else {
+            match (slots.len(), na) {
+                (4, 1) => mixed!(1, 4),
+                (4, 2) => mixed!(2, 4),
+                (6, 1) => mixed!(1, 6),
+                (6, 2) => mixed!(2, 6),
+                _ => full!(),
+            }
         }
     } else {
         full!()
@@ -5732,26 +5737,25 @@ fn apply_ltbs_transform_inner(out: &mut [ObsGrad], log_transform: bool) {
 /// identifies rows retained by a mixed-order jet; omitted rows are valid because
 /// their `dp_deta` is identically zero.
 #[allow(clippy::too_many_arguments)]
-fn chain_pk_outer_jet<const N: usize>(
+fn chain_pk_outer_jet<const NA: usize, const N: usize, const PARTIAL: bool>(
     f: f64,
     grad: &[f64; N],
-    hess_at: impl Fn(usize, usize) -> f64,
-    axis_of: &[usize],
-    has_hessian_row: &[bool],
+    hess: &[[f64; N]; NA],
+    axis_of: &[usize; N],
+    has_hessian_row: &[bool; N],
     pd: &crate::sens::ode_provider::ParamDerivs,
     n_eta: usize,
     n_theta: usize,
 ) -> ObsSens {
-    debug_assert_eq!(axis_of.len(), has_hessian_row.len());
-    debug_assert_eq!(axis_of.len(), pd.dp_deta.len());
-    let n_indiv = axis_of.len();
+    debug_assert_eq!(N, pd.dp_deta.len());
     let mut df_deta = vec![0.0; n_eta];
     let mut d2f_deta2 = vec![0.0; n_eta * n_eta];
     let mut df_dtheta = vec![0.0; n_theta];
     let mut d2f_deta_dtheta = vec![0.0; n_eta * n_theta];
 
-    for i in 0..n_indiv {
-        let gi = grad[axis_of[i]];
+    for i in 0..N {
+        let ai = if PARTIAL { axis_of[i] } else { i };
+        let gi = grad[ai];
         for k in 0..n_eta {
             df_deta[k] += gi * pd.dp_deta[i][k];
         }
@@ -5762,14 +5766,15 @@ fn chain_pk_outer_jet<const N: usize>(
     for k in 0..n_eta {
         for l in 0..n_eta {
             let mut acc = 0.0;
-            for i in 0..n_indiv {
-                if has_hessian_row[i] {
-                    for j in 0..n_indiv {
-                        acc +=
-                            hess_at(axis_of[i], axis_of[j]) * pd.dp_deta[i][k] * pd.dp_deta[j][l];
+            for i in 0..N {
+                let ai = if PARTIAL { axis_of[i] } else { i };
+                if !PARTIAL || has_hessian_row[i] {
+                    for j in 0..N {
+                        let aj = if PARTIAL { axis_of[j] } else { j };
+                        acc += hess[ai][aj] * pd.dp_deta[i][k] * pd.dp_deta[j][l];
                     }
                 }
-                acc += grad[axis_of[i]] * pd.d2p_deta2[i][k][l];
+                acc += grad[ai] * pd.d2p_deta2[i][k][l];
             }
             d2f_deta2[k * n_eta + l] = acc;
         }
@@ -5777,14 +5782,15 @@ fn chain_pk_outer_jet<const N: usize>(
     for k in 0..n_eta {
         for m in 0..n_theta {
             let mut acc = 0.0;
-            for i in 0..n_indiv {
-                if has_hessian_row[i] {
-                    for j in 0..n_indiv {
-                        acc +=
-                            hess_at(axis_of[i], axis_of[j]) * pd.dp_deta[i][k] * pd.dp_dtheta[j][m];
+            for i in 0..N {
+                let ai = if PARTIAL { axis_of[i] } else { i };
+                if !PARTIAL || has_hessian_row[i] {
+                    for j in 0..N {
+                        let aj = if PARTIAL { axis_of[j] } else { j };
+                        acc += hess[ai][aj] * pd.dp_deta[i][k] * pd.dp_dtheta[j][m];
                     }
                 }
-                acc += grad[axis_of[i]] * pd.d2p_detadtheta[i][k][m];
+                acc += grad[ai] * pd.d2p_detadtheta[i][k][m];
             }
             d2f_deta_dtheta[k * n_theta + m] = acc;
         }
@@ -5804,7 +5810,7 @@ fn chain_pk_outer_jet<const N: usize>(
 /// (= number of differentiated PK parameters) and retained Hessian-row count
 /// `NA`. `seed_dim[s]` maps each PK slot to its compact, possibly permuted axis.
 #[allow(clippy::too_many_arguments)]
-fn run_obs<const NA: usize, const N: usize, const ALLOW_EXPLICIT: bool>(
+fn run_obs<const NA: usize, const N: usize, const PARTIAL: bool>(
     seed_dim: &[Option<usize>; N_PK],
     pk: &crate::types::PkParams,
     oral: bool,
@@ -5817,18 +5823,36 @@ fn run_obs<const NA: usize, const N: usize, const ALLOW_EXPLICIT: bool>(
     explicit_kind: Option<ExKind>,
     subject: &Subject,
     pd: &crate::sens::ode_provider::ParamDerivs,
-    mixed_axes: Option<(&[usize], &[bool])>,
+    mixed_axes: Option<(&[usize; N], &[bool; N])>,
     n_eta: usize,
     n_theta: usize,
     readout: Option<&crate::parser::model_parser::OdeOutputProgram>,
 ) -> Vec<ObsSens> {
     #[cfg(test)]
-    if !ALLOW_EXPLICIT {
+    if PARTIAL {
         MIXED_ANALYTIC_RUNS.with(|runs| runs.set(runs.get() + 1));
     }
     let identity_axes = std::array::from_fn::<_, N, _>(|i| i);
     let full_hessian_rows = [true; N];
-    let (axis_of, is_iiv) = mixed_axes.unwrap_or((&identity_axes, &full_hessian_rows));
+    let (axis_of, is_iiv) = if PARTIAL {
+        mixed_axes.expect("partial jet requires an IIV-leading axis plan")
+    } else {
+        debug_assert!(mixed_axes.is_none());
+        (&identity_axes, &full_hessian_rows)
+    };
+    if PARTIAL {
+        debug_assert!(NA < N, "partial jet must drop at least one Hessian row");
+        debug_assert_eq!(is_iiv.iter().filter(|&&v| v).count(), NA);
+        debug_assert!(
+            is_iiv
+                .iter()
+                .enumerate()
+                .all(|(i, &v)| !v || axis_of[i] < NA),
+            "IIV-bearing rows must occupy the retained 0..NA axes"
+        );
+    } else {
+        debug_assert_eq!(NA, N, "full jet must retain all Hessian rows");
+    }
     let (cl, v1, q, v2, ka, f_bio, q3, v3) = (
         pk.cl(),
         pk.v(),
@@ -5868,7 +5892,7 @@ fn run_obs<const NA: usize, const N: usize, const ALLOW_EXPLICIT: bool>(
 
         // Build the compact PK-space jet from the explicit kernel when available,
         // otherwise by propagating the selected dual type through the closed form.
-        let jet = if let (true, Some(kind)) = (ALLOW_EXPLICIT, explicit_kind) {
+        let jet = if let (false, Some(kind)) = (PARTIAL, explicit_kind) {
             let mut gv = [0.0; N];
             let mut hv = [[0.0; N]; N];
             let mut val = 0.0;
@@ -5926,15 +5950,8 @@ fn run_obs<const NA: usize, const N: usize, const ALLOW_EXPLICIT: bool>(
             &mut ro_vars,
             &mut ro_stack,
         );
-        out.push(chain_pk_outer_jet(
-            y.value,
-            &y.grad,
-            |i, j| y.hess[i][j],
-            axis_of,
-            is_iiv,
-            pd,
-            n_eta,
-            n_theta,
+        out.push(chain_pk_outer_jet::<NA, N, PARTIAL>(
+            y.value, &y.grad, &y.hess, axis_of, is_iiv, pd, n_eta, n_theta,
         ));
     }
     out

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -5910,7 +5910,8 @@ fn run_obs<const NA: usize, const N: usize, const ALLOW_EXPLICIT: bool>(
         };
 
         // Analytic Form C readout (#650): replace the central concentration jet with
-        // `y = <expr>` over `Dual2<N>`. The central compartment **amount** is
+        // `y = <expr>` over the current `DualMixed<NA, N>` jet (`NA = N` on the
+        // full `Dual2<N>` path). The central compartment **amount** is
         // `concentration × V` (so a `central / V` readout recovers the concentration and
         // an additive term layers on); the readout's `∂y/∂pk` / `∂²y/∂pk²` then ride the
         // same `pd` chain to `(θ, η)` below. Covariates come from the per-observation

--- a/src/sens/provider.rs
+++ b/src/sens/provider.rs
@@ -5421,7 +5421,6 @@ fn subject_sensitivities_impl(
     };
 
     let mixed_eligible = explicit_kind.is_none() && ANALYTIC_MIXED_N.contains(&slots.len());
-
     // Dispatch on the differentiated-parameter count so the dual width is
     // right-sized. The hand-written explicit kernels remain on their existing
     // path; they already avoid generic dual arithmetic. Eligible generic-walk
@@ -5465,7 +5464,7 @@ fn subject_sensitivities_impl(
     let mut sens = if mixed_eligible {
         // IIV-bearing rows have a nonzero η derivative. Put them on the leading
         // dual axes so `DualMixed<NA, N>` retains exactly the Hessian rows used
-        // by the η/θ chain. This planning runs only for transit/IG candidates;
+        // by the η/θ chain. This planning runs only for generic-walk candidates;
         // the common explicit-kernel path pays no added per-subject scan.
         let mut is_iiv = [false; MAX_CLOSED_FORM_SLOTS];
         let mut axis_buf = [0usize; MAX_CLOSED_FORM_SLOTS];

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -5731,6 +5731,103 @@ const ONECPT_TRANSIT_MODEL: &str = r#"
   method = focei
 "#;
 
+/// The mixed analytic closed-form walk must retain every output bit from the
+/// full `Dual2` walk. The program orders rows alphabetically (`CL, MTT, NTR, V`),
+/// so the two IIV rows (`CL`, `V`) require the non-trivial permutation
+/// `[0, 2, 3, 1]`; this exercises both retained η-η and η-θ Hessian blocks while
+/// dropping the IIV-free `MTT/NTR` square block (issue #829).
+#[test]
+fn analytic_transit_mixed_matches_full_dual2_bit_for_bit() {
+    let model = parse_model_string(ONECPT_TRANSIT_MODEL).expect("parse transit");
+    let subject = subject_with_doses_and_resets(
+        vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(12.0, 80.0, 1, 0.0, false, 0.0),
+        ],
+        &[0.5, 2.0, 8.0, 12.5, 16.0, 24.0],
+        Vec::new(),
+    );
+    let theta = [5.0, 50.0, 1.0, 3.0];
+    let eta = [0.1, -0.05];
+    let pk = (model.pk_param_fn)(&theta, &eta, &subject.covariates, 0.0);
+    let (pd, slots) = resolve_param_derivs(&model, &subject, &theta, &eta, &pk).expect("pd");
+    assert_eq!(slots.len(), 4);
+
+    let full_seed = seed_dim_from_slots(&slots);
+    let full = run_obs::<4, 4, true>(
+        &full_seed,
+        &pk,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        None,
+        &subject,
+        &pd,
+        None,
+        model.n_eta,
+        model.n_theta,
+        None,
+    );
+
+    let mut is_iiv = [false; 4];
+    for i in 0..4 {
+        is_iiv[i] = pd.dp_deta[i].iter().any(|&v| v != 0.0);
+    }
+    assert_eq!(is_iiv, [true, false, false, true]);
+    let axis_of = [0, 2, 3, 1];
+    let mixed_seed = seed_dim_from_slots_with_axes(&slots, &axis_of);
+    let mixed = run_obs::<2, 4, false>(
+        &mixed_seed,
+        &pk,
+        false,
+        false,
+        false,
+        true,
+        false,
+        false,
+        false,
+        None,
+        &subject,
+        &pd,
+        Some((&axis_of, &is_iiv)),
+        model.n_eta,
+        model.n_theta,
+        None,
+    );
+    MIXED_ANALYTIC_RUNS.with(|runs| runs.set(0));
+    subject_sensitivities(&model, &subject, &theta, &eta).expect("dispatcher serves transit");
+    MIXED_ANALYTIC_RUNS.with(|runs| {
+        assert_eq!(runs.get(), 1);
+    });
+
+    assert_eq!(full.len(), mixed.len());
+    for (obs_i, (a, b)) in full.iter().zip(&mixed).enumerate() {
+        let assert_bits = |lhs: &[f64], rhs: &[f64], field: &str| {
+            assert_eq!(
+                lhs.len(),
+                rhs.len(),
+                "{field} length at observation {obs_i}"
+            );
+            for (i, (&x, &y)) in lhs.iter().zip(rhs).enumerate() {
+                assert_eq!(
+                    x.to_bits(),
+                    y.to_bits(),
+                    "{field}[{i}] at observation {obs_i}: {x:.17e} != {y:.17e}"
+                );
+            }
+        };
+        assert_eq!(a.f.to_bits(), b.f.to_bits(), "f at observation {obs_i}");
+        assert_bits(&a.df_deta, &b.df_deta, "df_deta");
+        assert_bits(&a.d2f_deta2, &b.d2f_deta2, "d2f_deta2");
+        assert_bits(&a.df_dtheta, &b.df_dtheta, "df_dtheta");
+        assert_bits(&a.d2f_deta_dtheta, &b.d2f_deta_dtheta, "d2f_deta_dtheta");
+    }
+}
+
 /// A `one_cpt_transit` subject with time-varying covariates is served by the model's ODE
 /// `transit()` equivalent (`effective_for` routes it there), NOT the closed form — the
 /// closed form assumes constant parameters over each absorption window, and the

--- a/src/sens/provider_tests.rs
+++ b/src/sens/provider_tests.rs
@@ -5754,7 +5754,7 @@ fn analytic_transit_mixed_matches_full_dual2_bit_for_bit() {
     assert_eq!(slots.len(), 4);
 
     let full_seed = seed_dim_from_slots(&slots);
-    let full = run_obs::<4, 4, true>(
+    let full = run_obs::<4, 4, false>(
         &full_seed,
         &pk,
         false,
@@ -5780,7 +5780,7 @@ fn analytic_transit_mixed_matches_full_dual2_bit_for_bit() {
     assert_eq!(is_iiv, [true, false, false, true]);
     let axis_of = [0, 2, 3, 1];
     let mixed_seed = seed_dim_from_slots_with_axes(&slots, &axis_of);
-    let mixed = run_obs::<2, 4, false>(
+    let mixed = run_obs::<2, 4, true>(
         &mixed_seed,
         &pk,
         false,
@@ -5826,6 +5826,44 @@ fn analytic_transit_mixed_matches_full_dual2_bit_for_bit() {
         assert_bits(&a.df_dtheta, &b.df_dtheta, "df_dtheta");
         assert_bits(&a.d2f_deta_dtheta, &b.d2f_deta_dtheta, "d2f_deta_dtheta");
     }
+}
+
+/// A lagtime disables the hand-written explicit kernel, so this ordinary oral
+/// model exercises the broadened generic-walk eligibility rather than the
+/// transit/IG-specific route that originally motivated issue #829.
+#[test]
+fn analytic_lagtime_generic_walk_uses_mixed_hessian() {
+    let model = parse_model_string(
+        r#"
+[parameters]
+  theta TVCL(5.0, 0.1, 100.0)
+  theta TVV(50.0, 5.0, 500.0)
+  theta TVKA(1.0, 0.05, 24.0)
+  theta TVLAG(0.4, 0.0, 4.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.15 (sd)
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V = TVV * exp(ETA_V)
+  KA = TVKA
+  LAGTIME = TVLAG
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA, lagtime=LAGTIME)
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#,
+    )
+    .expect("parse lagtime model");
+    let subject = subject_with_dose(
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        &[0.5, 1.0, 2.0, 4.0, 8.0],
+    );
+
+    MIXED_ANALYTIC_RUNS.with(|runs| runs.set(0));
+    subject_sensitivities(&model, &subject, &[5.0, 50.0, 1.0, 0.4], &[0.1, -0.05])
+        .expect("lagtime generic walk is analytic");
+    MIXED_ANALYTIC_RUNS.with(|runs| assert_eq!(runs.get(), 1));
 }
 
 /// A `one_cpt_transit` subject with time-varying covariates is served by the model's ODE


### PR DESCRIPTION
## Why

The static analytical FOCEI provider propagated a full `N x N` `Dual2<N>` Hessian even though the outer gradient reads only rows belonging to PK parameters that carry IIV. Transit and inverse-Gaussian models commonly have two IIV-bearing rows among four or six differentiated PK parameters, so their IIV-free Hessian block was dead work.

Closes #829.

## What changed

- Reuse `DualMixed<NA, N>` in the static analytical provider and seed IIV-bearing PK rows on the leading axes.
- Share the same dose walk, readout, clamp, and PK-to-eta/theta chain between full and mixed jets.
- Specialize the measured common shapes only: `N = 4/6` and `NA = 1/2`. Wider or differently shaped models retain the exact full-Hessian path. This bounds compile-time monomorphization cost.
- Keep explicit 1/2/3-compartment derivative kernels on their existing path; they already avoid generic dual arithmetic.

## Alternatives considered

Specializing every `0 < NA < N` shape made optimized test builds materially heavier. The final dispatch keeps four mixed types that cover the measured four- and six-parameter generic-walk cases and uses the existing full path everywhere else.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [x] None

## Numerical validation

The new regression uses a multidose one-compartment transit model whose program row order requires a nontrivial axis permutation. It asserts production selects the mixed walker, then compares prediction, eta gradient, eta-eta Hessian, theta gradient, and eta-theta Hessian against full `Dual2<4>` with `f64::to_bits` equality.

- [x] Compared against prior ferx full-Hessian path
- [x] Existing analytical/ODE/NONMEM anchors exercised by the full library suite

## Performance

Optimized `ci-fast` measurements on a seven-observation transit subject and a 24-subject analytical population gradient:

| Scope | Full Hessian | Mixed Hessian | Speedup |
|---|---:|---:|---:|
| 24-subject FOCEI analytic population gradient | 1.04–1.14 ms/eval | 0.71–0.77 ms/eval | 1.42–1.58x |

The issue's profile attributes about 20% of an affected objective evaluation to this gradient path, implying roughly 5–7% total evaluation speedup. This is an inference from the component benchmark; full-fit impact depends on optimizer and inner-solve work.

## Tests

- [x] Bit-exact unit regression added in the provider module
- [x] Mutation check: deleting the four production mixed-dispatch arms makes the route assertion fail
- [x] `cargo test --lib`: 4,195 passed, 23 ignored; one known main-branch failure remains in `ss_input_rate_over_capacity_deep_saturation_declines`
- [x] `tools/preflight.sh` groups green: fmt, all five check configurations, Clippy, Rustdoc, docs
- [x] Public API baseline matches exactly

## Example
- [x] Not applicable; internal performance change with no API or DSL change

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No user-visible documentation change

## Checklist
- [x] Sensitivity operations remain differentiable; `DualMixed` reuses the existing `PkNum` implementation
- [x] No version bump required
- [x] No example execution step needed

## Reviewer hints

The subtle invariant is in `chain_pk_outer_jet`: a Hessian row is skipped only when that PK row has zero derivative with respect to every eta. The original `i`/`j` accumulation order is retained for full jets, which preserves exact output bits. The `NA <= 2`, `N = 4/6` cap is deliberate compile-cost control, not a numerical limitation; unmatched shapes fall back to `Dual2`.
Review follow-up:
- The full path now keeps fixed `[N]` arrays, `0..N` loop bounds, direct Hessian indexing, and a compile-time `PARTIAL = false`, removing mixed-path permutation loads and row branches.
- The mixed boundary asserts that exactly `NA` rows carry IIV and that their axes lie in `0..NA`.
- Eligibility now covers every generic analytical walk at `N = 4/6`, including lagtime/F cases, while explicit-kernel subjects remain untouched.