### PR TITLE
docs(tools): add a Tools landing page so the sidebar entry opens something

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -103,6 +103,7 @@ website:
           - estimation/ctmm.qmd
           - estimation/mixture.qmd
       - text: "Tools"
+        href: tools/index.qmd
         contents:
           - tools/bootstrap.qmd
           - tools/gam-screening.qmd

--- a/docs/tools/index.qmd
+++ b/docs/tools/index.qmd
@@ -1,0 +1,50 @@
+---
+pagetitle: "Model-development tools in ferx"
+description-meta: "The ferx-tools workflows that run many fits: bootstrap, GAM covariate screening, and the Pharmpy-style model-space searches (structural, IIV, IOV, residual error, covariates) up to automatic model development."
+---
+
+# Tools
+
+`ferx-core` fits one model to one dataset. Everything that calls `fit()` more
+than once — resampling, screening, searching a model space — lives in
+`ferx-tools` and is exposed as a `ferx <tool>` subcommand. Each tool carries a
+maturity tag; see [Feature Maturity](../maturity.qmd) for what the tags mean.
+
+## Uncertainty
+
+- **[Bootstrap](bootstrap.qmd)** — non-parametric case bootstrap: resample
+  subjects with replacement, refit, and read bias, standard errors and
+  confidence intervals off the spread of the estimates. PsN `bootstrap`
+  feature parity.
+
+## Covariate screening
+
+- **[GAM covariate screening](gam-screening.qmd)** — rank covariate–ETA pairs
+  by ΔAIC on the EBEs before paying for a stepwise search. The ferx
+  equivalent of Xpose4's `xpose.gam()`.
+
+## Model-space searches
+
+All searches read the same [`.ferxsearch` configuration file](search.qmd),
+whose search space is written in Pharmpy's Model Feature Language (MFL).
+
+- **[Search configuration](search.qmd)** — the `.ferxsearch` TOML file, the
+  MFL grammar ferx accepts, and the coverage table of what is and is not
+  supported.
+- **[Covariate search](covsearch.qmd)** — stepwise covariate modelling: PsN
+  `scm` forward / forward-then-backward and Pharmpy `covsearch`, plus
+  allometric scaling.
+- **[Structural model search](modelsearch.qmd)** — Pharmpy `modelsearch` over
+  absorption route, peripheral compartments, transit compartments and lag time.
+- **[Residual-error search](ruvsearch.qmd)** — Pharmpy `ruvsearch` over the
+  `[error_model]` block, tested by likelihood ratio.
+- **[Variability-structure search](iivsearch.qmd)** — Pharmpy `iivsearch`:
+  which parameters carry an η and how the omegas are blocked.
+- **[Inter-occasion variability search](iovsearch.qmd)** — Pharmpy
+  `iovsearch`: which parameters carry an occasion-level κ.
+
+## End to end
+
+- **[Automatic model development](amd.qmd)** — Pharmpy `amd`: the searches
+  above run in order from one `.ferxsearch` file, each seeded from the model
+  the last one selected, reported as one object.


### PR DESCRIPTION
## Why
Clicking **Tools** in the docs sidebar at https://ferx-nlme.github.io/ferx-core/ opens nothing. The section in `docs/_quarto.yml` had `contents:` but no `href:`, unlike every other section (Estimation Methods, File Formats, Examples all point at an `index.qmd`), so Quarto renders it as a collapse toggle only. The nine tool pages under `docs/tools/` exist and deploy fine, but look absent.

## What changed
- New `docs/tools/index.qmd`: landing page grouping the tools — Uncertainty (bootstrap), Covariate screening (GAM), Model-space searches (search configuration + covsearch / modelsearch / ruvsearch / iivsearch / iovsearch), End to end (amd). Same shape as `docs/estimation/index.qmd`.
- `docs/_quarto.yml`: `href: tools/index.qmd` on the Tools entry.

## Alternatives considered
None — one-line config gap plus the missing page.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: docs only; `cargo run -p docs-lint -- --check` passes, R4 verifies every link on the new page resolves)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml`
- [x] `CHANGELOG.md` — N/A (docs navigation only)

## Checklist
- [x] `tools/preflight.sh docs` green
- [x] `Dual2` path untouched
- [x] No version bump

## Docs & examples
### ferx-site
- [x] N/A
### ferx-book
- [x] N/A
### Example execution
- [x] No example execution step needed (docs-only)

## Reviewer hints
Skim the index page prose; the config change is one line.

## Open questions
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXkxkgTg7syudEGc5WS5Gj
