### PR TITLE
fix(ode): count and report a walk abandoned on an unorderable timeline [closes #1234]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,10 @@ section of the SDLC for the versioning policy).
   `ofv = NaN` with no warning mentioning the subject, the timeline or `NaN`. The counter reports
   *walks*, not subjects (a subject whose predictions and `[odes]` state readout are both
   requested contributes more than one), and it rides in the warning's `details` payload.
+  `ode_predictions_with_solver_stats` reports it too. The `ode_solver` message no longer ends
+  by recommending a different `ode_method` or looser tolerances when the only thing that went
+  wrong is an abandoned walk: nothing was integrated, so no solver setting changes the
+  outcome, and the message now says that instead.
 - Deeply saturated, over-capacity steady-state input-rate models no longer let
   Anderson acceleration report a huge spurious periodic state when integration
   error hides the positive per-cycle surplus (#867, PR #955).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,18 @@ section of the SDLC for the versioning policy).
   added parameter; `examples/two_cpt_oral_covmodel.ferx` goes from OFV -1026.35 at its
   initial estimates to -1195.30, and `examples/two_cpt_oral_cov.ferx` from -1168.48 to
   -1199.33 (NONMEM FOCEI: -1199.43).
+- A subject whose timeline cannot be ordered — a `NaN` or infinite dose time, lagtime, route
+  lag or infusion duration — is now **reported** instead of being silently indistinguishable
+  from a subject with nothing to integrate (#1234). The prediction engines abandon such a walk
+  before calling the solver, which left every counter in the `ode_solver` diagnostic at zero:
+  measured on one model, a non-finite timeline, a subject with no records, and a subject with a
+  single observation at `t = 0` all read `attempted/accepted/rejected = 0/0/0` while returning
+  `[NaN, …]`, `[]` and `[0.0]` respectively. A new `abandoned_non_finite_timeline` counter on
+  `OdeSolverStats` separates the first from the other two, and a fit that hits it now emits an
+  `ode_solver` **Warning** naming the count and what to check, where before it returned
+  `ofv = NaN` with no warning mentioning the subject, the timeline or `NaN`. The counter reports
+  *walks*, not subjects (a subject whose predictions and `[odes]` state readout are both
+  requested contributes more than one), and it rides in the warning's `details` payload.
 - Deeply saturated, over-capacity steady-state input-rate models no longer let
   Anderson acceleration report a huge spurious periodic state when integration
   error hides the positive per-cycle surplus (#867, PR #955).

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -1135,6 +1135,7 @@ pub ferx_core::ode::solver::OdeSolverOptions::stiff_abort_after: core::option::O
 impl core::default::Default for ferx_core::ode::OdeSolverOptions
 pub fn ferx_core::ode::OdeSolverOptions::default() -> Self
 pub struct ferx_core::ode::solver::OdeSolverStats
+pub ferx_core::ode::solver::OdeSolverStats::abandoned_non_finite_timeline: usize
 pub ferx_core::ode::solver::OdeSolverStats::accepted_steps: usize
 pub ferx_core::ode::solver::OdeSolverStats::attempted_steps: usize
 pub ferx_core::ode::solver::OdeSolverStats::auto_fallback_failed: usize
@@ -1203,6 +1204,7 @@ pub ferx_core::ode::OdeSolverOptions::stiff_abort_after: core::option::Option<u3
 impl core::default::Default for ferx_core::ode::OdeSolverOptions
 pub fn ferx_core::ode::OdeSolverOptions::default() -> Self
 pub struct ferx_core::ode::OdeSolverStats
+pub ferx_core::ode::OdeSolverStats::abandoned_non_finite_timeline: usize
 pub ferx_core::ode::OdeSolverStats::accepted_steps: usize
 pub ferx_core::ode::OdeSolverStats::attempted_steps: usize
 pub ferx_core::ode::OdeSolverStats::auto_fallback_failed: usize

--- a/docs/.lint-baseline
+++ b/docs/.lint-baseline
@@ -12,4 +12,3 @@ R1 5239 docs/estimation/tte.qmd::competing-risks-cause-specific-hazards
 R1 7642 docs/model-file/adaptive-dosing.qmd::current-scope-and-limits
 R1 6006 docs/model-file/error-model.qmd::covariate-selected-error-models-ifelse
 R1 5746 docs/model-file/scaling.qmd::interaction-with-gradients
-R1 7391 docs/warnings.qmd::warning-codes

--- a/docs/model-file/ode-models.qmd
+++ b/docs/model-file/ode-models.qmd
@@ -650,8 +650,9 @@ warning (see [Warnings](../warnings.qmd#warning-codes)). It fires when a step cl
 minimum
 step size, when a returned segment stopped before its requested end, when an `auto` escalation
 had to be discarded and re-solved explicitly, when that explicit fallback also failed, when an
-escalation was discarded because its derivatives overflowed, or when `ode_stiff_abort_after`
-cut a segment short — and, at `Info` severity, when `auto` escalated
+escalation was discarded because its derivatives overflowed, when `ode_stiff_abort_after`
+cut a segment short, or when a walk was abandoned *before integrating* because the subject's
+timeline could not be ordered — and, at `Info` severity, when `auto` escalated
 and everything worked, so an escalation is never invisible. Either way it says how many
 segments changed stepper part-way through, because that changes how the step counts above it
 read: the steps before a switch were taken by a different method than the ones after it. Clamps taken inside an escalation
@@ -661,6 +662,16 @@ most actionable line ferx prints about the solver: the probe was right that the 
 stiff and wrong about which stiff method could integrate it, which is the case for naming
 `ode_method = rodas5p` (or `rosenbrock23`) by hand. The counters ride along in the warning's
 `details` payload.
+
+The abandoned-walk case is the odd one out, and has its own counter
+(`abandoned_non_finite_timeline`) for that reason. A `NaN` or infinite dose time, lagtime,
+route lag or infusion duration makes the timeline unsortable, so ferx returns `NaN`
+predictions for that subject rather than silently dropping the offending dose and reporting
+the remaining, drug-free trajectory as valid. Nothing is integrated, so such a subject
+contributes nothing to any other counter in the payload — which, before this counter existed,
+read exactly like a subject there was nothing to integrate for. It is not an `ode_method`
+problem and no solver setting fixes it: check the dose records, and any exponential covariate
+model on `ALAG` / `F` / `D` / `R` that can overflow at typical covariate values.
 
 #### When the derivatives overflow but the predictions do not
 

--- a/docs/model-file/ode-models.qmd
+++ b/docs/model-file/ode-models.qmd
@@ -673,6 +673,11 @@ read exactly like a subject there was nothing to integrate for. It is not an `od
 problem and no solver setting fixes it: check the dose records, and any exponential covariate
 model on `ALAG` / `F` / `D` / `R` that can overflow at typical covariate values.
 
+The counter is reported by `fit()`. `predict()`, `simulate()` and `predict_survival()` still
+return `NaN` for such a subject and say nothing about it — the solver-statistics scope those
+counters accumulate into is opened by the fit only. The `NaN` itself is the signal on those
+entry points, as it was before.
+
 #### When the derivatives overflow but the predictions do not
 
 One rejection reason is not about the method at all. A dual number's derivative jets carry

--- a/docs/warnings.qmd
+++ b/docs/warnings.qmd
@@ -39,7 +39,11 @@ when empty.
 
 ## Warning codes {#warning-codes}
 
-Each `WarningCode` token, what it flags, and a typical response.
+Each `WarningCode` token, what it flags, and a typical response. The groups below
+are for reading convenience only — the token is what a consumer branches on, and
+a code never moves between groups in a way that changes its `category` string.
+
+### Convergence and covariance {#codes-convergence}
 
 | Code (`category`) | Severity | Flags | Typical agent response |
 |-------------------|----------|-------|------------------------|
@@ -50,20 +54,45 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `condition_number` | Critical | Ill-conditioned covariance / high condition number. | Over-parameterized — drop a random effect or covariate. |
 | `optimizer_health` | Warning | Trust-radius collapse / degeneracy. | Try a different optimizer or re-scale parameters. |
 | `vi_bad_basin` | Critical | VI's final ELBO tightness check found that a flat objective is an unusable variational bound, not convergence. | Reject the fit; use better starting values or initialize VI from a fitted point with `method = [focei, vi]`. |
+
+### Residual and random-effect diagnostics {#codes-residuals}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `dw_autocorrelation` | Warning | IWRES autocorrelation (Durbin–Watson out of range). | Revisit the residual-error / structural model. |
 | `eta_normality` | Warning | ETA departs from normality. | Consider a mixture or transform. |
+
+### Censoring, resampling, and experimental features {#codes-methods}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `experimental` | Warning | An experimental feature (SDE, neural-network) was used. | Treat results with caution; validate. |
 | `bloq_method` | Warning | BLOQ / M3 censoring caveat. | Confirm the censoring semantics match intent. |
 | `sir` | Warning | SIR failed or was requested without a covariance. | Ensure a covariance exists before requesting SIR. |
 | `importance_sampling` | Warning | ESS = 0 / proposal collapse. | Increase samples or improve the proposal. |
+
+### Shrinkage and parameter identifiability {#codes-identifiability}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `eps_shrinkage` | Warning | Residual (EPS) shrinkage high / negative. | Sparse data for the error model — simplify it. |
 | `eta_shrinkage` | Warning | One or more ETA shrinkages exceed ~30%. | Data poorly inform that IIV — consider removing it on the affected parameter(s). |
 | `boundary_estimate` | Warning | One or more THETA estimates are pinned to an optimizer bound. | Non-identifiability or a too-tight bound — inspect; relax the bound or simplify. |
 | `parameter_at_runaway_guard` | Critical / Warning | A free coordinate is pinned to a hidden optimizer guard (implicit THETA cap, OMEGA / SIGMA rail), with a `verdict` the side does not decide. | `collapse` (`Warning`): remove or simplify it. `runaway` (`Critical`): `converged: false` — reject; revisit model, data, inits; for SIGMA, rescale DV. |
 | `inflated_rse` | Warning | One or more THETA estimates have RSE > ~50%. | Imprecisely estimated — often over-parameterization; consider simplifying. |
 | `high_correlation` | Warning | One or more THETA (fixed-effect) pairs have \|correlation\| ≥ 0.95. | Over-parameterization / non-identifiability — fix or remove one of each pair. |
+
+### Dataset and model structure {#codes-structure}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `data_quality` | Warning | Dataset issue (missing DV, ADDL/II, non-positive DV, …). | Fix the dataset before trusting the fit. |
 | `omega_structure` | Warning | Mixed lognormal / additive block in omega. | Make the block's parameterization consistent. |
+
+### Run configuration and informational notes {#codes-run}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `gradient_fallback` | Info | A gradient / sampler fallback was taken. | None; note the slower path. |
 | `mu_referencing` | Warning / Info | Missing or partial mu-referencing. | Prefer `CL = TVCL * exp(ETA_CL)` forms for SAEM/Bayes. |
 | `optimizer_config` | Warning / Info | `global_search` config note or failure. | Check the global-search setup if disabled unexpectedly. |
@@ -71,10 +100,20 @@ Each `WarningCode` token, what it flags, and a typical response.
 | `cancelled` | Info | Run cancelled by the user. | None. |
 | `threads` | Info | Thread-count efficiency note. | Optionally tune `threads`. |
 | `simulation` | Warning | A simulated subject was handled specially — a degenerate hazard draw (censored, no event) or an over-large recurrent-event stream (skipped/truncated). Surfaced by `simulate_with_options_diag` and on `--simulate` runs (#762/#763). | Inspect the named subject's hazard parameters / covariate values; the estimated model is unaffected. |
+
+### Absorption diagnostics {#codes-absorption}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `flip_flop` | Warning | A transit / inverse-Gaussian absorption closed form entered the flip-flop regime (disposition rate ≥ the tilting abscissa). Either auto-rerouted to the ODE twin (informational) or — for a twin-less model at a subject's fitted EBE (#785) — a silently degenerate likelihood contribution. | Rewrite as an explicit ODE `transit()`/`igd()` model (which reroutes per subject), or check the named subject's MTT/CL (transit) or MAT/CV²/CL (IG) estimates. |
 | `absorption_twin_declined` | Warning | An analytic transit / inverse-Gaussian model's ODE twin could not be built, so the model keeps no ODE fallback (#1008). The fit itself is an ordinary closed-form fit; what is lost is the reroute, so a subject needing it (time-varying covariates, a `TIME`-dependent parameter, IOV, SS / infusion doses, the flip-flop regime) is rejected with an explicit error. | Read the quoted reason — usually an individual parameter named after a twin state (`CENTRAL`, `PERIPH`); rename it to restore the twin. |
+
+### Solver, numerics, and unclassified {#codes-solver}
+
+| Code (`category`) | Severity | Flags | Typical agent response |
+|-------------------|----------|-------|------------------------|
 | `flat_parameter` | Warning | A non-fixed THETA has an ≈ 0 outer gradient at the initial estimate — it never reaches the objective (unmapped, or dropped from the structural / scaling model). The pre-flight guard froze it at its initial value so the remaining parameters could estimate, instead of the whole fit dying on an eval-1 optimizer `Failure` (#826). | Map the named parameter into the model, or remove it. Its reported estimate is just its initial value (SE = N/A). |
-| `ode_solver` | Warning / Info | The ODE solver's own health at the final estimates (#1080). **Warning** when steps clamped at the minimum step size (a stability-limited segment whose un-integrated tail is freeze-padded), when a segment stopped before its requested end, when `ode_stiff_abort_after` cut segments short, or when `ode_method = auto` discarded an escalation and re-solved it explicitly — including when only its **analytic derivatives** overflowed, its values staying finite — and when that re-solve failed too. **Info** when `auto` escalated and everything worked (a separate `W_ODE_SOLVER_ESCALATION_NOTE` token, so the severity survives re-classification) — routine on a stiff model, but a decision you never asked for and cannot otherwise see. Both severities report how many segments changed stepper **part-way through** (`ode_auto_switch`, default on): steps before a switch were taken by a different method than those after. | A rejected escalation means the probe was right about the stiffness and wrong about the method: name `ode_method = rodas5p` (or `rosenbrock23`). Non-zero `auto_stiff_rejected_jets` is the exception: the method worked, the *sensitivities* overflowed — check units and scaling, not `ode_method`. Non-zero `auto_fallback_failed`: neither attempt gave a usable trajectory; do not trust the fit. Clamps with no rejection mean the explicit stepper is stability-limited — try a stiff method, or loosen `ode_reltol` / `ode_abstol`. |
+| `ode_solver` | Warning / Info | The ODE solver's own health at the final estimates (#1080). **Warning** when steps clamped at the minimum step size (a stability-limited segment whose un-integrated tail is freeze-padded), when a segment stopped before its requested end, when `ode_stiff_abort_after` cut segments short, or when `ode_method = auto` discarded an escalation and re-solved it explicitly — including when only its **analytic derivatives** overflowed, its values staying finite — and when that re-solve failed too. Also **Warning** when a prediction walk was abandoned *before integrating* because the subject's timeline could not be ordered — a `NaN` or infinite dose time, lagtime, route lag, or infusion duration (#1234). That case is the only one here whose predictions are `NaN` rather than merely inaccurate, and it leaves every step counter at zero, so it is reported by its own counter (`abandoned_non_finite_timeline`) rather than inferred from the others. **Info** when `auto` escalated and everything worked (a separate `W_ODE_SOLVER_ESCALATION_NOTE` token, so the severity survives re-classification) — routine on a stiff model, but a decision you never asked for and cannot otherwise see. Both severities report how many segments changed stepper **part-way through** (`ode_auto_switch`, default on): steps before a switch were taken by a different method than those after. | A rejected escalation means the probe was right about the stiffness and wrong about the method: name `ode_method = rodas5p` (or `rosenbrock23`). Non-zero `auto_stiff_rejected_jets` is the exception: the method worked, the *sensitivities* overflowed — check units and scaling, not `ode_method`. Non-zero `auto_fallback_failed`: neither attempt gave a usable trajectory; do not trust the fit. Clamps with no rejection mean the explicit stepper is stability-limited — try a stiff method, or loosen `ode_reltol` / `ode_abstol`. Non-zero `abandoned_non_finite_timeline` is not a solver setting at all: some subject's timeline is unorderable, so check the dose records and any exponential covariate model on `ALAG` / `F` / `D` / `R` for a value that overflows at typical covariates. |
 | `general` | Warning | Unrecognised message (fallback bucket). | Read the message text. |
 
 ## Details payloads {#details}
@@ -94,7 +133,7 @@ Treat `details` as optional: check for its presence rather than assuming it.
 | `inflated_rse` | `threshold_pct`, `parameters` (array of `{parameter, estimate, se, rse_pct}`) |
 | `high_correlation` | `threshold`, `pairs` (array of `{parameter_a, parameter_b, correlation}`) |
 | `flip_flop` | `phase` (`"ebe"`), `model`, `subjects` (array of affected subject IDs) |
-| `ode_solver` | `phase` (`"postfit_predictions"`), `ode_method`, `attempted_steps`, `accepted_steps`, `rejected_steps`, `min_step_clamped_steps`, `stiff_min_step_clamped_steps`, `discarded_clamped_steps`, `kept_clamped_steps`, `auto_stiff_segments`, `auto_switched_segments`, `auto_stiff_rejected`, `auto_stiff_rejected_jets`, `auto_fallback_failed`, `unfinished_segments`, `discarded_unfinished_segments`, `kept_unfinished_segments`, `stiff_aborted_segments`. These are not all disjoint: `kept_unfinished_segments` is a roll-up that already includes `stiff_aborted_segments`, and `auto_fallback_failed` ⊆ `auto_stiff_rejected` ⊆ `auto_stiff_segments`. `auto_stiff_rejected_jets` is the one key not from the prediction pass — it comes from the post-fit sensitivity sweep, so it is disjoint from the rest, not a subset. The message text subtracts the overlaps before reporting; a consumer reading the payload should not add these keys together. |
+| `ode_solver` | `phase` (`"postfit_predictions"`), `ode_method`, `attempted_steps`, `accepted_steps`, `rejected_steps`, `min_step_clamped_steps`, `stiff_min_step_clamped_steps`, `discarded_clamped_steps`, `kept_clamped_steps`, `auto_stiff_segments`, `auto_switched_segments`, `auto_stiff_rejected`, `auto_stiff_rejected_jets`, `auto_fallback_failed`, `unfinished_segments`, `discarded_unfinished_segments`, `kept_unfinished_segments`, `stiff_aborted_segments`, `abandoned_non_finite_timeline`. These are not all disjoint: `kept_unfinished_segments` is a roll-up that already includes `stiff_aborted_segments`, and `auto_fallback_failed` ⊆ `auto_stiff_rejected` ⊆ `auto_stiff_segments`. `auto_stiff_rejected_jets` is the one key not from the prediction pass — it comes from the post-fit sensitivity sweep, so it is disjoint from the rest, not a subset. `abandoned_non_finite_timeline` is disjoint too, and for the opposite reason: every other key describes a segment that *started*, and an abandoned walk never called the solver, so all of them are zero for it. It counts **walks, not subjects** — one subject whose predictions and whose `[odes]` state readout are both requested contributes more than one (measured: 3 per subject on a plain FOCEI post-fit sweep). The message text subtracts the overlaps before reporting; a consumer reading the payload should not add these keys together. |
 | `covariance_failed`, `covariance_regularized` | `condition_number`, `min_eigenvalue`, `n_negative_eigenvalues` (each present only when computed — a hard failure with no matrix omits the eigenvalue keys) |
 | `condition_number` | `condition_number` |
 

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1958,13 +1958,17 @@ pub(crate) fn ode_solver_diagnostics_warning(
     } else {
         String::new()
     };
-    let unclean = clamped > 0
+    // Split in two (#1234 review §2). Every counter but `abandoned` describes an integration
+    // that *ran* and came back inaccurate; `abandoned` describes one that never started. The
+    // difference decides both the lead-in verb and whether the solver-knob advice applies, so
+    // the two cannot share one flag.
+    let unclean_integration = clamped > 0
         || rejected > 0
         || rejected_jets > 0
         || fallback_failed > 0
         || unfinished_kept > 0
-        || aborted > 0
-        || abandoned > 0;
+        || aborted > 0;
+    let unclean = unclean_integration || abandoned > 0;
     if !unclean && escalated == 0 {
         return None;
     }
@@ -2102,12 +2106,37 @@ pub(crate) fn ode_solver_diagnostics_warning(
         ));
     }
 
+    // The lead-in has to survive the abandoned-only case: "did not integrate cleanly"
+    // understates a walk that never integrated at all and whose predictions are every one
+    // `NaN`.
+    let lead = if unclean_integration {
+        "did not integrate cleanly"
+    } else {
+        "did not produce a usable integration"
+    };
+    // #1234 review §2: the solver-knob advice is about an integration that ran badly, and
+    // saying it unconditionally contradicted this PR's own `docs/model-file/ode-models.qmd`
+    // ("It is not an `ode_method` problem and no solver setting fixes it") — as the *last*
+    // sentence of the message and the only one naming concrete knobs. So it is attached to
+    // the counters it is true of, and an abandoned walk gets the advice that applies to it.
+    let solver_knob_advice = if unclean_integration {
+        " For the segments that did integrate, consider a different ode_method, a looser \
+         ode_reltol / ode_abstol, or checking the parameter estimates that produce these \
+         dynamics."
+    } else {
+        ""
+    };
+    let abandoned_advice = if abandoned > 0 {
+        " The abandoned walk(s) are not an ode_method or tolerance problem — nothing was \
+         integrated for them, so no solver setting changes the outcome; fix the record or \
+         the parameter that produces the non-finite time."
+    } else {
+        ""
+    };
     let msg = format!(
-        "{ODE_SOLVER_WARNING_TOKEN}: the ODE solver did not integrate cleanly at the final \
-         estimates (ode_method = {method}): {body}. Counters are from the post-fit prediction \
-         pass over all subjects; consider a different ode_method, a looser ode_reltol / \
-         ode_abstol, or checking the parameter estimates that produce these dynamics.\
-         {switched_warn_clause}",
+        "{ODE_SOLVER_WARNING_TOKEN}: the ODE solver {lead} at the final estimates \
+         (ode_method = {method}): {body}. Counters are from the post-fit prediction pass over \
+         all subjects.{solver_knob_advice}{abandoned_advice}{switched_warn_clause}",
         method = options.ode_method.as_str(),
         body = parts.join("; "),
     );

--- a/src/api/postfit.rs
+++ b/src/api/postfit.rs
@@ -1860,9 +1860,11 @@ pub(crate) fn sweep_sensitivity_solver_stats(
 /// Two severities, because the two things being reported are not the same kind of event:
 ///
 /// * **Warning** — a step clamped at `min_dt`, an escalation was discarded, its explicit
-///   fallback also failed, a segment ended before its requested horizon, or a segment was cut
-///   short by `ode_stiff_abort_after`. Each means part of some subject's trajectory was
-///   freeze-padded or re-solved, i.e. the integration was not clean.
+///   fallback also failed, a segment ended before its requested horizon, a segment was cut
+///   short by `ode_stiff_abort_after`, or a walk was abandoned before integrating because its
+///   timeline could not be ordered (#1234). Each means part of some subject's trajectory was
+///   freeze-padded, re-solved, or — in the last case — never produced at all, i.e. the
+///   integration was not clean.
 /// * **Info** — `auto` escalated and everything worked. Routine on a stiff model (the TMDD
 ///   `cr` testdata escalates 240 of 580 segments) and not a problem, but it *is* a decision
 ///   the user never asked for and could not otherwise see.
@@ -1919,6 +1921,15 @@ pub(crate) fn ode_solver_diagnostics_warning(
     // *steps*, so it cannot collide with a segment count the same way; its own segment-level
     // overlap is described in the wording below.)
     let unfinished_other = unfinished_kept.saturating_sub(aborted);
+    // Walks abandoned before a driver was ever called, because the timeline could not be
+    // ordered (#1189, counted since #1234). Disjoint from every counter above by construction:
+    // those all describe a segment that *started*, and here none did — which is exactly why it
+    // needs its own clause. Without it this is the one damaged outcome that leaves the whole
+    // stats block at zero and so reads identical to a subject there was nothing to integrate
+    // for. It is not part of the `unfinished_kept` roll-up either — an abandoned walk has no
+    // segments at all, so folding it in would report it as a segment that started and stopped,
+    // which is a different (and less alarming) failure than the one that happened.
+    let abandoned = stats.abandoned_non_finite_timeline;
     let escalated = stats.auto_stiff_segments;
     // Segments whose stepper changed part-way through (#1080 Part C). Reported as a clause on
     // the escalation note rather than as a warning of its own: a mid-segment switch is `auto`
@@ -1952,7 +1963,8 @@ pub(crate) fn ode_solver_diagnostics_warning(
         || rejected_jets > 0
         || fallback_failed > 0
         || unfinished_kept > 0
-        || aborted > 0;
+        || aborted > 0
+        || abandoned > 0;
     if !unclean && escalated == 0 {
         return None;
     }
@@ -1976,6 +1988,7 @@ pub(crate) fn ode_solver_diagnostics_warning(
         "discarded_unfinished_segments": stats.discarded_unfinished_segments,
         "kept_unfinished_segments": unfinished_kept,
         "stiff_aborted_segments": aborted,
+        "abandoned_non_finite_timeline": abandoned,
     }));
 
     if !unclean {
@@ -1999,6 +2012,22 @@ pub(crate) fn ode_solver_diagnostics_warning(
     }
 
     let mut parts: Vec<String> = Vec::new();
+    // First, because it is the only clause here that reports predictions which are `NaN` rather
+    // than merely inaccurate: every other outcome returns a finite trajectory that was
+    // freeze-padded or re-solved, and this one returns no trajectory at all.
+    if abandoned > 0 {
+        parts.push(format!(
+            "{abandoned} solver walk(s) were abandoned before integrating because the \
+             subject's timeline could not be ordered — a NaN or infinite dose time, lagtime, \
+             route lag, or infusion duration at the final estimates — so those subjects' \
+             predictions are NaN by construction, and they contributed nothing to any other \
+             counter in this payload because nothing was integrated for them. This counts \
+             walks, not subjects: one subject reaches more than one engine in this pass (its \
+             predictions and its [odes] state readout are separate walks), so it contributes \
+             more than one. Check the dose records and any exponential covariate model on ALAG \
+             / F / D / R for a value that overflows at typical covariates"
+        ));
+    }
     if clamped > 0 {
         parts.push(format!(
             "{clamped} step(s) clamped at the minimum step size — the local-error test failed \

--- a/src/api/tests/ode_solver_diagnostics_tests.rs
+++ b/src/api/tests/ode_solver_diagnostics_tests.rs
@@ -927,3 +927,75 @@ fn a_fit_over_an_unorderable_timeline_says_so() {
         result.warnings
     );
 }
+
+/// T9 — the **public** getter reports it too.
+///
+/// `ode_predictions_with_solver_stats` (`src/ode/predictions.rs`) is the only `pub fn` that
+/// returns an `OdeSolverStats`, and it is the surface #1234 item 1 was reported against. It
+/// opens no `SolverStatsScope`: it hands the engine a `&mut OdeSolverStats` out-parameter and
+/// returns it. So a recorder that writes only the thread-local sink leaves *this* function
+/// answering `abandoned_non_finite_timeline = 0` for a walk whose predictions are all `NaN` —
+/// which is the conflation the counter exists to remove, on the public surface. Measured at
+/// `335cb9e5`, before the fix: `preds` all `NaN`, every field of the returned block `0`.
+///
+/// Deliberately **not** wrapped in a scope: the scope route is T1's, and running this one
+/// inside a scope would let the sink supply the answer and hide the out-parameter defect.
+///
+/// Mutation (run): drop `stats.as_deref_mut()` back to `None` at
+/// `ode_predictions_with_extra_breaks_and_stats`' guard → this fires; T1–T4 stay green,
+/// because they all collect through the scope.
+#[test]
+fn the_public_solver_stats_surface_reports_an_abandoned_walk() {
+    let model = two_state_model(1.0);
+    let ode = model.ode_spec.as_ref().expect("ode model");
+    let theta = &model.default_params.theta;
+    let pk = [1.0, 10.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+
+    let (preds, stats) = crate::ode::ode_predictions_with_solver_stats(
+        ode,
+        &pk,
+        theta,
+        &[0.0],
+        &nan_dose_time_subject("bad"),
+    );
+    assert_eq!(
+        preds.len(),
+        4,
+        "the fixture must have observations: {preds:?}"
+    );
+    assert!(
+        preds.iter().all(|p| p.is_nan()),
+        "the fixture must actually be abandoned, got {preds:?}"
+    );
+    assert_eq!(
+        stats.abandoned_non_finite_timeline, 1,
+        "the public getter must report the abandoned walk, not hand back an all-zero block \
+         that reads like a subject with nothing to integrate: {stats:?}"
+    );
+    assert_eq!(
+        stats.attempted_steps, 0,
+        "nothing was integrated, so the step counters must stay zero: {stats:?}"
+    );
+
+    // The straddle, through the same public surface: an ordinary subject must integrate and
+    // record nothing. Without it a counter wired to fire on every call would pass above.
+    let (preds, clean) =
+        crate::ode::ode_predictions_with_solver_stats(ode, &pk, theta, &[0.0], &subject("2", 1.0));
+    assert_eq!(
+        preds.len(),
+        4,
+        "the control must have observations: {preds:?}"
+    );
+    assert!(
+        preds.iter().all(|p| p.is_finite()),
+        "the control must actually integrate, got {preds:?}"
+    );
+    assert_eq!(
+        clean.abandoned_non_finite_timeline, 0,
+        "an ordinary subject is not an abandoned walk: {clean:?}"
+    );
+    assert!(
+        clean.attempted_steps > 0,
+        "the control must actually integrate, or it separates nothing: {clean:?}"
+    );
+}

--- a/src/api/tests/ode_solver_diagnostics_tests.rs
+++ b/src/api/tests/ode_solver_diagnostics_tests.rs
@@ -999,3 +999,94 @@ fn the_public_solver_stats_surface_reports_an_abandoned_walk() {
         "the control must actually integrate, or it separates nothing: {clean:?}"
     );
 }
+
+/// T10 — the advice must not contradict the clause it follows (#1234 review §2).
+///
+/// The message used to end, unconditionally, with "consider a different ode_method, a looser
+/// ode_reltol / ode_abstol, or checking the parameter estimates that produce these dynamics" —
+/// the last thing the user reads and the only sentence naming concrete knobs. On an abandoned
+/// walk that is wrong, and `docs/model-file/ode-models.qmd` says so in this same change: no
+/// solver setting fixes a timeline that cannot be ordered, because nothing was integrated.
+///
+/// Three arms, because the wording is now a function of *which* counters fired and a
+/// single-arm test cannot see a branch:
+///
+/// * abandoned only → no solver-knob advice, and the lead-in must not claim an integration;
+/// * an ordinary unclean integration → the knob advice, unchanged, and no abandoned advice;
+/// * both → both, since the mixed case has segments the knobs really do apply to.
+///
+/// Mutation (run): make `solver_knob_advice` unconditional again → the first arm fires.
+/// Delete `abandoned_advice` → the first and third arms fire. Make `lead` unconditional →
+/// the first arm's lead-in assert fires.
+#[test]
+fn the_solver_knob_advice_is_attached_only_to_counters_it_applies_to() {
+    const KNOBS: &str = "looser ode_reltol";
+    const NOT_A_SOLVER_SETTING: &str = "not an ode_method or tolerance problem";
+
+    let (abandoned_only, _) = ode_solver_diagnostics_warning(
+        &OdeSolverStats {
+            abandoned_non_finite_timeline: 3,
+            ..Default::default()
+        },
+        &FitOptions::default(),
+    )
+    .expect("an abandoned walk is a warning");
+    assert!(
+        !abandoned_only.contains(KNOBS),
+        "an abandoned walk never reached the solver, so the message must not end by \
+         recommending solver settings — it contradicts the clause above it: {abandoned_only}"
+    );
+    assert!(
+        abandoned_only.contains(NOT_A_SOLVER_SETTING),
+        "…and it must say so, rather than merely omitting the advice: {abandoned_only}"
+    );
+    assert!(
+        !abandoned_only.contains("did not integrate cleanly"),
+        "the lead-in must not describe a walk that never integrated as an unclean \
+         integration: {abandoned_only}"
+    );
+
+    // The control: an ordinary unclean integration keeps the advice it always had.
+    let (integration_only, _) = ode_solver_diagnostics_warning(
+        &OdeSolverStats {
+            attempted_steps: 400,
+            accepted_steps: 380,
+            min_step_clamped_steps: 7,
+            ..Default::default()
+        },
+        &FitOptions::default(),
+    )
+    .expect("a clamped step is a warning");
+    assert!(
+        integration_only.contains(KNOBS),
+        "a segment that did integrate is exactly what the solver knobs are for: \
+         {integration_only}"
+    );
+    assert!(
+        !integration_only.contains(NOT_A_SOLVER_SETTING),
+        "nothing was abandoned here, so the abandoned advice must not appear: \
+         {integration_only}"
+    );
+    assert!(
+        integration_only.contains("did not integrate cleanly"),
+        "the lead-in for a genuinely unclean integration is unchanged: {integration_only}"
+    );
+
+    // Both: the mixed case has segments the knobs apply to *and* walks they do not.
+    let (both, _) = ode_solver_diagnostics_warning(
+        &OdeSolverStats {
+            attempted_steps: 400,
+            accepted_steps: 380,
+            min_step_clamped_steps: 7,
+            abandoned_non_finite_timeline: 1,
+            ..Default::default()
+        },
+        &FitOptions::default(),
+    )
+    .expect("a warning");
+    assert!(
+        both.contains(KNOBS) && both.contains(NOT_A_SOLVER_SETTING),
+        "the mixed case must carry both, and scope the knob advice to the segments that ran: \
+         {both}"
+    );
+}

--- a/src/api/tests/ode_solver_diagnostics_tests.rs
+++ b/src/api/tests/ode_solver_diagnostics_tests.rs
@@ -713,6 +713,13 @@ fn static_walk(subj: &Subject) -> (OdeSolverStats, Vec<f64>) {
 #[test]
 fn the_static_walk_separates_an_abandoned_timeline_from_nothing_to_integrate() {
     let (abandoned, preds) = static_walk(&nan_dose_time_subject("bad"));
+    // `.all()` is vacuously true on an empty `preds`, and "the walk bails before recording
+    // observations" is the state under test — so the length is asserted before the premise.
+    assert_eq!(
+        preds.len(),
+        4,
+        "the fixture must have observations: {preds:?}"
+    );
     assert!(
         preds.iter().all(|p| p.is_nan()),
         "static walk: the fixture must actually be abandoned (NaN predictions), got {preds:?}"
@@ -785,6 +792,12 @@ fn the_event_driven_walk_separates_an_abandoned_timeline_from_nothing_to_integra
     };
 
     let (abandoned, preds) = run(&nan_dose_time_subject("bad"));
+    // As T1: `.all()` on an empty `preds` asserts nothing.
+    assert_eq!(
+        preds.len(),
+        4,
+        "the fixture must have observations: {preds:?}"
+    );
     assert!(
         preds.iter().all(|p| p.is_nan()),
         "event-driven walk: the fixture must actually be abandoned, got {preds:?}"
@@ -883,6 +896,20 @@ fn a_fit_over_an_unorderable_timeline_says_so() {
     // alone, so deleting either recorder would leave this test green (the redundant-gate hole);
     // pinning the count makes each site load-bearing here too, and it is the measurement behind
     // the message's "counts walks, not subjects" clause.
+    //
+    // **The count is asserted to be lane-independent**, and the test carries no feature gate
+    // because of it. The three walks are `ode_predictions` and `ode_predictions_with_states`,
+    // both unconditional in the post-fit sweep. The other five recorders sit on engines this
+    // fixture cannot reach: the scope wraps `compute_subject_results` only (`api/fit.rs:1912`),
+    // so `ode_dense_solve_states`' reachable callers all need a model feature this fixture does
+    // not have (a markov endpoint, a hazard state, a TV-covariate model — its
+    // `api/output_columns.rs` caller runs after the scope closes), the adaptive pair is
+    // `simulate()`-only, and `ode_solve_until_chz_threshold` needs a `chz` slot. That, not the
+    // feature flags themselves, is why `ci` and `ci,markov,nn` both read 3 (checked at
+    // `335cb9e5`, both lanes SUCCESS). If a future change routes one of those into the post-fit
+    // pass this number becomes lane-dependent, and the failure would read as a broken recorder
+    // rather than a feature-sensitive fixture — gate the test then rather than loosening it to
+    // `> 0`.
     assert_eq!(
         abandoned, 3,
         "one NaN-timeline subject is abandoned once per prediction walk the post-fit sweep \

--- a/src/api/tests/ode_solver_diagnostics_tests.rs
+++ b/src/api/tests/ode_solver_diagnostics_tests.rs
@@ -641,3 +641,289 @@ fn the_sensitivity_sweep_is_a_no_op_when_the_fit_asked_for_fd_gradients() {
     assert_eq!(stats.accepted_steps, 0, "{stats:?}");
     assert_eq!(stats.attempted_steps, 0, "{stats:?}");
 }
+
+// ── abandoned non-finite timelines (#1234) ───────────────────────────────────
+//
+// Before this, the three states below were one counter reading. Measured at `cf32e1fd` on
+// the `two_state_model(1.0)` fixture inside a `SolverStatsScope`: a normal subject read
+// `attempted/accepted/rejected = 7/7/0`, while a non-finite timeline, a subject with no
+// records, and a subject with one observation at `t = 0` all read `0/0/0` — returning
+// `[NaN; 4]`, `[]` and `[0.0]` respectively. The first of those three is a fit whose
+// predictions are `NaN` by construction; the other two are ordinary.
+
+/// A subject with a `NaN` dose **time**, which is how this reaches the engines at all:
+/// `check_model_data` passes it, because #1286 checks dose *attributes* (`ALAG`/`F`/`D`/`R`)
+/// and not record times.
+fn nan_dose_time_subject(id: &str) -> Subject {
+    let mut s = subject(id, 1.0);
+    s.doses = vec![DoseEvent::new(f64::NAN, 100.0, 1, 0.0, false, 0.0)];
+    s
+}
+
+/// Nothing to integrate: no doses, no observations.
+fn no_records_subject() -> Subject {
+    let mut s = subject("empty", 1.0);
+    s.doses = Vec::new();
+    s.obs_times = Vec::new();
+    s.observations = Vec::new();
+    s.obs_cmts = Vec::new();
+    s.cens = Vec::new();
+    s
+}
+
+/// Nothing to integrate *over*: one observation at the integration start.
+fn one_obs_at_zero_subject() -> Subject {
+    let mut s = subject("one", 1.0);
+    s.doses = Vec::new();
+    s.obs_times = vec![0.0];
+    s.observations = vec![1.0];
+    s.obs_cmts = vec![1];
+    s.cens = vec![0];
+    s
+}
+
+/// Counters collected while `f` runs, through the ordinary thread-local scope production
+/// uses (`api::fit`), not through `ode_predictions_with_solver_stats` — which has no
+/// production caller and so could be "fixed" without reaching a user.
+fn stats_of<R>(f: impl FnOnce() -> R) -> (OdeSolverStats, R) {
+    let scope = crate::ode::solver::SolverStatsScope::enter();
+    let out = f();
+    (scope.collected(), out)
+}
+
+fn static_walk(subj: &Subject) -> (OdeSolverStats, Vec<f64>) {
+    let model = two_state_model(1.0);
+    let ode = model.ode_spec.as_ref().expect("ode model");
+    let theta = &model.default_params.theta;
+    let pk = [1.0, 10.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0];
+    stats_of(|| crate::ode::ode_predictions(ode, &pk, theta, &[0.0], subj))
+}
+
+/// T1 — the three-way straddle on the **static dense** walk
+/// (`ode_predictions` → `ode_predictions_with_extra_breaks_and_stats`).
+///
+/// The straddle is the assertion: an abandoned walk and a walk with nothing to do are
+/// different states of the world, so a counter that cannot separate them is not reporting
+/// the first one. All three arms are checked in one test because pinning only the abandoned
+/// arm would pass just as well on a counter that fires on every subject.
+///
+/// Mutation (run): delete the `record_abandoned_non_finite_timeline()` call in
+/// `ode_predictions_with_extra_breaks_and_stats` → the abandoned arm reads 0 and the first
+/// assert fires, naming the static walk. T2 stays green under it.
+#[test]
+fn the_static_walk_separates_an_abandoned_timeline_from_nothing_to_integrate() {
+    let (abandoned, preds) = static_walk(&nan_dose_time_subject("bad"));
+    assert!(
+        preds.iter().all(|p| p.is_nan()),
+        "static walk: the fixture must actually be abandoned (NaN predictions), got {preds:?}"
+    );
+    assert_eq!(
+        abandoned.abandoned_non_finite_timeline, 1,
+        "static walk: a non-finite timeline must be recorded as abandoned, not left \
+         indistinguishable from a subject with nothing to integrate — got {abandoned:?}"
+    );
+    assert_eq!(
+        abandoned.attempted_steps, 0,
+        "static walk: nothing was integrated, so the step counters must stay zero — that is \
+         the whole reason this counter has to exist: {abandoned:?}"
+    );
+
+    let (empty, preds) = static_walk(&no_records_subject());
+    assert!(preds.is_empty(), "no-records fixture returned {preds:?}");
+    assert_eq!(
+        empty.abandoned_non_finite_timeline, 0,
+        "static walk: a subject with no records was not abandoned — its timeline is orderable, \
+         there is simply nothing on it: {empty:?}"
+    );
+
+    let (at_zero, preds) = static_walk(&one_obs_at_zero_subject());
+    assert_eq!(preds.len(), 1, "one-obs fixture returned {preds:?}");
+    assert!(
+        preds[0].is_finite(),
+        "one-obs fixture must be a finite reading of the initial state, got {preds:?}"
+    );
+    assert_eq!(
+        at_zero.abandoned_non_finite_timeline, 0,
+        "static walk: a single observation at t=0 was not abandoned: {at_zero:?}"
+    );
+}
+
+/// T2 — the same straddle on the **event-driven** walk (`ode_predictions_event_driven`), the
+/// engine a TV-covariate / lagtime / IOV / reset subject routes to.
+///
+/// Its own site, mutated on its own: a fixture that reaches only the dense engine cannot see
+/// this one, and the two guards return through different code (`(predictions, chz_states)`
+/// there, a bare `predictions` here) with a differently-spelled predicate
+/// (`times_have_non_finite` over `(time, kind, idx)` tuples).
+///
+/// Mutation (run): delete the `record_abandoned_non_finite_timeline()` call in
+/// `ode_predictions_event_driven` → the first assert fires, naming the event-driven walk.
+/// T1 stays green under it.
+#[test]
+fn the_event_driven_walk_separates_an_abandoned_timeline_from_nothing_to_integrate() {
+    let model = two_state_model(1.0);
+    let ode = model.ode_spec.as_ref().expect("ode model");
+    let mut pk = PkParams::default();
+    pk.values[crate::types::PK_IDX_CL] = 1.0;
+    pk.values[crate::types::PK_IDX_V] = 10.0;
+
+    let run = |subj: &Subject| {
+        let dose_pk = vec![pk; subj.doses.len()];
+        let obs_pk = vec![pk; subj.obs_times.len()];
+        stats_of(|| {
+            crate::ode::ode_predictions_event_driven(
+                ode,
+                subj,
+                &[],
+                &[],
+                &dose_pk,
+                &obs_pk,
+                &[],
+                &[],
+            )
+        })
+    };
+
+    let (abandoned, preds) = run(&nan_dose_time_subject("bad"));
+    assert!(
+        preds.iter().all(|p| p.is_nan()),
+        "event-driven walk: the fixture must actually be abandoned, got {preds:?}"
+    );
+    assert_eq!(
+        abandoned.abandoned_non_finite_timeline, 1,
+        "event-driven walk: a non-finite timeline must be recorded as abandoned here too — \
+         this engine has its own guard and its own return, and a fixture that reaches only \
+         the dense engine cannot see it: {abandoned:?}"
+    );
+    assert_eq!(
+        abandoned.attempted_steps, 0,
+        "event-driven walk: nothing was integrated, so the step counters must stay zero: \
+         {abandoned:?}"
+    );
+
+    let (empty, preds) = run(&no_records_subject());
+    assert!(preds.is_empty(), "no-records fixture returned {preds:?}");
+    assert_eq!(
+        empty.abandoned_non_finite_timeline, 0,
+        "event-driven walk: a subject with no records was not abandoned: {empty:?}"
+    );
+
+    let (at_zero, preds) = run(&one_obs_at_zero_subject());
+    assert_eq!(preds.len(), 1, "one-obs fixture returned {preds:?}");
+    assert!(
+        preds[0].is_finite(),
+        "one-obs fixture must be a finite reading of the initial state, got {preds:?}"
+    );
+    assert_eq!(
+        at_zero.abandoned_non_finite_timeline, 0,
+        "event-driven walk: a single observation at t=0 was not abandoned: {at_zero:?}"
+    );
+}
+
+/// T3 — the four counters that describe a segment which *started* must stay zero on an
+/// abandoned walk, because no segment did.
+///
+/// This is the check that the new counter is being set by the guard and not fed from
+/// something else: `abandoned_non_finite_timeline == 1` alone is satisfied by any expression
+/// that happens to equal 1 here.
+///
+/// Mutation (run): set the field from `unfinished_segments` (`acc.abandoned_non_finite_timeline
+/// += 1` → `= acc.unfinished_segments + 1`, or record inside the driver instead of the guard)
+/// → either the count or one of the four controls moves and this fires.
+#[test]
+fn an_abandoned_walk_leaves_every_started_segment_counter_at_zero() {
+    let (stats, _) = static_walk(&nan_dose_time_subject("bad"));
+    assert_eq!(stats.abandoned_non_finite_timeline, 1, "{stats:?}");
+    // All four describe a segment that began. None can fire on a walk that never called a
+    // driver, so a non-zero value here means the counter above is coming from somewhere else.
+    assert_eq!(stats.unfinished_segments, 0, "{stats:?}");
+    assert_eq!(stats.stiff_aborted_segments, 0, "{stats:?}");
+    assert_eq!(stats.discarded_clamped_steps, 0, "{stats:?}");
+    assert_eq!(stats.discarded_unfinished_segments, 0, "{stats:?}");
+}
+
+/// T4 — the wiring, end to end. `fit()` on a population carrying one `NaN`-dose-time subject
+/// must come back *saying so*.
+///
+/// Measured at `cf32e1fd`, before this change: `ofv = NaN`, five warnings, and the only
+/// substantive two were about EPS shrinkage and IWRES autocorrelation. `ode_solver` was
+/// `None`. Nothing named the subject, the timeline, or `NaN`.
+///
+/// Mutation (run): drop `|| abandoned > 0` from `unclean` in `ode_solver_diagnostics_warning`
+/// → the warning is `None` again and the first assert fires.
+#[test]
+fn a_fit_over_an_unorderable_timeline_says_so() {
+    let model = two_state_model(1.0);
+    let pop = Population {
+        subjects: vec![nan_dose_time_subject("bad"), subject("2", 1.2)],
+        covariate_names: Vec::new(),
+        dv_column: "DV".into(),
+        input_columns: Vec::new(),
+        exclusions: None,
+        warnings: Vec::new(),
+    };
+    // The premise: nothing upstream rejects this population, so the diagnostic is the only
+    // thing that can report it (#1286 checks dose attributes, not record times).
+    assert!(
+        crate::api::validation::check_model_data(&model, &pop).is_empty(),
+        "the fixture must reach the engines — if a data check now rejects it, this test is \
+         pinning the wrong path"
+    );
+
+    let result = fit(&model, &pop, &model.default_params, &one_iteration_opts()).expect("fit");
+    let entry = ode_solver_entry(&result)
+        .expect("a fit whose predictions are NaN by construction must carry an ode_solver warning");
+    let abandoned = entry.details.as_ref().unwrap()["abandoned_non_finite_timeline"]
+        .as_u64()
+        .unwrap();
+    // Exactly three, not `> 0`, and the difference is the point. Measured inside the fit's own
+    // `SolverStatsScope`: the one bad subject is abandoned **three times** in the post-fit
+    // sweep — twice at `ode_predictions_with_extra_breaks_and_stats` and once at
+    // `ode_predictions_with_states`. A `> 0` assertion is therefore satisfied by either site
+    // alone, so deleting either recorder would leave this test green (the redundant-gate hole);
+    // pinning the count makes each site load-bearing here too, and it is the measurement behind
+    // the message's "counts walks, not subjects" clause.
+    assert_eq!(
+        abandoned, 3,
+        "one NaN-timeline subject is abandoned once per prediction walk the post-fit sweep \
+         makes over it — measured as 3 (ode_predictions ×2, ode_predictions_with_states ×1). \
+         A different number means the sweep changed which engines it drives, or a recorder \
+         was dropped: {entry:?}"
+    );
+    assert!(
+        entry
+            .message
+            .contains(&format!("{abandoned} solver walk(s)")),
+        "the message must name the count, not only the details payload: {}",
+        entry.message
+    );
+    assert!(
+        entry.message.contains("could not be ordered"),
+        "the message must say what happened: {}",
+        entry.message
+    );
+    assert_eq!(
+        entry.severity,
+        WarningSeverity::Warning,
+        "NaN predictions are not an informational note: {entry:?}"
+    );
+    // The controls again, through the real fit rather than a hand-built stats block.
+    let d = entry.details.as_ref().unwrap();
+    for key in [
+        "unfinished_segments",
+        "stiff_aborted_segments",
+        "discarded_clamped_steps",
+        "discarded_unfinished_segments",
+    ] {
+        assert_eq!(
+            d[key].as_u64().unwrap(),
+            0,
+            "{key} must stay zero on an abandoned walk: {entry:?}"
+        );
+    }
+    assert!(
+        result.warnings.iter().any(|w| w.contains("W_ODE_SOLVER_")),
+        "the plain-text warnings must carry it too: {:?}",
+        result.warnings
+    );
+}

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -263,6 +263,7 @@ pub fn solve_ekf(
     // caller's default point, so overwrite it with NaN ipreds rather than returning a
     // finite-looking filter pass built on a timeline that could not be ordered.
     if crate::ode::predictions::timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         // `fill`, not a per-field loop: one spelling of the struct, so a field added to
         // `EkfObsPoint` cannot be left at its default here while the others go NaN.
         results.fill(EkfObsPoint {

--- a/src/ode/ekf.rs
+++ b/src/ode/ekf.rs
@@ -262,8 +262,7 @@ pub fn solve_ekf(
     // `ode::predictions::timeline_has_non_finite`. `results` is prefilled with the
     // caller's default point, so overwrite it with NaN ipreds rather than returning a
     // finite-looking filter pass built on a timeline that could not be ordered.
-    if crate::ode::predictions::timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if crate::ode::predictions::abandon_non_finite_timeline(break_times.iter().copied(), None) {
         // `fill`, not a per-field loop: one spelling of the struct, so a field added to
         // `EkfObsPoint` cannot be left at its default here while the others go NaN.
         results.fill(EkfObsPoint {
@@ -1408,6 +1407,10 @@ mod tests {
              detecting a non-total comparator, or this cannot fail"
         );
         let pk = make_pk(1.0, 10.0);
+        // Inside a `SolverStatsScope` so the #1234 counter is observable: this walk's
+        // recorder is its own site, and no other test in the tree can see it (the fit-level
+        // sweep never drives the EKF). Without the scope the call is unchanged.
+        let scope = crate::ode::solver::SolverStatsScope::enter();
         let got = solve_ekf(
             &one_cpt_rhs,
             1,
@@ -1421,10 +1424,24 @@ mod tests {
             &vec![1.0; obs_times.len()],
             OdeSolverOptions::default(),
         );
+        let stats = scope.collected();
         assert!(
             got.iter().all(|p| !p.ipred.is_finite()),
             "a non-finite timeline must give non-finite EKF ipreds, not a finite pass \
              with the bad dose silently dropped"
+        );
+        // Mutation: delete `ekf.rs`'s `abandon_non_finite_timeline` record (or route it
+        // through the bare predicate again) → this fires naming the EKF walk, and no other
+        // test in the tree moves.
+        assert_eq!(
+            stats.abandoned_non_finite_timeline, 1,
+            "the EKF walk must record its abandoned walk too — it has its own guard and its \
+             own return, and nothing else drives it: {stats:?}"
+        );
+        assert_eq!(
+            stats.attempted_steps, 0,
+            "EKF walk: nothing was integrated, so the step counters must stay zero — that is \
+             why the abandoned counter has to exist: {stats:?}"
         );
     }
 

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -273,6 +273,42 @@ pub(crate) fn times_have_non_finite(mut times: impl Iterator<Item = f64>) -> boo
     times.any(|t| !t.is_finite())
 }
 
+/// **The engine guard: `true` when this walk must be abandoned, and the abandonment recorded.**
+///
+/// The predicate and the counter are deliberately one call (#1234). Nothing about
+/// [`timeline_has_non_finite`] makes recording structural, and the counter is only worth
+/// having if every abandoning engine bumps it: a ninth guard written as a bare predicate would
+/// compile, run, and put the diagnostic back to `0/0/0` for that walk — indistinguishable from
+/// a subject there was nothing to integrate for, which is the whole defect. Going through here
+/// makes forgetting impossible rather than conventional, and
+/// `the_bare_timeline_predicates_are_not_called_outside_this_guard` fails if a new call site
+/// takes the bare spelling.
+///
+/// `times` is an iterator so the dense builders (`break_times.iter().copied()`) and the
+/// event-driven ones (`timeline.iter().map(|e| e.0)`) share one definition; `stats` is the
+/// caller's out-parameter where it has one — `Some` only in
+/// `ode_predictions_with_extra_breaks_and_stats`, whose public wrapper
+/// [`ode_predictions_with_solver_stats`] returns it. See
+/// [`crate::ode::solver::record_abandoned_non_finite_timeline`] for why both channels are fed.
+///
+/// **Deliberately not used by the two `sens/ode_provider.rs` walks**, which carry the same
+/// predicate and do *not* record: their sweep is collected in its own scope from which
+/// `fit_inner` copies one unrelated field, so a gradient-solve event deposited here would be
+/// discarded or fire a prediction-shaped warning clause. That exclusion is the guard test's
+/// only allowance, and it is stated there.
+#[inline]
+pub(crate) fn abandon_non_finite_timeline(
+    times: impl Iterator<Item = f64>,
+    stats: Option<&mut crate::ode::solver::OdeSolverStats>,
+) -> bool {
+    if times_have_non_finite(times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline(stats);
+        true
+    } else {
+        false
+    }
+}
+
 // Dose resolution + SS-equilibration primitives moved to `crate::dosing` (a neutral
 // leaf module) so pk/sens/api don't depend upward on ode/. A PRIVATE import (NOT a
 // `pub(crate) use` re-export) so these do not leak back out as `crate::ode::…` — the
@@ -3393,8 +3429,7 @@ fn ode_predictions_with_extra_breaks_and_stats(
     // Ordered **before** the #1223 fill below, deliberately: on a broken timeline every record
     // must be repelled, and filling first would hand a pre-start `TENTRY` the seeded state — a
     // scored `H = 0` — on a subject whose integration never happened.
-    if timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(break_times.iter().copied(), stats.as_deref_mut()) {
         return (predictions, chz_states);
     }
 
@@ -4437,8 +4472,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
     // it uses that rather than returning a NaN run the caller must re-diagnose. Placed
     // before the #700 exact-bit guards below, whose message would otherwise name the
     // wrong cause for a `NaN` time.
-    if timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(break_times.iter().copied(), None) {
         return Err(
             "ode_predictions_adaptive: a non-finite break time (NaN/infinite dose lagtime, \
              route lag, or infusion duration) — the subject's timeline cannot be ordered"
@@ -5417,8 +5451,7 @@ fn adaptive_frozen_replay_tv(
     break_times.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
     // A non-finite break time makes the subject non-finite (#1189); `predictions` is
     // NaN-prefilled, matching what the driver this verifies now reports as an `Err`.
-    if timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(break_times.iter().copied(), None) {
         return predictions;
     }
     if break_times.len() < 2 {
@@ -6003,8 +6036,7 @@ pub fn ode_predictions_event_driven(
     // dispatches typed events by index and so never re-applies a dose, but a `NaN` time
     // still sorts to the end and its event is silently never reached — the same silent
     // drop the dense engines get, reported the same way (`predictions` is NaN-prefilled).
-    if times_have_non_finite(timeline.iter().map(|e| e.0)) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(timeline.iter().map(|e| e.0), None) {
         return predictions;
     }
 
@@ -6542,8 +6574,7 @@ pub fn ode_predictions_with_states(
     break_times.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
     // A non-finite break time makes the subject non-finite (#1189); both outputs are
     // NaN-prefilled, so this returns exactly that.
-    if timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(break_times.iter().copied(), None) {
         return (predictions, states);
     }
 
@@ -7111,8 +7142,7 @@ pub fn ode_dense_solve_states(
     // A non-finite break time makes the subject non-finite (#1189); `result` is
     // NaN-prefilled, so the caller's finiteness guard sees a diverged solve rather than
     // a plausible-looking trajectory with the NaN-lagged dose silently missing.
-    if timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(break_times.iter().copied(), None) {
         return result;
     }
 
@@ -7356,8 +7386,7 @@ pub(crate) fn ode_solve_until_chz_threshold(
     // code: the walk would proceed on a timeline the bad dose had been deleted from,
     // never apply it, and return a finite crossing time — the silent-wrong-number
     // outcome, on the one engine whose typed failure was supposed to make it loud.
-    if timeline_has_non_finite(&break_times) {
-        crate::ode::solver::record_abandoned_non_finite_timeline();
+    if abandon_non_finite_timeline(break_times.iter().copied(), None) {
         return ThresholdOutcome::SolveFailed("non-finite break time".to_string());
     }
     break_times.retain(|&t| t <= horizon + 1e-15);

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -3394,6 +3394,7 @@ fn ode_predictions_with_extra_breaks_and_stats(
     // must be repelled, and filling first would hand a pre-start `TENTRY` the seeded state — a
     // scored `H = 0` — on a subject whose integration never happened.
     if timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return (predictions, chz_states);
     }
 
@@ -4437,6 +4438,7 @@ pub(crate) fn ode_predictions_adaptive_impl(
     // before the #700 exact-bit guards below, whose message would otherwise name the
     // wrong cause for a `NaN` time.
     if timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return Err(
             "ode_predictions_adaptive: a non-finite break time (NaN/infinite dose lagtime, \
              route lag, or infusion duration) — the subject's timeline cannot be ordered"
@@ -5416,6 +5418,7 @@ fn adaptive_frozen_replay_tv(
     // A non-finite break time makes the subject non-finite (#1189); `predictions` is
     // NaN-prefilled, matching what the driver this verifies now reports as an `Err`.
     if timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return predictions;
     }
     if break_times.len() < 2 {
@@ -6001,6 +6004,7 @@ pub fn ode_predictions_event_driven(
     // still sorts to the end and its event is silently never reached — the same silent
     // drop the dense engines get, reported the same way (`predictions` is NaN-prefilled).
     if times_have_non_finite(timeline.iter().map(|e| e.0)) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return predictions;
     }
 
@@ -6539,6 +6543,7 @@ pub fn ode_predictions_with_states(
     // A non-finite break time makes the subject non-finite (#1189); both outputs are
     // NaN-prefilled, so this returns exactly that.
     if timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return (predictions, states);
     }
 
@@ -7107,6 +7112,7 @@ pub fn ode_dense_solve_states(
     // NaN-prefilled, so the caller's finiteness guard sees a diverged solve rather than
     // a plausible-looking trajectory with the NaN-lagged dose silently missing.
     if timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return result;
     }
 
@@ -7351,6 +7357,7 @@ pub(crate) fn ode_solve_until_chz_threshold(
     // never apply it, and return a finite crossing time — the silent-wrong-number
     // outcome, on the one engine whose typed failure was supposed to make it loud.
     if timeline_has_non_finite(&break_times) {
+        crate::ode::solver::record_abandoned_non_finite_timeline();
         return ThresholdOutcome::SolveFailed("non-finite break time".to_string());
     }
     break_times.retain(|&t| t <= horizon + 1e-15);

--- a/src/ode/predictions_tests.rs
+++ b/src/ode/predictions_tests.rs
@@ -10320,6 +10320,114 @@ mod break_collision_1186 {
         }
     }
 
+    /// **#1234 — each of the four engines records its own abandoned walk.**
+    ///
+    /// The test above pins the *outcome* (non-finite predictions) across all four at once;
+    /// this pins the *diagnostic*, per engine, in its own `SolverStatsScope`. Per engine
+    /// because each has its own guard and its own return, so a shared assertion would be
+    /// satisfied by any one of them — and the failure message has to name which recorder
+    /// stopped recording, or the mutation cannot be attributed (CLAUDE.md: mutate each side
+    /// of a twin separately).
+    ///
+    /// The straddle is the second half of each arm: the same engine on the same fixture with
+    /// a finite lag must record nothing and must actually integrate. Without it a recorder
+    /// that fired unconditionally would pass.
+    ///
+    /// Mutation (run): revert any one engine's `abandon_non_finite_timeline` to the bare
+    /// `timeline_has_non_finite` → that engine's arm fires by name and the other three stay
+    /// green.
+    #[test]
+    fn every_dense_engine_records_its_own_abandoned_walk() {
+        let ode = spec();
+        let obs = vec![8.2001, 12.0];
+        let bad = pk(f64::NAN, 0.3);
+        let good = pk(7.9, 0.3);
+        let s = make_subject(doses(8.2), obs.clone());
+        let mk = |v: &[f64]| PkParams {
+            values: v.try_into().unwrap(),
+        };
+
+        // One closure per engine, so each recorder is exercised alone. `stats_in_scope`
+        // returns what the thread-local sink saw while exactly that engine ran.
+        let stats_in_scope = |f: &dyn Fn(&[f64]) -> Vec<f64>, pkv: &[f64]| {
+            let scope = crate::ode::solver::SolverStatsScope::enter();
+            let out = f(pkv);
+            (scope.collected(), out)
+        };
+        let dense = |pkv: &[f64]| ode_predictions(&ode, pkv, &[], &[], &s);
+        let with_states = |pkv: &[f64]| {
+            ode_predictions_with_states(&ode, pkv, &[], &[], &s)
+                .1
+                .iter()
+                .map(|u| u[1])
+                .collect::<Vec<f64>>()
+        };
+        let dense_states = |pkv: &[f64]| {
+            ode_dense_solve_states(&ode, pkv, &[], &[], &s, &obs)
+                .iter()
+                .map(|u| u[1])
+                .collect::<Vec<f64>>()
+        };
+        let event_driven = |pkv: &[f64]| {
+            let pk_d: Vec<PkParams> = s.doses.iter().map(|_| mk(pkv)).collect();
+            let pk_o: Vec<PkParams> = s.obs_times.iter().map(|_| mk(pkv)).collect();
+            ode_predictions_event_driven(&ode, &s, &[], &[], &pk_d, &pk_o, &[], &[])
+        };
+        // Aliased rather than written inline: the bare `&dyn Fn(&[f64]) -> Vec<f64>` array type
+        // trips `clippy::type_complexity`.
+        type EngineFn<'a> = &'a dyn Fn(&[f64]) -> Vec<f64>;
+        let engines: [(&str, EngineFn); 4] = [
+            (ENGINES[0], &dense),
+            (ENGINES[1], &with_states),
+            (ENGINES[2], &dense_states),
+            (ENGINES[3], &event_driven),
+        ];
+
+        for (name, f) in engines {
+            let (stats, out) = stats_in_scope(f, &bad);
+            // `.all()` is vacuously true on an empty `out`, and an abandoned walk returning
+            // nothing at all is a plausible future state — so the length comes first.
+            assert_eq!(
+                out.len(),
+                obs.len(),
+                "[{name}] the engine must return one value per observation: {out:?}"
+            );
+            assert!(
+                out.iter().all(|g| !g.is_finite()),
+                "[{name}] the fixture must actually be abandoned, got {out:?}"
+            );
+            assert_eq!(
+                stats.abandoned_non_finite_timeline, 1,
+                "[{name}] this engine's guard must record the abandoned walk: {stats:?}"
+            );
+            assert_eq!(
+                stats.attempted_steps, 0,
+                "[{name}] nothing was integrated, so the step counters must stay zero — that \
+                 is why the abandoned counter has to exist: {stats:?}"
+            );
+
+            let (clean, out) = stats_in_scope(f, &good);
+            assert_eq!(
+                out.len(),
+                obs.len(),
+                "[{name}] the control must return one value per observation: {out:?}"
+            );
+            assert!(
+                out.iter().all(|g| g.is_finite()),
+                "[{name}] the control fixture must actually integrate, got {out:?}"
+            );
+            assert_eq!(
+                clean.abandoned_non_finite_timeline, 0,
+                "[{name}] a finite lag is not an abandoned walk: {clean:?}"
+            );
+            assert!(
+                clean.attempted_steps > 0,
+                "[{name}] the control must actually integrate, or it separates nothing: \
+                 {clean:?}"
+            );
+        }
+    }
+
     /// A long timeline through every ODE engine, with a non-finite lag.
     ///
     /// Two distinct traps live here. `partial_cmp(..).unwrap()` — what these builders
@@ -10395,12 +10503,54 @@ mod break_collision_1186 {
         ] {
             let pkv = pk(route_lag, alag1);
             let s = make_subject(doses(8.2), obs.clone());
+            // In a scope so the #1234 recorder on this engine is observable: this is the
+            // event-time search, reached in production only from `simulate()`'s latent-event
+            // draw, and nothing else in the suite can see its counter.
+            let scope = crate::ode::solver::SolverStatsScope::enter();
             let got = ode_solve_until_chz_threshold(&ode, &pkv, &s, 1, 0.5, 24.0);
+            let stats = scope.collected();
             assert!(
                 matches!(got, ThresholdOutcome::SolveFailed(_)),
                 "[{label}] a non-finite timeline must be a typed SolveFailed, got {got:?}"
             );
+            // Mutation: revert this engine's `abandon_non_finite_timeline` to the bare
+            // predicate → this fires and the `SolveFailed` assert above stays green, which
+            // is the point: the typed failure and the counter are separate obligations.
+            assert_eq!(
+                stats.abandoned_non_finite_timeline, 1,
+                "[{label}] the CHZ event-time search must record its abandoned walk: {stats:?}"
+            );
         }
+
+        // The straddle, on the engine's own control: a finite timeline must solve and record
+        // nothing. Without it a recorder that fired on every call would pass above.
+        let s = make_subject(doses(8.2), obs.clone());
+        let scope = crate::ode::solver::SolverStatsScope::enter();
+        let got = ode_solve_until_chz_threshold(&ode, &pk(7.9, 0.3), &s, 1, 0.5, 24.0);
+        let clean = scope.collected();
+        assert!(
+            !matches!(got, ThresholdOutcome::SolveFailed(_)),
+            "the control must actually solve, got {got:?}"
+        );
+        assert_eq!(
+            clean.abandoned_non_finite_timeline, 0,
+            "a finite timeline is not an abandoned walk: {clean:?}"
+        );
+        // No `attempted_steps > 0` here, and the reason is a property of *this* engine worth
+        // recording: the threshold search runs on `solver::solve_ode_until_threshold`, its own
+        // driver, which does not go through `integrate_resolved_g`'s `STATS_SINK` tee — so its
+        // step counters never reach the scope and read `0` on a solve that worked (measured).
+        // The proof that the control actually ran is therefore the outcome asserted above, not
+        // the counters. It also means that on this one engine the step counters cannot serve as
+        // the "abandoned vs nothing to integrate" discriminator the way they do everywhere
+        // else; the new counter is the only thing that separates them here.
+        assert_eq!(
+            clean.attempted_steps, 0,
+            "this engine's own driver does not tee into the stats sink, so its step counters \
+             stay zero even on a solve that worked. If this is now non-zero the tee has been \
+             widened and the comment above (and the control's proof of life) needs revisiting: \
+             {clean:?}"
+        );
     }
 
     /// The control for the test above: the *same* engine on the *same* fixture with a
@@ -11921,4 +12071,265 @@ fn ss_monotone_run_in_anchor_is_the_same_with_an_empty_lag_slice() {
             "segment {m}: anchor {with_empty}, expected the pulse at {seg_start}"
         );
     }
+}
+
+// ── #1234: every engine that abandons an unorderable timeline must say so ────────────
+//
+// The counter (`OdeSolverStats::abandoned_non_finite_timeline`) is only worth having if
+// *every* abandoning walk bumps it: a walk that returns `NaN` predictions while leaving the
+// whole stats block at zero is indistinguishable from a subject there was nothing to
+// integrate for, which is the reading #1234 exists to remove. The four dense / event-driven
+// engines are covered next to their own guards in `break_collision_1186`; the two adaptive
+// walks are here, where the driver and its frozen replay are already driven directly.
+
+/// The **reactive driver**'s guard (`ode_predictions_adaptive_impl`) records too.
+///
+/// Its own site, and reachable from nowhere else in the test suite: the driver runs only
+/// under `simulate()`, which opens no `SolverStatsScope`, so nothing in the fit-level sweep
+/// can observe it. Driving it here in an explicit scope is what makes the recorder
+/// mutation-visible at all.
+///
+/// The straddle is the second half: the *same* driver on the *same* fixture with a finite
+/// dose time must record nothing, so this cannot pass on a counter that fires on every run.
+///
+/// Mutation: delete the record at `ode_predictions_adaptive_impl`'s guard (route it through
+/// the bare `timeline_has_non_finite` again) → the abandoned arm reads 0 and the first
+/// assert fires naming the driver; no other test in the tree moves.
+#[test]
+fn the_adaptive_driver_records_an_abandoned_walk() {
+    let ode = one_cpt_ode_spec();
+    let event_pk = crate::pk::EventPkParams {
+        dose: vec![pk_one(1.0, 10.0)],
+        obs: vec![pk_one(1.0, 10.0); 2],
+        pk_only: Vec::new(),
+        reset: Vec::new(),
+    };
+    let mut decide = |_ctx: &ControllerCtx| ControllerDecision {
+        actions: vec![DoseAction::Bolus { amt: 100.0, cmt: 1 }],
+        rule: None,
+    };
+    let run_at = |dose_time: f64, decide: &mut dyn FnMut(&ControllerCtx) -> ControllerDecision| {
+        let base = make_subject(
+            vec![DoseEvent::new(dose_time, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 4.0],
+        );
+        let scope = crate::ode::solver::SolverStatsScope::enter();
+        let out = ode_predictions_adaptive_impl(
+            &ode,
+            &event_pk.obs[0].values,
+            Some(&event_pk),
+            None,
+            None,
+            &[],
+            &[],
+            &base,
+            &[0.0],
+            &[],
+            decide,
+            100,
+            None,
+        );
+        (scope.collected(), out)
+    };
+
+    let (stats, out) = run_at(f64::NAN, &mut decide);
+    let err = out.expect_err("a NaN dose time must be the driver's typed error");
+    assert!(
+        err.contains("cannot be ordered"),
+        "the driver must reject it for the timeline, not for something else: {err}"
+    );
+    assert_eq!(
+        stats.abandoned_non_finite_timeline, 1,
+        "the adaptive driver must record its abandoned walk — its guard is its own site and \
+         no other test drives it: {stats:?}"
+    );
+    assert_eq!(
+        stats.attempted_steps, 0,
+        "adaptive driver: nothing was integrated, so the step counters must stay zero: \
+         {stats:?}"
+    );
+
+    // The straddle: same engine, same fixture, orderable timeline.
+    let (clean, out) = run_at(0.0, &mut decide);
+    out.expect("the control fixture must actually run");
+    assert_eq!(
+        clean.abandoned_non_finite_timeline, 0,
+        "a finite dose time is not an abandoned walk: {clean:?}"
+    );
+    assert!(
+        clean.attempted_steps > 0,
+        "the control must actually integrate, or it does not separate anything: {clean:?}"
+    );
+}
+
+/// The **frozen-schedule replay verifier**'s guard (`adaptive_frozen_replay_tv`) records too.
+///
+/// A separate site from the driver's, in a separate function, returning a NaN-prefilled
+/// `Vec<f64>` rather than an `Err` — and the replay is only ever reached from
+/// `verify_adaptive_frozen_replay`, i.e. under `simulate()` in a debug build. Nothing else in
+/// the suite can see this recorder.
+///
+/// Mutation: delete the record at `adaptive_frozen_replay_tv`'s guard → the first assert
+/// fires naming the replay; `the_adaptive_driver_records_an_abandoned_walk` stays green.
+#[test]
+fn the_adaptive_frozen_replay_records_an_abandoned_walk() {
+    let ode = one_cpt_ode_spec();
+    let event_pk = crate::pk::EventPkParams {
+        dose: vec![pk_one(1.0, 10.0)],
+        obs: vec![pk_one(1.0, 10.0); 2],
+        pk_only: Vec::new(),
+        reset: Vec::new(),
+    };
+    let replay_at = |dose_time: f64| {
+        let subject = make_subject(
+            vec![DoseEvent::new(dose_time, 100.0, 1, 0.0, false, 0.0)],
+            vec![1.0, 4.0],
+        );
+        let scope = crate::ode::solver::SolverStatsScope::enter();
+        let preds =
+            adaptive_frozen_replay_tv(&ode, &event_pk, None, None, &[], &[], &subject, &[1.0], &[]);
+        (scope.collected(), preds)
+    };
+
+    let (stats, preds) = replay_at(f64::NAN);
+    // Length first: `.all()` on an empty `preds` asserts nothing.
+    assert_eq!(
+        preds.len(),
+        2,
+        "the replay must return both observations: {preds:?}"
+    );
+    assert!(
+        preds.iter().all(|p| p.is_nan()),
+        "the replay must come back NaN-prefilled on an unorderable timeline, got {preds:?}"
+    );
+    assert_eq!(
+        stats.abandoned_non_finite_timeline, 1,
+        "the frozen replay must record its abandoned walk — its own guard, its own return: \
+         {stats:?}"
+    );
+    assert_eq!(
+        stats.attempted_steps, 0,
+        "frozen replay: nothing was integrated, so the step counters must stay zero: {stats:?}"
+    );
+
+    let (clean, preds) = replay_at(0.0);
+    assert_eq!(
+        preds.len(),
+        2,
+        "the control must return both observations: {preds:?}"
+    );
+    assert!(
+        preds.iter().all(|p| p.is_finite()),
+        "the control fixture must actually integrate, got {preds:?}"
+    );
+    assert_eq!(
+        clean.abandoned_non_finite_timeline, 0,
+        "a finite dose time is not an abandoned walk: {clean:?}"
+    );
+    assert!(
+        clean.attempted_steps > 0,
+        "the control must actually integrate, or it does not separate anything: {clean:?}"
+    );
+}
+
+/// **The pairing is structural, not conventional (#1234 §5).**
+///
+/// `timeline_has_non_finite` / `times_have_non_finite` decide *whether* a walk is abandoned;
+/// [`abandon_non_finite_timeline`](crate::ode::predictions::abandon_non_finite_timeline) also
+/// *records* it. Nothing in the type system stops a ninth guard from taking the bare
+/// predicate — it would compile, run, and silently put the diagnostic back to `0/0/0` for
+/// that walk, which is exactly the defect the counter exists to remove. Per-site tests cannot
+/// close that: they can only cover sites that already exist.
+///
+/// So the call sites are pinned. The bare predicates may be called from **two** places, and
+/// this lists both rather than allowing a directory:
+///
+/// * `src/ode/predictions.rs` — twice, and both inside the shared helpers themselves
+///   (`timeline_has_non_finite`'s one-line body, and `abandon_non_finite_timeline`'s test).
+///   A third would be a guard that bypassed the recorder.
+/// * `src/sens/ode_provider.rs` — twice, the two analytic-sensitivity walks, which carry the
+///   same predicate and deliberately do **not** record: their sweep is collected in a
+///   separate scope from which `fit_inner` copies one unrelated field, so an event deposited
+///   there would be discarded or fire a prediction-shaped warning clause. Documented at both
+///   guards and on the counter's own field doc.
+///
+/// Exact counts, not a floor: a removed allowance has to be re-stated here too, so the
+/// exclusion cannot quietly widen or vanish.
+///
+/// Mutation (run): revert any one of the eight engine guards to
+/// `timeline_has_non_finite(&break_times)` → `src/ode/predictions.rs` reads 3 and this fires
+/// naming the file. Adding a bare call in a new file fires with that file named.
+#[test]
+fn the_bare_timeline_predicates_are_not_called_outside_this_guard() {
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+        for entry in std::fs::read_dir(dir).expect("readable directory") {
+            let path = entry.expect("readable dir entry").path();
+            if path.is_dir() {
+                rust_sources(&path, out);
+            } else if path.extension().and_then(|e| e.to_str()) == Some("rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut files = Vec::new();
+    rust_sources(&root.join("src"), &mut files);
+    files.sort();
+    assert!(
+        files.len() > 100,
+        "the scan found only {} files under src/ — it is measuring the walk, not the code",
+        files.len()
+    );
+
+    let mut seen_name: BTreeMap<&str, usize> = BTreeMap::new();
+    let mut calls: BTreeMap<String, usize> = BTreeMap::new();
+    for file in &files {
+        let text = std::fs::read_to_string(file).expect("readable source");
+        let rel = file
+            .strip_prefix(&root)
+            .expect("under the manifest dir")
+            .to_string_lossy()
+            .replace('\\', "/");
+        for line in text.lines() {
+            // Comments are where these names legitimately appear everywhere — the guards'
+            // own prose, the mutation notes, the field doc. Only code counts.
+            let code = line.split("//").next().unwrap_or("");
+            for name in ["timeline_has_non_finite", "times_have_non_finite"] {
+                // `fn <name>(` is the definition, not a call.
+                let defined = code.contains(&format!("fn {name}("));
+                if code.contains(&format!("{name}(")) && !defined {
+                    *seen_name.entry(name).or_default() += 1;
+                    *calls.entry(rel.clone()).or_default() += 1;
+                }
+            }
+        }
+    }
+
+    // Non-degeneracy: a rename that made the scan match nothing would otherwise pass.
+    assert_eq!(
+        seen_name.len(),
+        2,
+        "both predicate names must still be called somewhere, or this test is scanning for \
+         strings that no longer exist: {seen_name:?}"
+    );
+
+    let expected: BTreeMap<String, usize> = [
+        ("src/ode/predictions.rs".to_string(), 2),
+        ("src/sens/ode_provider.rs".to_string(), 2),
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(
+        calls, expected,
+        "the bare non-finite-timeline predicates are called somewhere new. An engine guard \
+         must go through `abandon_non_finite_timeline`, which records the abandoned walk as \
+         well as detecting it — a bare call compiles and runs but leaves the #1234 counter at \
+         zero for that walk, which is indistinguishable from a subject there was nothing to \
+         integrate for. If the new call really is a non-recording site (the two `sens/` \
+         gradient walks are), add it here with the reason."
+    );
 }

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -661,13 +661,28 @@ pub struct OdeSolverStats {
     /// `ode_predictions_with_states` once). Zero on every well-formed fit, so any non-zero value
     /// means some subject's predictions are `NaN` by construction.
     ///
-    /// Recorded on all eight `f64` engine sites — the four dense / event-driven prediction
-    /// walks, the adaptive driver and its frozen replay, the EKF walk, and
-    /// `ode_solve_until_chz_threshold`'s event-time solve, which is not a prediction walk but is
-    /// abandoned for the same reason and would otherwise be the one silent hole. The two
-    /// analytic-sensitivity walks
-    /// (`sens::ode_provider`) carry the same guard but deliberately do **not** bump it: their
-    /// sweep is collected in its own scope from which `fit_inner` copies exactly one field
+    /// Recorded on all eight `f64` engine sites, through
+    /// `ode::predictions::abandon_non_finite_timeline` — the predicate and this counter are one
+    /// call, so a ninth guard cannot be written that detects an unorderable timeline without
+    /// reporting it (pinned by
+    /// `the_bare_timeline_predicates_are_not_called_outside_this_guard`). The eight are the four
+    /// dense / event-driven prediction walks, the adaptive driver and its frozen replay, the EKF
+    /// walk, and `ode_solve_until_chz_threshold`'s event-time solve.
+    ///
+    /// **Three of the eight cannot fire in production today, and that is scope, not an
+    /// oversight.** Outside tests, `SolverStatsScope::enter` appears in exactly two places in
+    /// the tree, both in `api::fit`; `simulate.rs`, `predict.rs` and `sim/adaptive.rs` open
+    /// none. So the adaptive driver, its frozen replay and the CHZ event-time solve — reached
+    /// only under `simulate()` — record into an inactive sink and contribute nothing to any
+    /// warning. They carry the recorder so that wiring a scope onto those paths is a one-line
+    /// change rather than a re-audit, and each is exercised in an explicit scope by its own
+    /// test. Nor is the CHZ one "the one silent hole" it was described as before this
+    /// correction: its sole production caller (`survival::draw_ode_tte_latent`) `panic!`s on
+    /// `SolveFailed`, which is the loudest outcome of the eight.
+    ///
+    /// The two analytic-sensitivity walks (`sens::ode_provider`) carry the same predicate and
+    /// deliberately do **not** bump this: their sweep is collected in its own scope from which
+    /// `fit_inner` copies exactly one field
     /// ([`auto_stiff_rejected_jets`](Self::auto_stiff_rejected_jets)), so a gradient-solve event
     /// deposited here would either be discarded or — if that copy were widened — fire a warning
     /// clause about predictions.

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -642,6 +642,36 @@ pub struct OdeSolverStats {
     /// Of [`unfinished_segments`](Self::unfinished_segments), the attempts discarded by the
     /// `auto` escalation guard before it re-solved the segment explicitly.
     pub discarded_unfinished_segments: usize,
+    /// Engine walks abandoned **before integrating** because their timeline could not be
+    /// ordered — a `NaN`/`inf` dose time, lagtime, route lag or infusion duration
+    /// (`ode::predictions::timeline_has_non_finite`, #1189).
+    ///
+    /// The odd one out, and deliberately: every other counter here reports work that *happened*,
+    /// so an abandoned walk leaves all of them at zero. That reading is not distinguishable from
+    /// a subject there was nothing to integrate for — measured on one model in a
+    /// `SolverStatsScope`, a normal subject read `attempted/accepted/rejected = 7/7/0` while a
+    /// non-finite timeline, a subject with no records, and a subject with a single observation at
+    /// `t = 0` all read `0/0/0`, returning `[NaN, NaN, NaN, NaN]`, `[]` and `[0.0]` respectively
+    /// (#1234). This counter is what separates the first of those three from the other two.
+    ///
+    /// Counted **once per abandoned walk**, not per subject and not per segment — the honest
+    /// count of trajectories that were never integrated. A post-fit sweep drives more than one
+    /// engine over the same subject, so one bad subject contributes more than one: measured at
+    /// **3** on a plain two-subject FOCEI fit (`ode_predictions` twice,
+    /// `ode_predictions_with_states` once). Zero on every well-formed fit, so any non-zero value
+    /// means some subject's predictions are `NaN` by construction.
+    ///
+    /// Recorded on all eight `f64` engine sites — the four dense / event-driven prediction
+    /// walks, the adaptive driver and its frozen replay, the EKF walk, and
+    /// `ode_solve_until_chz_threshold`'s event-time solve, which is not a prediction walk but is
+    /// abandoned for the same reason and would otherwise be the one silent hole. The two
+    /// analytic-sensitivity walks
+    /// (`sens::ode_provider`) carry the same guard but deliberately do **not** bump it: their
+    /// sweep is collected in its own scope from which `fit_inner` copies exactly one field
+    /// ([`auto_stiff_rejected_jets`](Self::auto_stiff_rejected_jets)), so a gradient-solve event
+    /// deposited here would either be discarded or — if that copy were widened — fire a warning
+    /// clause about predictions.
+    pub abandoned_non_finite_timeline: usize,
 }
 
 impl OdeSolverStats {
@@ -682,6 +712,7 @@ impl OdeSolverStats {
             stiff_aborted_segments,
             discarded_clamped_steps,
             discarded_unfinished_segments,
+            abandoned_non_finite_timeline,
         } = *other;
         self.attempted_steps += attempted_steps;
         self.accepted_steps += accepted_steps;
@@ -697,6 +728,7 @@ impl OdeSolverStats {
         self.stiff_aborted_segments += stiff_aborted_segments;
         self.discarded_clamped_steps += discarded_clamped_steps;
         self.discarded_unfinished_segments += discarded_unfinished_segments;
+        self.abandoned_non_finite_timeline += abandoned_non_finite_timeline;
     }
 
     /// Record an attempt that produced no usable step at `min_dt` (a singular Rosenbrock
@@ -1785,6 +1817,27 @@ fn record_to_stats_sink(stats: &OdeSolverStats) {
     STATS_SINK.with(|c| {
         if let Some(mut acc) = c.get() {
             acc.merge(stats);
+            c.set(Some(acc));
+        }
+    });
+}
+
+/// Note that a prediction walk was abandoned before integrating, because its timeline could
+/// not be ordered ([`OdeSolverStats::abandoned_non_finite_timeline`], #1234).
+///
+/// Bumps the active [`SolverStatsScope`] **directly** rather than merging a local
+/// `OdeSolverStats`, because the ordinary route into the sink is the tee inside
+/// [`integrate_resolved_g`] and this event is precisely the one where no integration is ever
+/// reached: the guard returns before a driver is called, so nothing would arrive there and the
+/// scope would read `0/0/0` — identical to a subject with no records at all.
+///
+/// Off the diagnostic path this is one `Cell` read, taken only inside a guard that has already
+/// fired on a subject whose predictions are `NaN` regardless.
+#[inline]
+pub(crate) fn record_abandoned_non_finite_timeline() {
+    STATS_SINK.with(|c| {
+        if let Some(mut acc) = c.get() {
+            acc.abandoned_non_finite_timeline += 1;
             c.set(Some(acc));
         }
     });

--- a/src/ode/solver.rs
+++ b/src/ode/solver.rs
@@ -1825,22 +1825,36 @@ fn record_to_stats_sink(stats: &OdeSolverStats) {
 /// Note that a prediction walk was abandoned before integrating, because its timeline could
 /// not be ordered ([`OdeSolverStats::abandoned_non_finite_timeline`], #1234).
 ///
-/// Bumps the active [`SolverStatsScope`] **directly** rather than merging a local
-/// `OdeSolverStats`, because the ordinary route into the sink is the tee inside
-/// [`integrate_resolved_g`] and this event is precisely the one where no integration is ever
-/// reached: the guard returns before a driver is called, so nothing would arrive there and the
-/// scope would read `0/0/0` — identical to a subject with no records at all.
+/// Reached through [`crate::ode::predictions::abandon_non_finite_timeline`], never called
+/// directly by a guard — the predicate and this record are one call so a ninth guard cannot be
+/// written without the counter.
+///
+/// **Both channels, because the guard sits before the only place that normally tees them.**
+/// A walk's counters leave by two routes: the thread-local [`SolverStatsScope`], which is how
+/// production collects (`api::fit`), and the caller's own `stats` out-parameter, which is how
+/// [`crate::ode::ode_predictions_with_solver_stats`] — the one public getter for an
+/// `OdeSolverStats` — collects. The ordinary route into both is the tee inside
+/// [`integrate_resolved_g`], and this event is precisely the one where no integration is ever
+/// reached: the guard returns before a driver is called. Recording into the sink alone left
+/// the public getter reporting `0` for an abandoned walk, which is the exact conflation this
+/// counter exists to remove, on the surface #1234 reported it against.
 ///
 /// Off the diagnostic path this is one `Cell` read, taken only inside a guard that has already
 /// fired on a subject whose predictions are `NaN` regardless.
 #[inline]
-pub(crate) fn record_abandoned_non_finite_timeline() {
-    STATS_SINK.with(|c| {
-        if let Some(mut acc) = c.get() {
-            acc.abandoned_non_finite_timeline += 1;
-            c.set(Some(acc));
-        }
-    });
+pub(crate) fn record_abandoned_non_finite_timeline(stats: Option<&mut OdeSolverStats>) {
+    // One `OdeSolverStats` through the two ordinary merge paths, rather than a second
+    // hand-written `STATS_SINK` read-modify-write next to `record_to_stats_sink`'s: this is
+    // also what makes `merge`'s `abandoned_non_finite_timeline` line reachable, since nothing
+    // else ever produces a non-scope `OdeSolverStats` carrying the field.
+    let one = OdeSolverStats {
+        abandoned_non_finite_timeline: 1,
+        ..Default::default()
+    };
+    record_to_stats_sink(&one);
+    if let Some(s) = stats {
+        s.merge(&one);
+    }
 }
 
 /// [`integrate_resolved_g_inner`] with the thread-local [`SolverStatsScope`] tee.

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -4955,10 +4955,21 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
     // `ode::predictions::timeline_has_non_finite`. This walk dispatches typed events by
     // index and so never re-applies a dose, but a `NaN`/`inf` time sorts to the end and
     // its event is simply never reached: with a `+inf` lagtime both doses go unapplied
-    // and the walk returns a *finite, drug-free* gradient. NaN jets instead, so the
+    // and the walk returns a *finite, drug-free* gradient. A non-finite fill instead, so the
     // caller sees a diverged subject rather than a plausible wrong one. This is the
     // event-driven twin of the same guard in `integrate_g`; an estimated lagtime routes
     // here, not there, so the two must both carry it.
+    //
+    // Same fill, same caveat as that twin (#1234): `T::from_f64` lifts a *constant*, so this
+    // delivers a NaN **value** with jets of `0.0` and `jets_finite() == true` — not the "NaN
+    // jets" the comment here used to promise. Masked by any `/V`-style readout, which multiplies
+    // `NaN` into the jets afterwards. Repairing it is a behaviour change tracked separately; see
+    // `integrate_g` for the measured numbers.
+    //
+    // This walk has no `Option` to decline through — its return type is a bare `Vec<Vec<T>>`,
+    // with no `None` channel at all — which is why `Some(non-finite)` rather than `None` is the
+    // convention on the static side too. Collapsing that one to `None` would create an asymmetry
+    // this one cannot match.
     if crate::ode::predictions::times_have_non_finite(tl.iter().map(|e| e.0)) {
         for row in states.iter_mut() {
             for x in row.iter_mut() {
@@ -6686,10 +6697,45 @@ fn integrate_g<T: crate::sens::num::PkNum>(
     break_times.sort_by(|a, b| a.total_cmp(b));
     break_times.dedup_by(|a, b| (*a - *b).abs() < 1e-15);
     // A non-finite break time makes the subject non-finite (#1189) — see
-    // `ode::predictions::timeline_has_non_finite`. NaN *jets*, not just NaN values: the
-    // whole walk is unreachable, so neither the value nor its `∂/∂η` is defined, and the
-    // caller already tolerates a diverged walk. Without this the NaN-lagged dose is
-    // simply never applied and the gradient comes back finite and wrong.
+    // `ode::predictions::timeline_has_non_finite`. Without this the NaN-lagged dose is simply
+    // never applied and the gradient comes back finite and wrong.
+    //
+    // **What this fill actually delivers is a NaN *value* with jets of `0.0`** — not the "NaN
+    // jets" this comment claimed until #1234. `T::from_f64` lifts a *constant*, so on a dual the
+    // value is `NaN` while the gradient is `[0.0; N]` and `PkNum::jets_finite()` returns `true`.
+    // Measured through the provider on a bare-state readout (`ode(obs_cmt=central)`, no
+    // `[scaling]`): `ObsGrad { f: NaN, df_deta: [0.0] }`.
+    //
+    // It went unnoticed because the *readout* masks it, not because it does not happen. With
+    // `[scaling] y = central / V` and η on `V`, `d(central/V)` folds `NaN · dV` in and the jets
+    // become `NaN` by arithmetic downstream of this fill — measured `[NaN, NaN]` on the same
+    // fixture — so every scaled model agreed with the old comment.
+    //
+    // **Not repaired here, deliberately.** Filling real NaN jets instead is a behaviour change,
+    // not a documentation fix: measured on a 2-subject FOCEI fit with one NaN-dose-time subject,
+    // it moves the reported `ofv` from `NaN` to `2e20` (the outer objective's non-finite
+    // sentinel, `2 · 1e20`), the outer iteration count from 4 to 12, `converged` from `true` to
+    // `false`, and the *healthy* subject's η̂ from 1.000846558216595 to 0.8822190053957163. That
+    // belongs in its own change with its own validation — see the #1234 follow-up. `f` is `NaN`
+    // either way, so no caller reading the value is affected today; what a caller reading the
+    // *jets* gets is a zero gradient on a subject that is diverged.
+    //
+    // **`Some`, not `None`, and the discriminator matters.** This function's two failure exits
+    // answer different questions, and swapping them loses information the caller acts on:
+    //
+    // * `Some` with a non-finite fill — *the analytic walk ran and the subject is diverged.*
+    //   Nothing is wrong with the analytic machinery; the timeline itself is unorderable, so FD
+    //   would produce exactly the same `NaN` from exactly the same broken model, one solve per
+    //   perturbation more expensively.
+    // * `None` (the `recorded` check at the end of this function) — *the analytic walk declines
+    //   to answer.* An observation was never captured, so the state it would report is the
+    //   zero-initialised placeholder, and FD really can do better.
+    //
+    // `None` is also not available as a common spelling: `integrate_tvcov_g`, the event-driven
+    // twin an estimated lagtime routes to, returns a bare `Vec<Vec<T>>` with no `None` channel
+    // at all and NaN-fills this identical condition. `Some(non-finite)` is therefore already the
+    // cross-walk convention, and collapsing this exit to `None` would *create* the asymmetry
+    // rather than remove it.
     if crate::ode::predictions::timeline_has_non_finite(&break_times) {
         for row in states.iter_mut() {
             for x in row.iter_mut() {
@@ -7003,6 +7049,25 @@ fn integrate_g<T: crate::sens::num::PkNum>(
     // solver dropped/realigned — would keep its zero-initialised state and feed a
     // silent `f = 0`, `∂f = 0` into the gradient. Decline so the caller falls back
     // to FD for this subject rather than return a wrong `Some`.
+    //
+    // The only `None` this function itself returns, and deliberately (#1234) — the two `None`s
+    // further up are exits from the `zero_windows` `filter_map` closure, not from here. It says
+    // "this walk cannot answer", which is a statement about the analytic machinery and is
+    // actionable: FD will capture the observation this walk lost. The non-finite-timeline guard
+    // above says something else — "the walk ran and the subject is diverged" — which FD cannot
+    // improve on, so it returns `Some` carrying a `NaN` value (with, today, jets of `0.0`; see
+    // that guard). Swapping either exit for the other turns an actionable fallback into a silent
+    // one, or spends N+1 solves reproducing a `NaN` the model guarantees.
+    //
+    // Worth knowing before relying on this arm: it appears to be **unreachable from
+    // `ode_subject_sensitivities` today**. Nine shapes aimed at it — an observation below the
+    // timeline floor, an all-negative grid, observations `5e-13` after the integration start and
+    // after a dose, duplicate and `1e-16`-apart times, a single observation at `t = 0`,
+    // observations entirely before the first dose, and no doses at all — every one comes back
+    // `Some`. `subject_integration_start` (#573) is why the example above no longer reaches it:
+    // a negative observation time now *becomes* the first break rather than falling below it.
+    // A defensive backstop, then, not a live path — but leave it, since the `saveat` realignment
+    // half of the comment above is not covered by that argument.
     if recorded.iter().any(|&r| !r) {
         return None;
     }

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -10244,6 +10244,16 @@ fn the_static_walk_returns_a_non_finite_value_with_finite_zero_jets() {
     let sens = ode_subject_sensitivities(&m, &s, &[1.0, 10.0], &[0.0])
         .expect("the static walk answers Some for a diverged subject — it does not decline");
 
+    // Non-degeneracy: every assertion below lives inside this loop, so an empty `obs` would
+    // run none of them and the test would pass having checked nothing — and "the walk bails
+    // before recording observations" is exactly the state this test is about.
+    assert_eq!(
+        sens.obs.len(),
+        4,
+        "the walk must return the fixture's four observations, or the loop below asserts \
+         nothing: {:?}",
+        sens.obs.iter().map(|o| o.f).collect::<Vec<_>>()
+    );
     for (j, o) in sens.obs.iter().enumerate() {
         assert!(
             o.f.is_nan(),
@@ -10281,6 +10291,15 @@ fn the_scaled_readout_is_what_masked_the_zero_jets() {
     let s = nan_dose_time_subject(&[1.0, 2.0, 4.0, 8.0]);
     let sens = ode_subject_sensitivities(&m, &s, &[1.0, 10.0], &[0.0, 0.0]).expect("Some");
 
+    // Non-degeneracy, as T5: an empty `obs` would make this control vacuous, and a control
+    // that asserts nothing cannot explain anything.
+    assert_eq!(
+        sens.obs.len(),
+        4,
+        "the walk must return the fixture's four observations, or the loop below asserts \
+         nothing: {:?}",
+        sens.obs.iter().map(|o| o.f).collect::<Vec<_>>()
+    );
     for (j, o) in sens.obs.iter().enumerate() {
         assert!(o.f.is_nan(), "scaled readout, obs {j}: f = {}", o.f);
         assert!(
@@ -10347,6 +10366,14 @@ fn the_event_driven_walk_returns_a_non_finite_value_with_finite_zero_jets() {
          testing nothing",
     );
 
+    // Non-degeneracy, as T5.
+    assert_eq!(
+        sens.obs.len(),
+        8,
+        "the walk must return the fixture's eight observations, or the loop below asserts \
+         nothing: {:?}",
+        sens.obs.iter().map(|o| o.f).collect::<Vec<_>>()
+    );
     for (j, o) in sens.obs.iter().enumerate() {
         assert!(
             o.f.is_nan(),
@@ -10407,6 +10434,15 @@ fn a_diverged_subject_answers_some_rather_than_declining_to_fd() {
          perturbation more expensively, and `integrate_tvcov_g` — the event-driven twin that \
          an estimated lagtime routes to — returns a bare Vec with no `None` channel at all, so \
          `None` here would create the cross-walk asymmetry rather than remove one",
+    );
+    // Non-degeneracy: `.all()` on an empty `obs` is `true`, so without this the DIVERGED
+    // assertion below passes on a walk that returned nothing at all.
+    assert_eq!(
+        sens.obs.len(),
+        3,
+        "the walk must return the fixture's three observations, or `.all()` below is \
+         vacuously true: {:?}",
+        sens.obs.iter().map(|o| o.f).collect::<Vec<_>>()
     );
     assert!(
         sens.obs.iter().all(|o| o.f.is_nan()),

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -10143,3 +10143,286 @@ fn joint_ss_subject(ss: bool) -> Subject {
     s.obs_cmts = vec![2; s.obs_times.len()];
     s
 }
+
+// ── the two non-finite exits of the analytic walks (#1234) ───────────────────
+//
+// `integrate_g` has two failure exits and they answer different questions:
+//
+// * `Some` carrying a non-finite fill — *the walk ran and the subject is diverged.* The
+//   timeline itself could not be ordered, so FD would reproduce the same `NaN` one solve per
+//   perturbation more expensively.
+// * `None` — *the walk declines to answer.* An observation was never captured, so the state it
+//   would report is the zero-initialised placeholder and FD really can do better.
+//
+// `integrate_tvcov_g`, the event-driven twin, returns a bare `Vec<Vec<T>>` with no `None`
+// channel at all and NaN-fills the identical condition — so `Some(non-finite)` is already the
+// cross-walk convention, and collapsing the first exit to `None` would create the asymmetry
+// rather than remove it. The tests below pin each exit separately, with a message naming its
+// own side.
+
+/// A bare-state readout: `obs_cmt = central`, **no `[scaling]` block**. The readout is the
+/// whole point — see `the_scaled_readout_is_what_masked_the_zero_jets` below.
+const BARE_STATE_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+/// The same model with the ordinary `y = central / V` readout and η on `V`.
+const SCALED_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  omega ETA_CL ~ 0.09
+  omega ETA_V  ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+[structural_model]
+  ode(states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central
+[scaling]
+  y = central / V
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+
+/// [`bolus_subject`] whose single dose time is `NaN`. No lagtime and no covariates, so this
+/// routes to the **static** walk (`integrate_g`) — asserted per test with
+/// `ode_tvcov_supported`, not inferred from the fixture's shape.
+fn nan_dose_time_subject(times: &[f64]) -> Subject {
+    let mut s = bolus_subject(times);
+    s.doses = vec![DoseEvent::new(f64::NAN, 100.0, 1, 0.0, false, 0.0)];
+    s
+}
+
+/// T5 — the **static** walk's non-finite exit, asserted on the **jets**.
+///
+/// `is_finite()` on the value is the wrong assertion here and would pass either way: the value
+/// is `NaN` on both sides of every change this test could see. The guard's comment used to
+/// promise non-finite *derivatives* as well, which it never delivered — `T::from_f64(NAN)` lifts
+/// a constant, so `Dual1<1>` comes back `value = NaN, grad = [0.0]` and `PkNum::jets_finite()` is
+/// `true`. #1234 corrected the comment to say that; this test is what holds it to it.
+///
+/// So this pins the measured asymmetry rather than an aspiration: `f` is `NaN` and `∂f/∂η` is
+/// a **finite zero**. That is a real gap — a subject the walk knows is diverged handing FOCEI a
+/// gradient that claims to be fine — but repairing it is a behaviour change, not a comment fix:
+/// measured on a 2-subject FOCEI fit with one such subject, filling real NaN jets moves `ofv`
+/// from `NaN` to `2e20`, the outer iteration count from 4 to 12, `converged` from `true` to
+/// `false`, and the *healthy* subject's η̂ from 1.000846558216595 to 0.8822190053957163. It is
+/// tracked as the #1234 follow-up, and **this assertion is what makes that fix visible**: it
+/// goes red the moment the fill delivers non-finite jets (verified by applying that repair).
+///
+/// Mutation (run): delete `integrate_g`'s `timeline_has_non_finite` guard → the `NaN` dose
+/// never matches a break, is never applied, and the walk returns a finite drug-free `f`; the
+/// first assert fires naming the static walk. T7 stays green under it.
+#[test]
+fn the_static_walk_returns_a_non_finite_value_with_finite_zero_jets() {
+    let m = parse_model_string(BARE_STATE_ODE).expect("parse");
+    let s = nan_dose_time_subject(&[1.0, 2.0, 4.0, 8.0]);
+    // Which engine this fixture runs on, asserted rather than inferred: the same dispatch
+    // `ode_subject_sensitivities` uses. Without it a fixture that quietly started routing to the
+    // event-driven walk would test T7's site twice and leave this one uncovered.
+    assert!(
+        !ode_tvcov_supported(&m, &s),
+        "this fixture must run on the STATIC walk (integrate_g); it is routing to the \
+         event-driven one, so it is testing T7's guard rather than this one"
+    );
+    let sens = ode_subject_sensitivities(&m, &s, &[1.0, 10.0], &[0.0])
+        .expect("the static walk answers Some for a diverged subject — it does not decline");
+
+    for (j, o) in sens.obs.iter().enumerate() {
+        assert!(
+            o.f.is_nan(),
+            "static walk, obs {j}: a subject whose timeline could not be ordered came back \
+             with a finite value ({}), which means the NaN-timed dose was silently never \
+             applied and a drug-free trajectory was reported as valid",
+            o.f
+        );
+        // The jets, not the value. Pinned as measured — and known wrong; see the doc above.
+        assert_eq!(
+            o.df_deta,
+            vec![0.0],
+            "static walk, obs {j}: the non-finite fill's ∂f/∂η is a finite zero, not NaN — \
+             `T::from_f64(NAN)` lifts a *constant*. If this is now [NaN] the #1234 follow-up \
+             has landed and this assertion (and the guard's comment) must be inverted"
+        );
+    }
+}
+
+/// T6 — the control that explains why nobody saw T5's gap for so long.
+///
+/// It exists to **not** distinguish. With `y = central / V` and η on `V`, the readout computes
+/// `d(central/V) = (dc·V − c·dV)/V²`, which multiplies the fill's `NaN` value into the jets
+/// *downstream* of the fill — so `df_deta` is `[NaN, NaN]` whatever the fill puts there. Every
+/// fixture written on a scaled model therefore agrees with the "NaN jets" claim by arithmetic,
+/// including `nan_lagtime_sens_walk_is_non_finite_not_a_panic`
+/// (`sens/provider_tests.rs`), which additionally asserts only `o.f`.
+///
+/// Mutation: none. A control that could tell the two fills apart would not be a control — and
+/// that is the assertion: if this ever *starts* distinguishing them, the masking mechanism has
+/// changed and T5's reasoning needs re-deriving.
+#[test]
+fn the_scaled_readout_is_what_masked_the_zero_jets() {
+    let m = parse_model_string(SCALED_ODE).expect("parse");
+    let s = nan_dose_time_subject(&[1.0, 2.0, 4.0, 8.0]);
+    let sens = ode_subject_sensitivities(&m, &s, &[1.0, 10.0], &[0.0, 0.0]).expect("Some");
+
+    for (j, o) in sens.obs.iter().enumerate() {
+        assert!(o.f.is_nan(), "scaled readout, obs {j}: f = {}", o.f);
+        assert!(
+            o.df_deta.iter().all(|d| d.is_nan()),
+            "scaled readout, obs {j}: ∂f/∂η = {:?}. The `/V` readout multiplies the fill's NaN \
+             value into the jets, so this is NaN regardless of what the fill writes — that is \
+             what hid the zero jets T5 pins. If this is no longer NaN, the masking mechanism \
+             changed and T5's premise must be re-measured",
+            o.df_deta
+        );
+    }
+}
+
+/// T7 — the **event-driven** walk's non-finite exit (`integrate_tvcov_g`), its own site,
+/// mutated on its own.
+///
+/// An estimated lagtime routes here and never to `integrate_g`, so a fixture that reaches the
+/// static walk cannot see this guard at all — and this walk's return type has no `None` channel,
+/// so it cannot even spell the other exit. `WT = 1000` gives `LAGTIME = 0.3·exp(1000) = +inf`:
+/// `exp` on an unscaled covariate is how a lag actually goes non-finite at typical values, and
+/// `+inf` (rather than `NaN`) is the shape where dropping the guard is *silently* wrong — the
+/// event sorts to the end and is simply never reached, returning a finite drug-free gradient.
+///
+/// Mutation (run): delete `integrate_tvcov_g`'s `times_have_non_finite` guard → finite `f` and
+/// the first assert fires naming the event-driven walk. T5 stays green under it.
+#[test]
+fn the_event_driven_walk_returns_a_non_finite_value_with_finite_zero_jets() {
+    const BARE_STATE_LAG_ODE: &str = r#"
+[parameters]
+  theta TVCL(1.0, 0.1, 10.0)
+  theta TVV(10.0, 1.0, 100.0)
+  theta TVLAG(0.3, 0.0, 5.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.04
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  LAGTIME = TVLAG * exp(WT)
+[structural_model]
+  ode(obs_cmt=central, states=[central])
+[odes]
+  d/dt(central) = -(CL/V) * central
+[error_model]
+  DV ~ proportional(PROP_ERR)
+"#;
+    let m = parse_model_string(BARE_STATE_LAG_ODE).expect("parse");
+    let times: Vec<f64> = (1..=8).map(|i| i as f64).collect();
+    let mut s = bolus_subject(&times);
+    s.doses = vec![
+        DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+        DoseEvent::new(4.5, 100.0, 1, 0.0, false, 0.0),
+    ];
+    s.covariates.insert("WT".to_string(), 1000.0);
+    // The mirror of T5's routing assertion, and the reason the two are separable at all.
+    assert!(
+        ode_tvcov_supported(&m, &s),
+        "this fixture must run on the EVENT-DRIVEN walk (integrate_tvcov_g); it is routing to \
+         the static one, so it is testing T5's guard rather than this one"
+    );
+
+    let sens = ode_subject_sensitivities(&m, &s, &[1.0, 10.0, 0.3], &[0.0]).expect(
+        "the event-driven walk itself has no None channel (it returns a bare Vec), so a None \
+         here is the dispatch above it declining — not this guard, and this fixture is then \
+         testing nothing",
+    );
+
+    for (j, o) in sens.obs.iter().enumerate() {
+        assert!(
+            o.f.is_nan(),
+            "event-driven walk, obs {j}: an +inf-lagged subject came back finite ({}) — the \
+             lagged doses sorted to the end of the timeline, were never applied, and a \
+             drug-free trajectory was reported as a valid gradient",
+            o.f
+        );
+        assert_eq!(
+            o.df_deta,
+            vec![0.0],
+            "event-driven walk, obs {j}: the fill's ∂f/∂η is a finite zero here too, for the \
+             same reason as the static twin. If this is now [NaN] the #1234 follow-up has \
+             landed and both arms must be inverted together"
+        );
+    }
+}
+
+/// T8 — the discriminator: which exit answers which question, and what the caller does with
+/// the answer.
+///
+/// `integrate_g` has two failure exits and swapping either for the other is silent:
+///
+/// * a non-finite `Some` means *the walk ran and the subject is diverged*. FD cannot improve
+///   on it — the timeline is unorderable at any perturbation — so declining here would spend
+///   `N+1` solves reproducing a `NaN` the model guarantees, and would report the subject under
+///   an "outside the analytic provider's scope" warning whose remedy has nothing to do with
+///   its actual problem.
+/// * `None` (the `recorded` check at the end of that function) means *the walk declines to
+///   answer*: an observation was never captured, so its state would be the zero-initialised
+///   placeholder and FD really can do better.
+///
+/// **The `None` half is a defensive backstop with no reachable fixture from this entry point
+/// today**, and that was measured, not assumed: nine shapes aimed at it — an observation below
+/// the timeline floor, an all-negative observation grid, observations `5e-13` after the
+/// integration start and after a dose, duplicate and `1e-16`-apart observation times, a single
+/// observation at `t = 0`, observations entirely before the first dose, and no doses at all —
+/// every one returns `Some`. `subject_integration_start` (#573) is why the doc-comment's own
+/// example no longer reaches it: a negative observation time *becomes* the first break rather
+/// than falling below it. So this test pins the reachable half and the contract it buys.
+///
+/// Two assertions, and they are not redundant: the first is about what the provider returns,
+/// the second about how `fd_fallback_warning` reads it. A change to either side fires its own.
+///
+/// Mutation (run): return `None` from `integrate_g`'s `timeline_has_non_finite` guard → the
+/// DIVERGED assertion fires. The FD-ACCOUNTING one was checked *separately* under the same
+/// mutation, with DIVERGED temporarily made non-panicking, and fires on its own — otherwise
+/// "they are not redundant" would be a claim about a line that never ran.
+#[test]
+fn a_diverged_subject_answers_some_rather_than_declining_to_fd() {
+    let m = parse_model_string(BARE_STATE_ODE).expect("parse");
+    let s = nan_dose_time_subject(&[1.0, 2.0, 4.0]);
+    let theta = [1.0, 10.0];
+
+    let sens = ode_subject_sensitivities(&m, &s, &theta, &[0.0]).expect(
+        "DIVERGED: a subject whose timeline could not be ordered must answer `Some` carrying a \
+         non-finite fill, not decline. FD would reproduce the same NaN one solve per \
+         perturbation more expensively, and `integrate_tvcov_g` — the event-driven twin that \
+         an estimated lagtime routes to — returns a bare Vec with no `None` channel at all, so \
+         `None` here would create the cross-walk asymmetry rather than remove one",
+    );
+    assert!(
+        sens.obs.iter().all(|o| o.f.is_nan()),
+        "DIVERGED: the `Some` must carry the non-finite fill, or it is a *wrong* answer rather \
+         than a diverged one: {:?}",
+        sens.obs.iter().map(|o| o.f).collect::<Vec<_>>()
+    );
+
+    // What the discriminator buys, at the caller. `fd_fallback_warning` counts a subject as FD
+    // **iff** this returns `None`, and reports it under "outside the analytic provider's scope
+    // … their results are correct but slower" — a sentence that would be doubly wrong here:
+    // the subject is not out of scope, and its results are not correct.
+    assert!(
+        crate::sens::provider::subject_eta_grad(&m, &s, &theta, &[0.0]).is_some(),
+        "FD-ACCOUNTING: a diverged subject must not be counted as a finite-difference \
+         fallback — `fd_fallback_warning` keys on exactly this `is_none()`, so declining here \
+         mislabels an unorderable timeline as an analytic-scope gap"
+    );
+}


### PR DESCRIPTION
## Why

An `OdeSolverStats` block full of zeros meant three different things and the fit could not tell
them apart. Measured at `cf32e1fd`, same model, inside the `SolverStatsScope` production
actually collects through (`api/fit.rs`):

| subject | `attempted / accepted / rejected` | predictions |
|---|---|---|
| normal | `7 / 7 / 0` | `[95.12, 81.87, 44.93, 9.07]` |
| **non-finite timeline** | **`0 / 0 / 0`** | `[NaN, NaN, NaN, NaN]` |
| no records at all | `0 / 0 / 0` | `[]` |
| one observation at `t = 0` | `0 / 0 / 0` | `[0.0]` |

Every counter on `OdeSolverStats` reports work that *happened*, and a walk abandoned before the
solver is called does none — so the one case whose predictions are `NaN` by construction reads
exactly like the two ordinary ones.

That path is still reachable after #1286, which checks dose *attributes* (`ALAG`/`F`/`D`/`R`),
not record times: a subject with a `NaN` dose **time** gets 0 diagnostics from
`check_model_data`, and `fit()` then returns `ofv = NaN` with five warnings, **none** of which
names the subject, the timeline, or `NaN`. The `ode_solver` entry was `None`.

Second half of the issue: both analytic-sensitivity guards claimed to return "NaN **jets**".
They do not — `T::from_f64(NAN)` lifts a *constant*, so the value is `NaN` and the gradient is
`[0.0; N]`, with `PkNum::jets_finite()` returning `true`.

## What changed

**The counter (N2a-1).** New `OdeSolverStats::abandoned_non_finite_timeline`, bumped by a new
`pub(crate) record_abandoned_non_finite_timeline()` that writes the thread-local sink
*directly* — the ordinary route in is the tee inside `integrate_resolved_g`, and this is
precisely the event where no driver is ever reached. Wired at all **eight** `f64`-side guard
sites: `ode/predictions.rs` 3396, 4439, 5418, 6003, 6541, 7109, 7353 and `ode/ekf.rs` 265.
`merge`'s exhaustive destructure forced the coupling, as intended — no `..` added.

Deliberately **not** recorded at the two `sens/ode_provider.rs` sites (4962, 6693): `fit_inner`
copies exactly one field out of the sensitivity sweep's scope (`auto_stiff_rejected_jets`) and
discards the rest, so anything else deposited there is either dropped or — if that copy were
widened — would fire a warning clause about *predictions* on the strength of a gradient solve.

**The warning (N2a-2).** `abandoned` joins `unclean` in `ode_solver_diagnostics_warning` and
gets its own clause, placed **first** because it is the only clause here reporting predictions
that are `NaN` rather than merely inaccurate. New `abandoned_non_finite_timeline` key in the
`details` payload.

**The two sens exits (N2b-i).** Both comments now say what the fill actually delivers, with the
measured numbers, and the **discriminator** between `integrate_g`'s two failure exits is
documented at all three sites:

- non-finite `Some` — *the walk ran and the subject is diverged*; FD would reproduce the same
  `NaN` one solve per perturbation more expensively, and would report it under an "outside the
  analytic provider's scope … correct but slower" warning that is wrong twice over.
- `None` (the `recorded` check) — *the walk declines to answer*; an observation was never
  captured, so FD really can do better.

`None` is not available as a common spelling anyway: `integrate_tvcov_g`, the twin an estimated
lagtime routes to, returns a bare `Vec<Vec<T>>` with **no `None` channel at all** and NaN-fills
the identical condition. `Some(non-finite)` is already the cross-walk convention; collapsing
the static exit to `None` would *create* the asymmetry rather than remove one.

**Docs.** `docs/warnings.qmd`'s `## Warning codes` was baselined at R1 7391 and shrink-only, so
growing the `ode_solver` row was impossible without splitting it. Split into eight `###`
subsections with `{#warning-codes}` kept on the `##` (three inbound R4 links: `warnings.qmd:12`,
`output.qmd:134`, `model-file/ode-models.qmd:649` — all still resolve), and its baseline line
**deleted**, since a stale entry is itself a failure. `docs-lint --check` is green with **five**
baselined sections. `## Details payloads` had 2,160 chars of headroom, so the new key fits with
no split. `model-file/ode-models.qmd` gained the case in its "where the step counts show up"
section.

## Alternatives considered

**Fixing `ode_predictions_with_solver_stats`'s `stats` parameter** — the surface the issue names.
It has **no production caller** (only `sens/ode_provider_tests.rs:8589` and
`tests/transit_nonmem_anchor.rs`); `ode/solver.rs` already says so in prose. Fixing it would
satisfy the issue's literal wording and reach no user. Production collects through the
thread-local scope, so that is where the counter had to go. Deleting the dead surface is a
separate change.

**Returning `None` from the non-finite guard** (the issue's item-2 proposal) — rejected on the
measurement above: it would create the cross-walk asymmetry, not remove it.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

`OdeSolverStats` is referenced nowhere in `ferx-r` on `origin/main`, and nowhere in `crates/`.
The field is additive, so this is a baseline regeneration only — no ferx-r PR, no lock bump.

## Breaking changes
- [ ] `.ferx` model file format
- [ ] `FitResult` / sdtab fields changed
- [x] Public Rust API — `api/ferx-core-public-api.txt` regenerated with
      `tools/update-public-api.sh`. One additive item, listed twice
      (`ferx_core::ode::` and `ferx_core::ode::solver::`):
      `OdeSolverStats::abandoned_non_finite_timeline`. It is public because every other field
      of that struct is, and because it is the counter a consumer reading the `ode_solver`
      `details` payload needs in order to tell an abandoned walk from a clean one — the same
      role `auto_stiff_rejected_jets` plays for #1204.
- [ ] None

## Numerical validation

- [x] Not applicable — but the twin was measured, because the split depends on it.

No NONMEM anchor: NONMEM has no spelling for "which of my own diagnostics fired", and the three
outcomes above are exact hand-computed values (a walk that never ran has 0 steps), not
tolerances.

**The twin that proves nothing else moved.** `fit()` on the `NaN`-dose-time population before
and after this PR:

```
# before (cf32e1fd)                # after (this PR)
ofv          = NaN                 ofv          = NaN
n_iterations = 4                   n_iterations = 4
converged    = true                converged    = true
warnings     = 5                   warnings     = 6   (+ W_ODE_SOLVER_DIAGNOSTICS)
eta (healthy subject)              eta (healthy subject)
             = 1.000846558216595                = 1.000846558216595
```

The only difference is the warning this PR exists to add.

**Why the jet repair was split out.** Making the fill deliver real NaN jets — the one-line
change `T::from_f64(NAN)` → `T::from_f64(NAN).exp()` — moves the fit, measured on the same
fixture with nothing else changed:

| | before | after |
|---|---|---|
| `ofv` | `NaN` | **`2e20`** |
| `n_iterations` | 4 | **12** |
| `converged` | `true` | **`false`** |
| warnings | 6 | **7** (adds "Outer optimization did not converge") |
| η̂ of the **healthy** subject | `1.000846558216595` | **`0.8822190053957163`** |

`2e20` is `2 · 1e20`, consistent with the outer objective's non-finite sentinel. A healthy
subject's η̂ moving is not a diagnostics change, so per the plan's own exit condition it is
split out as **#1295** rather than folded in here. This PR corrects the claim; that
one changes the behaviour, with its own validation.

## Performance
- [x] No significant impact expected — one `Cell` read per fired guard, inside a branch that
      only runs on a subject whose predictions are already `NaN`.

## Tests
- [x] Unit tests added in the same module (`cargo test --lib` passes: 4430 passed, 0 failed)
- [x] Regression tests added that fail without this fix
- [ ] No new tests needed

Eight Tier-1 tests, each mutation-tested with `--no-fail-fast`. **Which engine each fixture ran
on is asserted, not inferred** — T5/T7 call `ode_tvcov_supported` directly so a fixture that
silently started routing to the other walk fails rather than testing the wrong guard.

| | test | file | engine |
|---|---|---|---|
| T1 | `the_static_walk_separates_an_abandoned_timeline_from_nothing_to_integrate` | `api/tests/ode_solver_diagnostics_tests.rs` | `f64`, dense static |
| T2 | `the_event_driven_walk_separates_an_abandoned_timeline_from_nothing_to_integrate` | same | `f64`, event-driven |
| T3 | `an_abandoned_walk_leaves_every_started_segment_counter_at_zero` | same | `f64`, dense static |
| T4 | `a_fit_over_an_unorderable_timeline_says_so` | same | `f64`, real `fit()` |
| T5 | `the_static_walk_returns_a_non_finite_value_with_finite_zero_jets` | `sens/ode_provider_tests.rs` | `Dual1`/`Dual2`, `integrate_g` |
| T6 | `the_scaled_readout_is_what_masked_the_zero_jets` | same | `Dual1`/`Dual2`, `integrate_g` |
| T7 | `the_event_driven_walk_returns_a_non_finite_value_with_finite_zero_jets` | same | `Dual1`/`Dual2`, `integrate_tvcov_g` |
| T8 | `a_diverged_subject_answers_some_rather_than_declining_to_fd` | same | `Dual1`/`Dual2`, `integrate_g` + `fd_fallback_warning`'s predicate |

### Mutation matrix (every cell run)

| mutation | T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 |
|---|---|---|---|---|---|---|---|---|
| delete the record at `predictions.rs:3396` (static) | **RED** | green | RED | RED | — | — | — | — |
| delete the record at `predictions.rs:6003` (event-driven) | green | **RED** | green | green | — | — | — | — |
| delete the record at `predictions.rs:6541` (`with_states`) | green | green | green | **RED** | — | — | — | — |
| counter also bumps `unfinished_segments` | green | green | **RED** | RED | — | — | — | — |
| drop `\|\| abandoned > 0` from `unclean` | green | green | green | **RED** | — | — | — | — |
| delete `integrate_g`'s guard | — | — | — | — | **RED** | RED | green | RED |
| delete `integrate_tvcov_g`'s guard | — | — | — | — | green | green | **RED** | green |
| apply the follow-up's jet repair to `integrate_g` | — | — | — | — | **RED** | **green** | green | green |
| swap `integrate_g`'s `Some(states)` for `None` | — | — | — | — | RED | RED | green | **RED** |

Three things that matrix is there to show:

1. **T1/T2 and T5/T7 are separable in both directions**, and each failure message names its own
   side ("static walk: …" / "event-driven walk: …"). A single fixture reaching only one engine
   cannot see the other's guard.
2. **T4 pins the count at `== 3`, not `> 0`** — and that is load-bearing. Measured inside the
   fit's own scope, one bad subject is abandoned three times in the post-fit sweep
   (`ode_predictions` ×2, `ode_predictions_with_states` ×1). At `> 0` the third row of the
   matrix was **green**: either recorder alone kept the assertion satisfied, the
   redundant-gate hole. Pinning the count also measures the "counts walks, not subjects" claim
   in the warning text.
3. **T6 provably cannot distinguish the two fills** — row 8 shows it green under the exact
   repair that reddens T5. That is its whole job: it explains why
   `nan_lagtime_sens_walk_is_non_finite_not_a_panic` (`sens/provider_tests.rs:11612`), which
   uses a `/V` model **and** asserts only `o.f`, is not a regression guard for any of this.

`is_finite()` is deliberately *not* the assertion in T5/T7: the value is `NaN` on both arms
already, and the jets are a finite `0.0`. The jets are what is asserted.

Full suite: `cargo test --lib --features ci,survival --no-fail-fast` → 4430 passed / 0 failed;
`cargo test --features ci,survival --no-fail-fast` (all integration binaries) green;
`tools/preflight.sh` green.

## Example (user-facing features only)
- [x] Not applicable (a diagnostic; the user-visible surface is the existing `ode_solver`
      warning, whose new clause and payload key are documented in `docs/warnings.qmd`)

## Docs
- [x] `docs/` updated — `warnings.qmd` (`ode_solver` row, `details` key, the `###` split),
      `model-file/ode-models.qmd`
- [x] No new pages, so `_quarto.yml` unchanged; `docs/_site/` not committed
- [x] `CHANGELOG.md` `[Unreleased]` → `### Fixed`
- [ ] No user-visible change

## Checklist
- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy
      (`--all-targets`), rustdoc, docs, public-API baseline
- [x] `Dual2` path — the sens changes are comments plus one `pub(crate)` recorder that the sens
      walks deliberately do **not** call; no `*_g<T: PkNum>` body changed, so differentiability
      is untouched. T5–T8 exercise both `Dual1` and `Dual2` instantiations through
      `ode_subject_sensitivities`.
- [x] No version bump (additive)

## Docs & examples

### ferx-site / ferx-book
- [x] No new `.ferx` DSL syntax or `[fit_options]` key
- [x] No new example or data file
- [x] No new estimator / DSL feature / fit option

### Example execution
- [x] No example execution step needed — the change is a diagnostic counter and a warning
      clause; no example's numbers move (see the twin above).

## Reviewer hints

- **Start with the mutation matrix.** Rows 3 and 8 are the two that caught real holes: row 3
  turned T4 from `> 0` into `== 3`, and row 8 is what earns T6 its place instead of reading as
  a duplicate of T5.
- **The counter counts walks, not subjects,** and that is stated in the field doc, the warning
  text, and `docs/warnings.qmd`. Three per subject on a plain FOCEI post-fit sweep, measured.
  If you would rather it were per-subject, say so — it would mean deduplicating across engines
  inside the scope, which the scope has no subject identity to do with.
- **The two sens sites are comment-only.** The fills are byte-identical to `cf32e1fd`; what
  changed is that they now describe what they do. The behaviour change lives in
  **#1295** with the measurement above.
- **One observation, not filed:** `integrate_g`'s `None` exit (the `recorded` check) appears to
  be **unreachable from `ode_subject_sensitivities` today**. Nine shapes aimed at it — an
  observation below the timeline floor, an all-negative grid, observations `5e-13` after the
  integration start and after a dose, duplicate and `1e-16`-apart times, a single observation at
  `t = 0`, observations entirely before the first dose, no doses at all — all return `Some`.
  `subject_integration_start` (#573) is why: a negative observation time now *becomes* the first
  break rather than falling below it, so the exit's own doc-comment example no longer reaches
  it. A defensive backstop being unreachable is fine, so this is recorded in T8's doc comment
  rather than filed — but it is why T8 pins the reachable half plus the caller contract
  (`fd_fallback_warning` keys on exactly that `is_none()`) instead of both exits behaviourally.
- **Skimmable:** the `docs/warnings.qmd` split is a mechanical partition of one table into eight
  — no row text changed except `ode_solver`'s, and no row moved between groups.

## Open questions

None blocking. The one judgement call is walks-vs-subjects on the counter (see hints).


## Round 2 — after review (`8d13b805`)

Everything above describes this PR as first submitted (`335cb9e5`). The review found ten
findings; the full disposition table, the mutation matrix and the measurements are in
[the round-2 reply](https://github.com/FeRx-NLME/ferx-core/pull/1296#issuecomment-5596677193).
What follows is the summary, so this description is not read as the final state.

| commit | findings |
|---|---|
| `ece0cfb2` | §1 (blocking), §3, §5, §7 |
| `a423383a` | §2 |
| `8d13b805` | §4, §6, §8, §9 |

- **§1 was real, and was reproduced red before it was fixed.** The counter reached the
  thread-local scope but **not** the `stats` out-parameter, so
  `ode_predictions_with_solver_stats` — the one public getter, and the surface #1234's item 1
  actually names — still answered `0` on a `NaN`-prediction walk, which also left
  `OdeSolverStats::merge`'s new line unreachable.
  `record_abandoned_non_finite_timeline(Option<&mut OdeSolverStats>)` now feeds both channels
  through `record_to_stats_sink` + `merge`; that is §7's fix as well.
- **The guard/recorder pairing is structural now (§5).**
  `ode::predictions::abandon_non_finite_timeline` detects *and* records in one call, and all
  eight engine guards route through it.
  `the_bare_timeline_predicates_are_not_called_outside_this_guard` scans `src/**/*.rs` and pins
  the bare predicates at **exact** counts — `src/ode/predictions.rs` ×2 (inside the two helpers)
  and `src/sens/ode_provider.rs` ×2 (the deliberate non-recorders) — so a ninth guard cannot be
  written without the counter, and the allowance cannot quietly widen *or* vanish.
- **The warning's tail no longer contradicts its own new clause (§2).** `unclean` splits into
  `unclean_integration` and the abandoned count; the solver-knob advice is scoped to the former,
  an abandoned walk gets advice that agrees with `ode-models.qmd`, and the lead-in verb branches
  too. The replacement wording was measured out of a real `fit()`, not read off the source.
- **Six more tests; the matrix is now 12 mutations, 12 killed, no survivors,** per-site kill sets
  disjoint. The round-1 table above (T1–T8) is superseded by the reply's. Three recorder sites —
  `ode_dense_solve_states`, `ode_solve_until_chz_threshold`, `ekf.rs` — had **no** test at all
  before. M1, dropping the out-param, is killed by the new public-getter test **alone**, with
  T1–T4 staying green, which is exactly why §1 was invisible.
- **Two of the review's own premises were wrong, corrected by measurement.**
  `ode_dense_solve_states` has **five** production callers, not a `markov`-only one
  (`markov::endpoint:341`, `survival/mod.rs:728`, `api/output_columns.rs:640`,
  `ode_predictions_event_driven_with_states`, `adaptive_window_signal_aucs`); T4's `== 3` is
  lane-independent for a different and stronger reason — the scope wraps
  `compute_subject_results` only (`api/fit.rs:1912`), and the `output_columns` caller runs after
  it closes. And `ode_solve_until_chz_threshold` runs on `solver::solve_ode_until_threshold`, its
  own driver, which never tees into `STATS_SINK` — measured `attempted_steps = 0` on a solve that
  crossed the threshold normally — so its control asserts the *outcome*, not the counters.

§10 (`OdeSolverStats` is not `#[non_exhaustive]`) is **not** fixed here: adding the attribute is
itself a breaking change and wants its own baseline diff. Filed as **#1302**, alongside **#1303**
(`fit()` returns `converged: true` with `ofv = NaN`) and **#1304** (`predict()` / `simulate()`
open no `SolverStatsScope`, which is §4 and §9's underlying scope question).

Gates at `8d13b805`: `tools/preflight.sh` green, all six groups — the public API still matches the
committed baseline, no new `pub` items this round. `--workspace --tests --no-default-features
--features ferx-core/ci` = **203 binaries / 5877 passed / 0 failed**; `--tests
--no-default-features --features ci,markov,nn` = **181 / 5568 / 0**.
