### PR TITLE
fix(sens): one infusion-membership predicate for every rate boundary [closes #1077]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,8 +305,12 @@ section of the SDLC for the versioning policy).
   the first sample past the window end) for a subject that receives no drug and predicts
   `0.0` everywhere. Reachable only from a hand-built model spec that runs no validation;
   no validated fit changes. The compartment test is now one shared predicate asked by
-  every infusion-forcing site on both engines, rather than four hand-written copies plus
-  one site that was missing it.
+- The analytic ODE sensitivity walk no longer injects a rate-off boundary term for `CMT=0`
+  infusions on an unbound compartment (#1077). `check_dose_compartments` already rejects
+  such zero-order `CMT=0` infusions with `E_DOSE_CMT_NOT_INFUSABLE`, so this change is
+  user-visible only through hand-built specs. The walk now uses the same shared
+  `infusion_has_rate_channel` predicate as production, preventing spurious
+  `∂f/∂η_LAG` jumps when both engines predict `f ≡ 0`.
 - A fit no longer stops on its first evaluation and reports every parameter at its
   initial value (#1290). The outer loop's EBE warm-start cache adopted the empirical
   Bayes estimates of *every* evaluation, including the ones the line search rejects, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,17 @@ section of the SDLC for the versioning policy).
 - `cov_inner_tol` now rejects a non-positive or non-finite value at parse time, as
   `fd_hessian_step` already did (#956). Such a value used to parse and then silently make
   every covariance-step EBE reconvergence exhaust `inner_maxiter`.
+- The analytic ODE sensitivity walk no longer injects a rate-off boundary term for a
+  `CMT=0` infusion, whose rate it never turns on (#1077). `CMT=0` is NONMEM's default
+  dose *bolus* compartment and has no meaning for a zero-order input, so both predictors
+  drop such a row and `check_dose_compartments` rejects it outright
+  (`E_DOSE_CMT_NOT_INFUSABLE`) — but when the dose also carried a lagtime the gradient
+  walk still fired the infusion-end saltation, reporting a finite `∂f/∂η_LAG` (+1.89 at
+  the first sample past the window end) for a subject that receives no drug and predicts
+  `0.0` everywhere. Reachable only from a hand-built model spec that runs no validation;
+  no validated fit changes. The compartment test is now one shared predicate asked by
+  every infusion-forcing site on both engines, rather than four hand-written copies plus
+  one site that was missing it.
 - A fit no longer stops on its first evaluation and reports every parameter at its
   initial value (#1290). The outer loop's EBE warm-start cache adopted the empirical
   Bayes estimates of *every* evaluation, including the ones the line search rejects, so

--- a/src/dosing.rs
+++ b/src/dosing.rs
@@ -797,6 +797,36 @@ pub(crate) fn is_real_infusion(d: &DoseEvent) -> bool {
     d.is_infusion() && d.duration > 0.0 && d.duration.is_finite()
 }
 
+/// Whether a zero-order input into this dose's compartment has a rate channel at all —
+/// the compartment half of "this infusion contributes a `+rate`", spelled **once** for
+/// every engine (#1077).
+///
+/// `CMT=0` is NONMEM's *default dose compartment*: defined for a bolus, where both
+/// engines resolve it to state index 0 (#899), and **not** defined for a zero-order
+/// input, which has no default target. `check_dose_compartments` rejects such a row
+/// outright (`E_DOSE_CMT_NOT_INFUSABLE`, both engines), so this is reachable only from a
+/// hand-built spec that runs no validation — but *there* every engine has to read it the
+/// same way, which is the whole reason it is one function.
+///
+/// Two callers, and #1077 is both of them disagreeing in turn. The value path
+/// ([`crate::ode::predictions::infusion_contributes`]) once had no compartment test at
+/// all and delivered such an infusion while the analytic sensitivity walk
+/// (`sens/ode_provider.rs`) dropped it — a *value* divergence, closed by #1196 step 3
+/// giving the value path this test. What that left was the walk disagreeing with
+/// **itself**: four rate-*on* sites spelled `cmt_raw() >= 1` and the rate-*off* saltation
+/// at `K_INF_END` did not, so a lagged `CMT=0` infusion delivered nothing (`f ≡ 0`, both
+/// engines) yet moved `∂f/∂η_LAG` by `+1.8878965164` at the first observation past the
+/// window end, where central FD of the predictor is exactly `0.0`.
+///
+/// Deliberately **not** folded into [`is_real_infusion`]: that predicate answers "are
+/// this row's `rate`/`duration` usable", the break-time builders ask it about every
+/// infusion including a `CMT=0` one (they must still break at its window end for the
+/// segment structure to line up), and only the *forcing* sites ask this.
+#[inline]
+pub(crate) fn infusion_has_rate_channel(d: &DoseEvent) -> bool {
+    d.cmt_raw() != 0
+}
+
 // ---------------------------------------------------------------------------
 // Where a lagged steady-state dose loads, and what the previous cycle leaves
 // running across the dose record (#1121).
@@ -1406,5 +1436,45 @@ mod tad_referent_tests {
             Some(17.0),
             "no wrap without an interval"
         );
+    }
+}
+
+#[cfg(test)]
+mod infusion_rate_channel_tests {
+    use super::*;
+
+    /// The convention, stated once: `CMT=0` is the default dose *bolus* compartment
+    /// (`cmt_idx() == 0`, same state as `CMT=1`), and it is **not** a zero-order input
+    /// target. So the two resolved accessors deliberately disagree with this predicate on
+    /// `CMT=0`, and that disagreement is the whole content of the function — a version
+    /// that returned `d.cmt_idx() < n` or `d.cmt_1based() >= 1` would be `true`
+    /// everywhere and silently re-open #1077 on all six call sites at once.
+    #[test]
+    fn only_cmt_zero_lacks_a_rate_channel() {
+        let cmt0 = DoseEvent::new(0.0, 100.0, 0, 40.0, false, 0.0);
+        let cmt1 = DoseEvent::new(0.0, 100.0, 1, 40.0, false, 0.0);
+        let cmt3 = DoseEvent::new(0.0, 100.0, 3, 40.0, false, 0.0);
+
+        assert!(!infusion_has_rate_channel(&cmt0));
+        assert!(infusion_has_rate_channel(&cmt1));
+        assert!(infusion_has_rate_channel(&cmt3));
+
+        // `CMT=0` and `CMT=1` are the same *state*: the predicate is about the dose's
+        // spelling, not about where the compartment is, which is why it cannot be derived
+        // from either resolved accessor.
+        assert_eq!(cmt0.cmt_idx(), cmt1.cmt_idx());
+        assert_eq!(cmt0.cmt_1based(), cmt1.cmt_1based());
+    }
+
+    /// Orthogonal to `is_real_infusion`, on purpose: the break-time builders ask *that*
+    /// about every infusion — including a `CMT=0` one, whose window end must still break
+    /// the timeline for the segment structure to line up — and only the forcing sites ask
+    /// this. Folding the two would delete a break and change segment geometry.
+    #[test]
+    fn it_is_independent_of_whether_the_row_is_a_real_infusion() {
+        let bolus_cmt0 = DoseEvent::new(0.0, 100.0, 0, 0.0, false, 0.0);
+        let inf_cmt0 = DoseEvent::new(0.0, 100.0, 0, 40.0, false, 0.0);
+        assert!(!is_real_infusion(&bolus_cmt0) && !infusion_has_rate_channel(&bolus_cmt0));
+        assert!(is_real_infusion(&inf_cmt0) && !infusion_has_rate_channel(&inf_cmt0));
     }
 }

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -1910,7 +1910,10 @@ pub(crate) fn infusion_contributes(
     d: &DoseEvent,
     n_states: usize,
 ) -> bool {
-    if !is_real_infusion(d) || d.cmt_raw() == 0 {
+    // The `CMT=0` half is [`crate::dosing::infusion_has_rate_channel`] rather than a
+    // local `cmt_raw() == 0`, so this resolver and the analytic sensitivity walk cannot
+    // spell it differently — which is exactly what they did through #1077.
+    if !is_real_infusion(d) || !crate::dosing::infusion_has_rate_channel(d) {
         return false;
     }
     // One binding, so the range test and the forcing test provably ask about the same

--- a/src/sens/ode_provider.rs
+++ b/src/sens/ode_provider.rs
@@ -5087,10 +5087,13 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
         // Infusions this side sees (mode-aware effective forcing `inf_eff[k].0`).
         if has_any_infusion {
             for (k, d) in subject.doses.iter().enumerate() {
-                // `d.cmt < 1`: an infusion with `CMT=0` has no target and is rejected up
-                // front on both engines (#375 / #899) — see the `filter` in the saltation
-                // walk below. Unreachable from a validated call.
-                if !is_inf(d) || d.cmt_raw() < 1 {
+                // `CMT=0` has no rate channel — the shared predicate, not a local
+                // `cmt_raw() >= 1` (#1077; see `infusion_has_rate_channel`). Rejected up
+                // front on both engines (`E_DOSE_CMT_NOT_INFUSABLE`), so unreachable from
+                // a validated call; it must still read the same here as in the walk's
+                // forcing and in its rate-off saltation, or the gradient carries a
+                // boundary the trajectory never had.
+                if !is_inf(d) || !crate::dosing::infusion_has_rate_channel(d) {
                     continue;
                 }
                 let iws = d.time + lag_val(k);
@@ -5324,13 +5327,17 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
                     .doses
                     .iter()
                     .enumerate()
-                    // `d.cmt >= 1`: an infusion with `CMT=0` has no target — the default dose
-                    // compartment is defined for a bolus but not for a zero-order input, so
-                    // both engines reject it up front (analytical since #375, ODE since #899;
-                    // the datareader does *not* reject it, contrary to #472 #6 / #473 #3 —
-                    // only a *missing* CMT column defaults to 1). Unreachable from a validated
-                    // call, kept for hand-built specs that run no validation.
-                    .filter(|(_, d)| is_inf(d) && d.cmt_raw() >= 1)
+                    // An infusion with `CMT=0` has no target — the default dose compartment
+                    // is defined for a bolus but not for a zero-order input. It is the
+                    // *validator* that rejects it (`check_dose_compartments`, both engines
+                    // since #899), not the datareader, which passes an explicitly written
+                    // `CMT=0` through unchanged (contrary to #472 #6 / #473 #3 — only a
+                    // *missing* CMT column defaults to 1). So this is unreachable from a
+                    // validated call and live for a hand-built spec, where it must agree
+                    // with `active_infusions` and with the rate-off saltation below —
+                    // hence the shared predicate rather than a local `cmt_raw() >= 1`
+                    // (#1077).
+                    .filter(|(_, d)| is_inf(d) && crate::dosing::infusion_has_rate_channel(d))
                     .filter(|(k, d)| {
                         // (Lagged) window start; an infusion before the most recent reset is
                         // off (#472 review #1) and the window tolerance is production's
@@ -5725,13 +5732,15 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
                             // there is tracked in #1072.
                             //
                             // `CMT=0`: the walk's own segment forcing skips this infusion
-                            // entirely (`cmt_raw() >= 1`, mirrored in `boundary_velocity`),
-                            // so there is no rate boundary here to differentiate — injecting
-                            // one would give the gradient a jump the trajectory never had
-                            // (#1060 review #11). Unreachable from a validated call; that the
-                            // walk skips it at all while production's `active_infusions`
-                            // delivers it — a *value* divergence — is tracked in #1077.
-                            if d.cmt_raw() >= 1 {
+                            // entirely (`infusion_has_rate_channel`, mirrored in
+                            // `boundary_velocity`), so there is no rate boundary here to
+                            // differentiate — injecting one would give the gradient a jump
+                            // the trajectory never had (#1060 review #11). Since #1196 step 3
+                            // production's `active_infusions` skips it too, so the *value*
+                            // divergence #1077 reported is closed; the rate-off half of this
+                            // pair at `K_INF_END` still needs the same test, which is what
+                            // makes it one shared predicate rather than five spellings.
+                            if crate::dosing::infusion_has_rate_channel(d) {
                                 let post_params = arrival_post_params();
                                 let prep_post = prep_for(post_params);
                                 // Strict membership (#1060 review #2): only forcings that
@@ -6234,9 +6243,17 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
             // #530: a modeled-duration dose's window end `t+dur` moves with `D` (the `dtinf`
             // jet below carries `∂/∂D`); a modeled-rate dose is already `is_rate_defined`.
             let is_modeled = modeled_at(idx).is_some();
-            // `saturating_sub`: `CMT=0` is the default dose compartment, state index 0 (#899).
-            // The former `d.cmt >= 1` gate dropped this saltation term for such a dose — again
-            // a wrong gradient rather than a visibly zero value.
+            // `CMT=0`: **no** rate turns off here, because none was ever turned on — the
+            // segment forcing and the rate-on saltation both skip such an infusion
+            // (`infusion_has_rate_channel`). This site did not, which is the half of #1077
+            // that survived #1196 step 3 giving the value path the same test: measured on a
+            // lagged `CMT=0` infusion (`ONECPT_IV_LAG_INF_ODE`, `RATE=40`, `AMT=100`), both
+            // engines predict `f ≡ 0` at every observation — no drug ever enters the system
+            // — while this saltation moved `∂f/∂η_LAG` to `+1.8878965164` at the first
+            // observation past the window end, against a central-FD reference of exactly
+            // `0.0`. #899 removed a `d.cmt >= 1` gate here on the premise that the walk
+            // delivered such an infusion; it does not, so the gate belongs — but as the one
+            // predicate every other site asks, not as a fifth local spelling of it.
             // `K_SS_INF_END` closes the *previous* cycle's window, which opened at the
             // dose record rather than at the arrival — so that, not the arrival, is what the
             // reset test must compare (#1121). The shift `δ` is the same either way: the
@@ -6249,6 +6266,7 @@ fn integrate_tvcov_g<T: crate::sens::num::PkNum>(
             };
             if (has_lagtime || is_rate_defined || is_modeled)
                 && window_start >= reset_floor
+                && crate::dosing::infusion_has_rate_channel(d)
                 && d.cmt_idx() < n_states
             {
                 let cmt = d.cmt_idx();
@@ -6927,10 +6945,12 @@ fn integrate_g<T: crate::sens::num::PkNum>(
         // inside or outside each infusion window). `F` is resolved per dose compartment
         // (`dose_f_bio[k]`, #486); pre-scale `F·rate` as a dual once per segment so the RHS
         // closure (every RK45 stage) just adds it. Skipped for bolus-only subjects; the
-        // `cmt >= 1` guard, the `reset_floor` (an infusion before the most recent reset is
-        // off — its window may straddle the reset, #472 review #1/#6), and production's
-        // `INFUSION_EPS` window tolerance all come via the shared `infusion_spans_segment`
-        // predicate (#472 review [7]).
+        // `reset_floor` (an infusion before the most recent reset is off — its window may
+        // straddle the reset, #472 review #1/#6) and production's `INFUSION_EPS` window
+        // tolerance both come via the shared `infusion_spans_segment` predicate
+        // (#472 review [7]), which is purely temporal — the compartment test is the
+        // separate `infusion_has_rate_channel` below (#1077; this comment used to claim
+        // `infusion_spans_segment` carried it, and it never has).
         let active_inf: Vec<(usize, T)> = if !has_any_infusion {
             Vec::new()
         } else {
@@ -6938,7 +6958,7 @@ fn integrate_g<T: crate::sens::num::PkNum>(
                 .doses
                 .iter()
                 .enumerate()
-                .filter(|(_, d)| d.is_infusion() && d.cmt_raw() >= 1)
+                .filter(|(_, d)| d.is_infusion() && crate::dosing::infusion_has_rate_channel(d))
                 .filter(|(_, d)| {
                     infusion_spans_segment(d.time, d.duration, t_start, t_end, reset_floor)
                 })

--- a/src/sens/ode_provider_tests.rs
+++ b/src/sens/ode_provider_tests.rs
@@ -10462,3 +10462,536 @@ fn a_diverged_subject_answers_some_rather_than_declining_to_fd() {
          mislabels an unorderable timeline as an analytic-scope gap"
     );
 }
+
+// ── `CMT=0` on an *infusion*: no rate channel, on either side of the walk (#1077) ──
+//
+// `CMT=0` is the default dose *bolus* compartment; a zero-order input has no default
+// target, so `check_dose_compartments` rejects such a row on both engines
+// (`E_DOSE_CMT_NOT_INFUSABLE`) and neither predictor delivers it. That makes these
+// fixtures hand-built by necessity — the point is precisely what the walk does when
+// validation has not run, because whatever it does must match `active_infusions`.
+//
+// The two tests split by which walk they reach, and they are not interchangeable: the
+// static walk has no infusion rate-off saltation at all (its only moving boundary is a
+// zero-order window end), so the defect below is reachable only from the event-driven
+// one, and a lagtime is what routes a subject there.
+
+/// **Regression for #1077's surviving half.** A lagged `CMT=0` infusion delivers nothing
+/// — the segment forcing and the rate-on saltation both skip it — but the rate-*off*
+/// saltation at `K_INF_END` had no compartment test, so it injected the boundary term for
+/// a rate that was never turned on. Measured before the fix, on exactly this fixture:
+/// `f ≡ 0` at every observation on *both* engines while the walk reported
+/// `∂f/∂η_LAG = +1.8878965164038346` at `t = 4`, `+1.2133620764183783` at `t = 8` and
+/// `+0.7798348668467985` at `t = 12`, against a central-FD reference of exactly `0.0`.
+/// An undosed subject handing FOCEI a finite lagtime gradient is infinite relative error,
+/// not a tolerance question — hence the exact-zero assertions.
+///
+/// Non-degeneracy, all four teeth, because "everything is zero" is the easiest assertion
+/// in the world to pass vacuously:
+///   1. the fixture must reach the **event-driven** walk, the only one with this site;
+///   2. observations must straddle the bioavailable window end (`lag + AMT/RATE`), or
+///      `K_INF_END` is processed with nothing downstream of it to record the injected jet
+///      and the mutation is unreachable;
+///   3. the `CMT=1` twin must be live *on the η_LAG axis specifically* — a twin that is
+///      merely non-zero would still pass if the lagtime axis were dead, which is the one
+///      axis this defect moves;
+///   4. `f` itself must be exactly zero, so a predicate that starts delivering `CMT=0`
+///      infusions again (rather than one that merely stops injecting) also fails here.
+#[test]
+fn ode_provider_cmt_zero_lagged_infusion_injects_no_rate_boundary() {
+    let model = parse_model_string(ONECPT_IV_LAG_INF_ODE).expect("parse lag+inf ODE");
+    let times = [1.0, 2.0, 4.0, 8.0, 12.0];
+    let theta = vec![1.0, 10.0, 0.5];
+    let eta = vec![0.1, 0.05];
+    const ETA_LAG: usize = 1;
+
+    let mk = |cmt: usize| {
+        let mut s = bolus_subject(&times);
+        s.doses = vec![DoseEvent::new(0.0, 100.0, cmt, 40.0, false, 0.0)];
+        s
+    };
+    let s0 = mk(0);
+    let s1 = mk(1);
+
+    // (1) The event-driven walk owns `K_INF_END`; the static walk has no infusion
+    // rate-off saltation, so a static fixture cannot observe this at all.
+    assert!(
+        ode_tvcov_supported(&model, &s0),
+        "fixture must reach the event-driven walk, where the rate-off saltation lives"
+    );
+
+    // (2) The window end must fall strictly inside the observation range, with samples on
+    // both sides: `K_INF_END` is where the jet is injected, and only an observation
+    // *after* it can record one.
+    let window_end = theta[2] * f64::exp(eta[ETA_LAG]) + 100.0 / 40.0;
+    assert!(
+        times.iter().any(|&t| t < window_end) && times.iter().any(|&t| t > window_end),
+        "observations must straddle the window end {window_end}, else `K_INF_END` has \
+         nothing downstream to record its injection"
+    );
+
+    let a = ode_subject_sensitivities(&model, &s0, &theta, &eta).expect("supported");
+    let b = ode_subject_sensitivities(&model, &s1, &theta, &eta).expect("supported");
+    let p0 = compute_predictions_with_tv(&model, &s0, &theta, &eta);
+    assert_eq!(a.obs.len(), times.len());
+
+    // (3) The `CMT=1` twin is live on the η_LAG axis — the one this defect moves. Without
+    // this the whole test passes on a fixture where nothing depends on the lagtime.
+    let twin_lag_grad = b
+        .obs
+        .iter()
+        .map(|o| o.df_deta[ETA_LAG].abs())
+        .fold(0.0_f64, |acc, g| {
+            assert!(
+                g.is_finite(),
+                "CMT=1 twin produced a non-finite η_LAG gradient"
+            );
+            acc.max(g)
+        });
+    assert!(
+        twin_lag_grad > 1.0,
+        "CMT=1 twin's |∂f/∂η_LAG| peaks at {twin_lag_grad}, too small for the CMT=0 arm's \
+         zero to mean anything"
+    );
+
+    for (j, o) in a.obs.iter().enumerate() {
+        // (4) Nothing is delivered, on either engine: no drug ever enters the system.
+        assert_eq!(o.f, 0.0, "obs {j}: CMT=0 infusion must deliver nothing");
+        assert_eq!(
+            p0[j], 0.0,
+            "obs {j}: production must agree it delivers nothing"
+        );
+        // The gradient of the identically-zero function is identically zero. This is the
+        // assertion the defect failed, at `+1.89` on the η_LAG axis.
+        for (k, g) in o.df_deta.iter().enumerate() {
+            assert_eq!(
+                *g, 0.0,
+                "obs {j} (t = {}): ∂f/∂η[{k}] = {g} on a subject that receives no drug — a \
+                 rate boundary was injected for a rate the walk never turned on (#1077)",
+                times[j]
+            );
+        }
+        for (m, g) in o.df_dtheta.iter().enumerate() {
+            assert_eq!(
+                *g, 0.0,
+                "obs {j} (t = {}): ∂f/∂θ[{m}] = {g} on a subject that receives no drug",
+                times[j]
+            );
+        }
+    }
+}
+
+/// The static-walk arm: no saltation site there, so what is under test is the segment
+/// **forcing** filter — the walk must integrate the same trajectory `active_infusions`
+/// does. Both drop a `CMT=0` infusion since #1196 step 3 (before it the value path
+/// delivered one and this walk did not, which is the *value* divergence #1077 was filed
+/// for). The `CMT=1` twin is asserted non-trivial so "they agree on zero" is not the
+/// whole content of the test.
+#[test]
+fn ode_provider_cmt_zero_infusion_static_walk_agrees_with_production() {
+    let model = parse_model_string(TWOCPT_ODE).expect("parse");
+    let times = [1.0, 3.0, 5.0, 6.0, 9.0, 24.0];
+    let theta = vec![4.0, 12.0, 2.0, 25.0];
+    let eta = vec![0.12, -0.08];
+
+    let mk = |cmt: usize| {
+        let mut s = bolus_subject(&times);
+        // amt=1000, rate=200 → a 5 h window, so the last four observations sit past its
+        // end and the first inside it.
+        s.doses = vec![DoseEvent::new(0.0, 1000.0, cmt, 200.0, false, 0.0)];
+        s
+    };
+    let s0 = mk(0);
+    let s1 = mk(1);
+
+    // Dispatch: the *static* walk, asserted both ways so a future routing change that
+    // silently moves this fixture to the event-driven walk fails here rather than
+    // quietly re-testing the other test's ground.
+    assert!(
+        !ode_tvcov_supported(&model, &s0) && ode_subject_supported(&model, &s0),
+        "fixture must reach the static walk"
+    );
+
+    let a = ode_subject_sensitivities(&model, &s0, &theta, &eta).expect("supported");
+    let p0 = compute_predictions_with_tv(&model, &s0, &theta, &eta);
+    let p1 = compute_predictions_with_tv(&model, &s1, &theta, &eta);
+    assert_eq!(a.obs.len(), times.len());
+
+    // The `CMT=1` twin is a real curve (peak 30.48 at t=5 on these parameters), so the
+    // zeros below are a statement about `CMT=0`, not about the fixture.
+    assert!(
+        p1.iter().all(|v| v.is_finite()) && p1.iter().any(|&v| v > 1.0),
+        "CMT=1 twin must be a non-trivial curve, got {p1:?}"
+    );
+
+    for (j, o) in a.obs.iter().enumerate() {
+        assert_eq!(o.f, p0[j], "obs {j}: static walk and production must agree");
+        assert_eq!(o.f, 0.0, "obs {j}: CMT=0 infusion must deliver nothing");
+        for (k, g) in o.df_deta.iter().enumerate() {
+            assert_eq!(*g, 0.0, "obs {j}: ∂f/∂η[{k}] = {g} on an undosed subject");
+        }
+    }
+}
+
+/// The **general** (two-sided) arm of the same boundary. The fixture above has flat
+/// covariates, so `pk_snapshot_equal` holds at `K_INF_END` and the walk takes the
+/// closed-form `inject_rate_saltation` fast path — which never calls `boundary_velocity`,
+/// leaving that site's own compartment test unexercised. A time-varying `WT` makes the
+/// pre/post snapshots differ, routing the same boundary through
+/// `general_rate_off_saltation` and its two `boundary_velocity` evaluations.
+///
+/// Two sites, two branches, one predicate: without this test, reverting the guard in
+/// `boundary_velocity` leaves the whole suite green (the fast path supplies the answer),
+/// which is the "a fast path can make the mutation unreachable" trap.
+#[test]
+fn ode_provider_cmt_zero_lagged_infusion_injects_no_rate_boundary_under_tv_covariates() {
+    let model = parse_model_string(ONECPT_IV_LAG_SS_INF_TVCOV_ODE).expect("parse lag+inf TV ODE");
+    let times = [2.0, 6.0, 9.0, 12.0, 20.0];
+    let theta = vec![1.0, 10.0, 8.0, 0.75];
+    let eta = vec![0.1, 0.05];
+    const ETA_LAG: usize = 1;
+
+    // WT differs at every record, so no two consecutive snapshots are equal and the
+    // rate-off boundary cannot take the `pk_snapshot_equal` fast path. Off the reference
+    // weight (70) throughout, so `WTEXP`'s own jet is live rather than identically zero.
+    let wt = |w: f64| HashMap::from([("WT".to_string(), w)]);
+    let mk = |cmt: usize| {
+        let mut s = bolus_subject(&times);
+        s.doses = vec![DoseEvent::new(0.0, 100.0, cmt, 40.0, false, 0.0)];
+        s.covariates = wt(62.0);
+        s.dose_covariates = vec![wt(62.0)];
+        s.obs_covariates = vec![wt(64.0), wt(68.0), wt(75.0), wt(82.0), wt(90.0)];
+        s
+    };
+    let s0 = mk(0);
+    let s1 = mk(1);
+
+    assert!(
+        s0.has_tv_covariates() && ode_tvcov_supported(&model, &s0),
+        "fixture must carry TV covariates and reach the event-driven walk"
+    );
+
+    // The window `[lag, lag + AMT/RATE]` must open and close strictly inside the
+    // observation range, with samples on both sides of the close.
+    let lag = theta[2] * f64::exp(eta[ETA_LAG]);
+    let window_end = lag + 100.0 / 40.0;
+    assert!(
+        times.iter().any(|&t| t > lag && t < window_end),
+        "an observation must sit inside the infusion window [{lag}, {window_end}]"
+    );
+    assert!(
+        times.iter().any(|&t| t > window_end),
+        "an observation must sit past the window end {window_end}, or `K_INF_END` has \
+         nothing downstream to record its injection"
+    );
+
+    let a = ode_subject_sensitivities(&model, &s0, &theta, &eta).expect("supported");
+    let b = ode_subject_sensitivities(&model, &s1, &theta, &eta).expect("supported");
+    let p0 = compute_predictions_with_tv(&model, &s0, &theta, &eta);
+
+    // The `CMT=1` twin is live on the η_LAG axis — the axis this defect moves.
+    let twin_lag_grad = b
+        .obs
+        .iter()
+        .map(|o| o.df_deta[ETA_LAG].abs())
+        .fold(0.0_f64, |acc, g| {
+            assert!(
+                g.is_finite(),
+                "CMT=1 twin produced a non-finite η_LAG gradient"
+            );
+            acc.max(g)
+        });
+    assert!(
+        twin_lag_grad > 1.0,
+        "CMT=1 twin's |∂f/∂η_LAG| peaks at {twin_lag_grad}, too small for the CMT=0 arm's \
+         zero to mean anything"
+    );
+
+    for (j, o) in a.obs.iter().enumerate() {
+        assert_eq!(o.f, 0.0, "obs {j}: CMT=0 infusion must deliver nothing");
+        assert_eq!(
+            p0[j], 0.0,
+            "obs {j}: production must agree it delivers nothing"
+        );
+        for (k, g) in o.df_deta.iter().enumerate() {
+            assert_eq!(
+                *g, 0.0,
+                "obs {j} (t = {}): ∂f/∂η[{k}] = {g} on a subject that receives no drug \
+                 (general two-sided rate-off branch, #1077)",
+                times[j]
+            );
+        }
+        for (m, g) in o.df_dtheta.iter().enumerate() {
+            assert_eq!(
+                *g, 0.0,
+                "obs {j} (t = {}): ∂f/∂θ[{m}] = {g} on a subject that receives no drug",
+                times[j]
+            );
+        }
+    }
+}
+
+/// A `CMT=0` infusion must not contaminate **another** dose's saltation.
+///
+/// `boundary_velocity` builds `v⁻`/`v⁺` by looping over every dose and adding the rate of
+/// each infusion window spanning the instant, so its own compartment test is reachable
+/// only when some *other* event takes a general two-sided saltation while a `CMT=0`
+/// window happens to be open underneath it. None of the single-dose fixtures above can
+/// see it: with the forcing, rate-on and rate-off sites all skipping the `CMT=0` dose, no
+/// general saltation is taken at all and `boundary_velocity` never runs. Mutation testing
+/// found that guard alive and unobservable — four gates covering for the fifth, which is a
+/// test hole and not belt-and-braces.
+///
+/// **Why this asserts the Hessian, and why that is not optional.** Removing the guard adds
+/// the same constant `r` to `v⁻[c]` *and* `v⁺[c]`, and the saltation is
+/// `u[c] += (v⁻[c] − v⁺[c])·δ + coef2·δ²` with `coef2 = ½(J⁻·v⁻ + J⁺·v⁺) − J⁺·v⁻`. The
+/// contamination cancels exactly in the first-order difference, so `f`, `∂f/∂η` and
+/// `∂f/∂θ` do **not** move; it survives only as `½·r·(J⁻ − J⁺)` in `coef2`, i.e. on `δ²`,
+/// i.e. in `d2f_deta2` / `d2f_deta_dtheta` — and only when the Jacobian actually jumps.
+/// A version of this test comparing the value and first-order blocks alone was written
+/// first and left the mutation alive.
+///
+/// The geometry, every piece load-bearing:
+///   * dose 1 is a `CMT=0` infusion with a **50 h** window, open across dose 2's arrival —
+///     a short window simply would not span the boundary;
+///   * dose 2 is a `CMT=1` **infusion** with a lagtime, so its arrival takes the lagged
+///     rate-on arm that calls `boundary_velocity` (a lagged *bolus* takes a different
+///     injection path and never reaches it);
+///   * `WT` varies per record, which does double duty — it forces the *general* two-sided
+///     branch instead of the closed-form `inject_rate_saltation` fast path (which never
+///     calls `boundary_velocity`), and it makes `J⁻ ≠ J⁺` so the contamination survives
+///     `coef2` at all.
+///
+/// The oracle is a differential pair rather than another bank of zeros: deleting dose 1
+/// must change nothing, because a `CMT=0` infusion contributes nothing. Measured
+/// deviation across all four blocks is **exactly `0.0`** — bit-identical, not merely close
+/// — so this asserts equality rather than a tolerance. (It is bit-identical despite dose 1
+/// contributing three extra break times because all three fall where the state is still
+/// identically zero, before dose 2 arrives.)
+#[test]
+fn ode_provider_cmt_zero_infusion_does_not_contaminate_another_doses_saltation() {
+    let model = parse_model_string(ONECPT_IV_LAG_SS_INF_TVCOV_ODE).expect("parse lag+inf TV ODE");
+    let times = [2.0, 10.0, 14.0, 20.0, 30.0];
+    let theta = vec![1.0, 10.0, 8.0, 0.75];
+    let eta = vec![0.1, 0.05];
+    const ETA_LAG: usize = 1;
+
+    // The `CMT=1` infusion whose lagged arrival carries the saltation under test.
+    let live_dose = DoseEvent::new(5.0, 100.0, 1, 40.0, false, 0.0);
+    // The inert `CMT=0` infusion: 1000 mg at 20 mg/h = a 50 h window.
+    let inert_dose = DoseEvent::new(0.0, 1000.0, 0, 20.0, false, 0.0);
+
+    let wt = |w: f64| HashMap::from([("WT".to_string(), w)]);
+    let mk = |doses: Vec<DoseEvent>| {
+        let mut s = bolus_subject(&times);
+        let n_doses = doses.len();
+        s.doses = doses;
+        s.covariates = wt(62.0);
+        s.dose_covariates = vec![wt(62.0); n_doses];
+        s.obs_covariates = vec![wt(64.0), wt(68.0), wt(75.0), wt(82.0), wt(90.0)];
+        s
+    };
+    // Doses in time order, as every walk expects.
+    let with_inert = mk(vec![inert_dose.clone(), live_dose.clone()]);
+    let reference = mk(vec![live_dose.clone()]);
+
+    assert!(
+        ode_tvcov_supported(&model, &with_inert) && ode_tvcov_supported(&model, &reference),
+        "both arms must reach the event-driven walk, where `boundary_velocity` lives"
+    );
+
+    // Asserted, not assumed: dose 2's lagged arrival has to land strictly inside dose 1's
+    // open window, or `boundary_velocity`'s spanning test excludes dose 1 and the mutation
+    // is unreachable all over again.
+    let lag = theta[2] * f64::exp(eta[ETA_LAG]);
+    let inert_open = inert_dose.time + lag;
+    let inert_close = inert_open + inert_dose.amt / inert_dose.rate;
+    let live_arrival = live_dose.time + lag;
+    assert!(
+        live_arrival > inert_open && live_arrival < inert_close,
+        "dose 2 arrives at {live_arrival}, which must sit strictly inside dose 1's window \
+         [{inert_open}, {inert_close}]"
+    );
+
+    let a = ode_subject_sensitivities(&model, &with_inert, &theta, &eta).expect("supported");
+    let b = ode_subject_sensitivities(&model, &reference, &theta, &eta).expect("supported");
+    assert_eq!(a.obs.len(), times.len());
+    assert_eq!(b.obs.len(), times.len());
+
+    // The reference must be a live curve on the η_LAG axis — the axis the contaminated
+    // `coef2` moves. Finiteness is checked before folding because `f64::max` silently
+    // discards `NaN`, so a diverged solve would otherwise pass this on the strength of
+    // whichever records happened to work.
+    let mut peak_f = 0.0_f64;
+    let mut peak_lag_grad = 0.0_f64;
+    let mut peak_lag_hess = 0.0_f64;
+    for o in &b.obs {
+        assert!(
+            o.f.is_finite(),
+            "reference produced a non-finite prediction"
+        );
+        assert!(
+            o.df_deta[ETA_LAG].is_finite() && o.d2f_deta2[ETA_LAG * 2 + ETA_LAG].is_finite(),
+            "reference produced a non-finite η_LAG derivative"
+        );
+        peak_f = peak_f.max(o.f.abs());
+        peak_lag_grad = peak_lag_grad.max(o.df_deta[ETA_LAG].abs());
+        peak_lag_hess = peak_lag_hess.max(o.d2f_deta2[ETA_LAG * 2 + ETA_LAG].abs());
+    }
+    // Measured: 5.168625231607172 / 31.408784904925405. The Hessian floor matters most —
+    // it is the block the mutation moves, so a fixture whose `∂²f/∂η_LAG²` were ~0 would
+    // make the comparison below vacuous however non-trivial the value curve looked.
+    assert!(
+        peak_f > 1.0 && peak_lag_grad > 1.0 && peak_lag_hess > 1.0,
+        "reference must be non-trivial: peak |f| {peak_f}, peak |∂f/∂η_LAG| {peak_lag_grad}, \
+         peak |∂²f/∂η_LAG²| {peak_lag_hess}"
+    );
+
+    for (j, (x, y)) in a.obs.iter().zip(b.obs.iter()).enumerate() {
+        assert_eq!(
+            x.f, y.f,
+            "obs {j}: an inert CMT=0 infusion moved the prediction"
+        );
+        assert_eq!(x.df_deta, y.df_deta, "obs {j}: it moved ∂f/∂η");
+        assert_eq!(x.df_dtheta, y.df_dtheta, "obs {j}: it moved ∂f/∂θ");
+        assert_eq!(
+            x.d2f_deta2, y.d2f_deta2,
+            "obs {j}: an inert CMT=0 infusion moved ∂²f/∂η² — its rate leaked into a \
+             neighbouring dose's saltation velocities (#1077, `boundary_velocity`)"
+        );
+        assert_eq!(
+            x.d2f_deta_dtheta, y.d2f_deta_dtheta,
+            "obs {j}: an inert CMT=0 infusion moved ∂²f/∂η∂θ (#1077, `boundary_velocity`)"
+        );
+    }
+}
+
+/// **#1129: an `EVID=3` reset strictly between a lagged infusion's dose record and its
+/// arrival must not touch the gradient.** The reset lands on an already-empty system, so
+/// it is a physical no-op — prediction *and* every derivative must be identical with and
+/// without it.
+///
+/// This geometry was uncovered when #1129 was filed. The nearest existing tests miss it in
+/// two different ways: `ode_provider_lagtime_reset_hessian_matches_fd_of_grad` uses a
+/// **bolus** and places the reset *at* the second dose's record time, and
+/// `ode_provider_ss_lagtime_reset_inside_the_pre_arrival_window_matches_production` is
+/// deliberately a bolus too. The uncovered cell is a reset landing strictly inside
+/// `(dose record, lagged **infusion** arrival)`, where `reset_floor` turns finite while a
+/// pending infusion window is still ahead of it — and both the `K_DOSE` rate-on branch and
+/// the `K_INF_END` rate-off branch take `reset_floor` as an argument.
+///
+/// The issue reported `∂f/∂η_LAG` **flipping sign**, `+7.14133` → `−12.53131`, against an
+/// FD reference of `+7.14133`, with `f` and `∂f/∂η_CL` untouched — invisible in any
+/// prediction and reaching FOCEI only through the inner EBE search and the `h` matrix. At
+/// this SHA both arms give `+7.141334` and match FD, so this is a regression pin rather
+/// than a fix; it is here because nothing else asserts it.
+///
+/// Three teeth, since "the two arms agree" is satisfiable by a fixture where neither arm
+/// does anything:
+///   1. both arms are also checked against central FD of the production predictor, so a
+///      change that corrupts *both* identically still fails;
+///   2. the reset must sit strictly between the record and the arrival, asserted from the
+///      realised lag rather than assumed from the θ;
+///   3. `∂f/∂η_LAG` must be large — it is the axis that flipped, and the issue's own
+///      numbers put the defect at ~20 units on it.
+#[test]
+fn ode_provider_reset_before_a_lagged_infusion_arrival_leaves_the_gradient_alone() {
+    let model = parse_model_string(ONECPT_IV_LAG_SS_INF_TVCOV_ODE).expect("parse lag+inf ODE");
+    // `T_inf = AMT/RATE = 4`, arrival ≈ 8.410, window end ≈ 12.410; the sample at 13 is
+    // past the end, so it sees the whole delivered mass and both boundaries.
+    let times = [13.0];
+    let theta = vec![1.0, 10.0, 8.0, 0.75];
+    let eta = vec![0.12, 0.05];
+    const ETA_LAG: usize = 1;
+    const RESET_AT: f64 = 2.0;
+
+    // Flat `WT` — #1129 reproduces with no time-varying covariate, so this must not need
+    // one. (The covariate is present but constant, so every snapshot is equal.)
+    let wt = |w: f64| HashMap::from([("WT".to_string(), w)]);
+    let mk = |resets: Vec<f64>| {
+        let mut s = bolus_subject(&times);
+        s.doses = vec![DoseEvent::new(0.0, 100.0, 1, 25.0, false, 0.0)];
+        s.covariates = wt(70.0);
+        s.dose_covariates = vec![wt(70.0)];
+        s.obs_covariates = vec![wt(70.0)];
+        s.reset_covariates = vec![wt(70.0); resets.len()];
+        s.reset_times = resets;
+        s
+    };
+    let no_reset = mk(vec![]);
+    let with_reset = mk(vec![RESET_AT]);
+
+    // (2) The reset has to land strictly inside `(dose record, arrival)`, which is the
+    // whole point — a reset after the arrival, or at the record, is a different cell that
+    // the tests named above already cover.
+    let lag = theta[2] * f64::exp(eta[ETA_LAG]);
+    let arrival = no_reset.doses[0].time + lag;
+    assert!(
+        RESET_AT > no_reset.doses[0].time && RESET_AT < arrival,
+        "reset {RESET_AT} must sit strictly between the dose record {} and the arrival \
+         {arrival}",
+        no_reset.doses[0].time
+    );
+    assert!(
+        times[0] > arrival + no_reset.doses[0].amt / no_reset.doses[0].rate,
+        "the sample must sit past the infusion window end, so the rate-off boundary is \
+         upstream of it"
+    );
+
+    let fd_deta = |s: &Subject, k: usize| -> f64 {
+        let h = 1e-6;
+        let mut ep = eta.clone();
+        ep[k] += h;
+        let mut em = eta.clone();
+        em[k] -= h;
+        (compute_predictions_with_tv(&model, s, &theta, &ep)[0]
+            - compute_predictions_with_tv(&model, s, &theta, &em)[0])
+            / (2.0 * h)
+    };
+
+    let a = ode_subject_sensitivities(&model, &no_reset, &theta, &eta).expect("supported");
+    let b = ode_subject_sensitivities(&model, &with_reset, &theta, &eta).expect("supported");
+
+    // (3) The lagtime axis must actually be live. Measured `+7.141334`; the defect moved it
+    // by ~19.7, so a fixture whose η_LAG gradient were near zero could not show it.
+    assert!(
+        a.obs[0].df_deta[ETA_LAG].abs() > 1.0,
+        "∂f/∂η_LAG is {} — too small for this fixture to witness a ~20-unit corruption",
+        a.obs[0].df_deta[ETA_LAG]
+    );
+
+    // (1) Both arms against FD of production. `2e-3` relative is the tolerance the rest of
+    // this module's `check_vs_production` uses for a central-difference reference; the
+    // defect under test is a 275% error on this element, nowhere near it.
+    for (name, s, sens) in [("no reset", &no_reset, &a), ("reset", &with_reset, &b)] {
+        for k in 0..model.n_eta {
+            let fd = fd_deta(s, k);
+            assert!(
+                fd.is_finite(),
+                "{name}: FD reference for η[{k}] is not finite"
+            );
+            approx::assert_relative_eq!(
+                sens.obs[0].df_deta[k],
+                fd,
+                max_relative = 2e-3,
+                epsilon = 1e-6
+            );
+        }
+    }
+
+    // The reset is a physical no-op, so the two arms must agree — on the value and on
+    // every derivative block, not just the one that flipped.
+    assert_eq!(a.obs[0].f, b.obs[0].f, "the reset moved the prediction");
+    assert_eq!(
+        a.obs[0].df_deta, b.obs[0].df_deta,
+        "an EVID=3 reset of an already-empty system moved ∂f/∂η (#1129)"
+    );
+    assert_eq!(
+        a.obs[0].df_dtheta, b.obs[0].df_dtheta,
+        "an EVID=3 reset of an already-empty system moved ∂f/∂θ (#1129)"
+    );
+    assert_eq!(
+        a.obs[0].d2f_deta2, b.obs[0].d2f_deta2,
+        "an EVID=3 reset of an already-empty system moved ∂²f/∂η² (#1129)"
+    );
+}


### PR DESCRIPTION
## Why

#1077 reports that a `CMT=0` infusion is delivered by the production ODE predictor but
skipped by the analytic sensitivity walk, so `f` itself diverges between the two.

**That half is already fixed, and the issue's proposed fix is now the wrong direction.**
Measured on `b706b1a3` (2-cpt ODE, `AMT=1000 RATE=200`, static walk):

| t | walk `f` (`CMT=0`) | production `f` (`CMT=0`) | production `f` (`CMT=1`) |
|---|---|---|---|
| 1 | 0.000000 | 0.000000 | 13.684469 |
| 5 | 0.000000 | 0.000000 | 30.479873 |
| 24 | 0.000000 | 0.000000 | 1.393836 |

The issue quotes a body of `active_infusions` that no longer exists. Since `4ea6a024`
(PR #1231, #1196 step 3) both infusion resolvers go through `infusion_contributes`, whose
first line drops `cmt_raw() == 0` — so the repo took the issue's *second* option ("reject
it"), as a side effect of a different PR. Two further premises are stale:

- "the datareader does not reject it" is true but not load-bearing:
  `check_dose_compartments` raises **`E_DOSE_CMT_NOT_INFUSABLE`** for any `AMT>0` `CMT=0`
  infusion on both engines, it is tested (`infusion_into_cmt_zero_is_rejected`), and it is
  documented user-facing behaviour (`docs/data-format.qmd` §`CMT`). The divergence was only
  ever reachable from a hand-built spec.
- "drop the guards so the walk mirrors `active_infusions`" was never available repo-wide:
  on the analytical engine `dose_channel(0)` is `None`, so delivering a `CMT=0` infusion
  there would panic. Rejecting is the deliberate convention.

**What is still live** is the walk disagreeing with *itself*. Four rate-**on** sites spelled
the compartment test `cmt_raw() >= 1`; the rate-**off** saltation at `K_INF_END` did not,
because #899 removed a `d.cmt >= 1` gate there on the premise that the walk delivered such
an infusion. So a lagged `CMT=0` infusion injects the boundary term for a rate that was
never turned on. Measured on `ONECPT_IV_LAG_INF_ODE` (`AMT=100 RATE=40`), event-driven walk:

| t | walk `f` | production `f` | walk `∂f/∂η_LAG` | central FD of production |
|---|---|---|---|---|
| 1.0 | 0.0 | 0.0 | 0.0 | 0.0 |
| 2.0 | 0.0 | 0.0 | 0.0 | 0.0 |
| 4.0 | 0.0 | 0.0 | **+1.8878965164038346** | 0.0 |
| 8.0 | 0.0 | 0.0 | **+1.2133620764183783** | 0.0 |
| 12.0 | 0.0 | 0.0 | **+0.7798348668467985** | 0.0 |

The nonzero entries begin exactly past the bioavailable window end
(`0.5·exp(0.05) + 100/40 ≈ 3.03`), the `K_INF_END` signature. A subject that receives no
drug hands FOCEI a finite lagtime gradient — infinite relative error, not a tolerance
question.

## What changed

One predicate, `dosing::infusion_has_rate_channel`, asked by **all six** infusion-forcing
sites — one on the value path, five on the sensitivity walk — replacing four hand-written
copies plus the one site that was missing it. This is CLAUDE.md's "when the bug report is
*two implementations disagree*, the fix is one implementation", and it is what stops the
rate-on and rate-off halves of the same boundary drifting apart again. `src/dosing.rs` is
the home because it is already the neutral one shared by `pk`/`ode`/`sens`.

Behaviour on every currently-reachable input is unchanged: the value-path edit is a literal
rewrite of the same condition, and a `CMT=0` infusion remains a hard validation error.

Three stale comments corrected in passing, all asserting things false at this SHA — that
the datareader rejects `CMT=0`, that `infusion_spans_segment` carries the compartment test
(it is purely temporal and never has), and that production delivers such an infusion.

Also included, no production change:

- **#1129 regression pin.** An `EVID=3` reset strictly between a lagged infusion's record
  and its arrival. The issue reports `∂f/∂η_LAG` flipping `+7.14133` → `−12.53131` against
  FD `+7.14133`; at this SHA both arms give `+7.141334` and match FD, so the defect is
  gone. The cell is genuinely uncovered though — the nearest tests use a *bolus*
  (`ode_provider_lagtime_reset_hessian_matches_fd_of_grad`) or put the reset *at* a record
  time — so the test is added as a pin. **#1129 stays open**: which commit fixed it is not
  yet identified, and "green now" is not a close.

## Alternatives considered

**Deliver `CMT=0` infusions in the walk** (the issue's preferred option). Rejected: it
contradicts the documented convention, cannot be matched on the analytical engine
(`dose_channel(0) == None`), and would re-open the value divergence in the opposite
direction now that #1196 gave the value path the same test.

**Route the walk to the FD fallback for this input.** Correct but a performance cliff for a
row that is a hard validation error anyway, and it leaves the five spellings in place.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public API change; `infusion_has_rate_channel` is `pub(crate)`.

## Breaking changes

- [x] None

## Numerical validation

- [x] Compared against: prior ferx commit `b706b1a3` (the before/after tables above)
- [x] Not applicable for NONMEM — see below

**On the NONMEM rule.** There is no equivalent run to make: the changed surface is
unreachable from any dataset NONMEM could also be handed, because ferx rejects it
(`E_DOSE_CMT_NOT_INFUSABLE`) before a fit starts. What anchors the fixtures instead is the
`CMT=1` twin, which *is* NONMEM-anchored — the `dose_cmt_*` family (13 evaluation-only runs
on NONMEM 7.6.0, `nonmem_anchor/README.md`) pins infusion compartment routing, and
`ss_cmt0`/`ss_cmt1` pins that NONMEM prints identical `PRED` for `CMT=0` and `CMT=1` on a
bolus. Each test asserts the `CMT=1` arm is live before concluding anything from the
`CMT=0` arm's zeros, so the anchor transfers rather than being assumed. No NONMEM
installation exists in this environment (only committed `.ctl`/`.csv`/`results`), so a new
run could not have been produced here in any case.

## Performance

- [x] No significant impact expected — one `usize` comparison, `#[inline]`, at sites that
      already ran per dose per segment.

## Tests

- [x] Unit test(s) added in module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

| test | walk | what only it can see |
|---|---|---|
| `..._cmt_zero_infusion_static_walk_agrees_with_production` | static | the static forcing filter; the static walk has no infusion rate-off saltation at all |
| `..._cmt_zero_lagged_infusion_injects_no_rate_boundary` | event-driven | **the regression**; `pk_snapshot_equal` fast path |
| `..._injects_no_rate_boundary_under_tv_covariates` | event-driven | the general two-sided branch |
| `..._does_not_contaminate_another_doses_saltation` | event-driven | a `CMT=0` window open *under another dose's* saltation |
| `..._reset_before_a_lagged_infusion_arrival_leaves_the_gradient_alone` | event-driven | #1129's uncovered cell |
| `only_cmt_zero_lacks_a_rate_channel` | — | the convention: the predicate disagrees with *both* resolved accessors on `CMT=0` |
| `it_is_independent_of_whether_the_row_is_a_real_infusion` | — | that it is not foldable into `is_real_infusion` |

Non-degeneracy, because "everything is zero" is the easiest assertion to pass vacuously:
each gradient test asserts the fixture reaches the intended walk, that observations straddle
the window end so `K_INF_END` has something downstream to record, that the `CMT=1` twin's
`|∂f/∂η_LAG|` peaks above 1.0 on the *lagtime* axis specifically, and that `f` is exactly
`0.0` — so a predicate that starts *delivering* `CMT=0` infusions fails too, not only one
that stops injecting.

### Mutation results

Every changed site reverted in turn:

| # | site | result | killed by |
|---|---|---|---|
| M1 | `infusion_has_rate_channel` -> `true` | killed | — |
| M2 | value path (`infusion_contributes`) | killed | — |
| M3 | `boundary_velocity` | **survived** | see below |
| M4 | event-walk segment forcing | killed | both lagged tests |
| M5 | rate-on arrival saltation | killed | both lagged tests |
| M6 | **rate-off `K_INF_END`** (the fix) | killed | both lagged tests |
| M7 | static-walk segment forcing | killed | static test |

M6 kills the fast-path arm and the general-branch arm *separately*, per CLAUDE.md's
"mutate each side of a twin separately".

**M3 survives, and I could not close it — stated rather than papered over.** The
contamination enters only as `1/2 r (J- - J+)` in the `delta^2` coefficient (it cancels
exactly in `v- - v+`), so it is observable only when the Jacobian jumps across the boundary.
A runtime probe shows it never does:

```
ZZARR t=13.410168771008193 snapshot_equal=true pre0=1.1638630102738547 post0=1.1638630102738547
ZZBV  t=13.410168771008193 k=0 cmt_raw=0 adding rate=20 strict=true   <- v-
ZZBV  t=13.410168771008193 k=0 cmt_raw=0 adding rate=20 strict=true   <- v+
```

The rate *is* added to both velocities, but both sides read the same snapshot (`CL`
back-solves to `WT = 75`, the `t = 14` record) even with a covariate record at `t = 10`
sitting strictly between the dose record and the arrival. That is **#1160's mechanism, at a
site #1160 does not claim** — it scopes the degeneracy to `K_INF_END`/`K_ZO_END`, and this
is the rate-on arrival, the branch #1060 made unconditional for exactly this geometry.

The guard is kept anyway: it becomes load-bearing the moment `pre != post` is possible, and
its absence would then be a live defect. The call site says so and points at #1160. I have
posted the probe evidence there, including the fork that should be settled before anything
is deleted — whether `pre == post` is the intended convention or is itself the wrong-number
defect, since under it the field jump #1060 targeted is captured by neither side.

## Docs

- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No user-visible change — `docs/data-format.qmd` already documents that a `CMT=0`
      infusion is rejected, and that statement is still true. No validated fit changes.

## Checklist

- [x] `tools/preflight.sh` green
- [x] Functions on the `Dual2` sensitivity path stay differentiable — the change only
      *removes* a jet injection on an input that carries no forcing; the predicate is on
      `DoseEvent`, not on `T`.

## Reviewer hints

The one line that changes behaviour is the `infusion_has_rate_channel(d)` added to the
`K_INF_END` guard in `integrate_tvcov_g`. Everything else is a literal rewrite of an
existing condition, a comment correction, or a test.

Worth a second opinion: whether keeping an unobservable guard in `boundary_velocity` is
right, versus deleting it and letting #1160 restore it if that investigation concludes the
branch should be live.

## Open questions

- #1129 is pinned but not attributed. Should it stay open (my assumption) until a bisect
  names the commit that fixed it?
- #1160 looks like it may be a wrong-number defect rather than dead code. Worth re-titling?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #1077
