### PR TITLE
fix(survival): pass dose-time anchors to TTE hazard readouts [closes #1261]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ section of the SDLC for the versioning policy).
 
 - **SAEM now averages the residual sufficient statistic for eligible single additive and proportional error models, reducing final-draw Monte Carlo noise in the residual SD estimate (#1321).**
 
+### Fixed
+
+- Fixed ODE-accumulated survival hazards that read `TAD`, which could reject valid multi-dose subjects with a misleading finite objective (#1261).
+
 ### Performance
 
 - **`focei, n_agq > 1` (the Gauss-Newton-anchored FOCEI quadrature refinement) now assembles

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -2598,6 +2598,27 @@ fn subject_dose_attrs(
     (dose_lagtimes, dose_f_bio)
 }
 
+/// Build the extended parameter slice required for a standalone RHS read at `t`.
+///
+/// Integrating prediction paths keep this slice live and update its TAD anchor at
+/// each segment boundary. Readout-only callers (the TTE hazard derivative) do not
+/// own that walk, so they must derive both anchors from the same dose-time helpers
+/// instead of passing a bare [`PkParams::values`](crate::types::PkParams::values)
+/// array to the RHS (#1261).
+#[cfg(feature = "survival")]
+#[inline]
+pub(crate) fn rhs_ext_params_at(
+    ode: &OdeSpec,
+    subject: &Subject,
+    pk_params_flat: &[f64],
+    t: f64,
+) -> [f64; crate::types::MAX_PK_PARAMS + 2] {
+    let (dose_lagtimes, _) = subject_dose_attrs(subject, ode, pk_params_flat);
+    let mut ext_params = seed_ext_params(pk_params_flat, earliest_dose_time(&subject.doses));
+    ext_params[crate::types::MAX_PK_PARAMS + 1] = tad_anchor_for(&subject.doses, &dose_lagtimes, t);
+    ext_params
+}
+
 /// Earliest dose record time, or `+∞` when there are no doses.
 ///
 /// Takes the dose list rather than the `Subject` so the EKF

--- a/src/ode/predictions.rs
+++ b/src/ode/predictions.rs
@@ -2598,7 +2598,28 @@ fn subject_dose_attrs(
     (dose_lagtimes, dose_f_bio)
 }
 
-/// Build the extended parameter slice required for a standalone RHS read at `t`.
+/// Per-dose lagtimes only — the half of [`subject_dose_attrs`] that
+/// [`rhs_ext_params_at`] needs. Callers that read `H`/`h` at many `times` for the same
+/// subject (the TTE hazard readouts, #1261) compute this once and reuse it, rather than
+/// re-walking the dose list — and recomputing the unused `F`/bioavailability half — on
+/// every timepoint.
+#[cfg(feature = "survival")]
+#[inline]
+pub(crate) fn dose_lagtimes_for(
+    subject: &Subject,
+    ode: &OdeSpec,
+    pk_params_flat: &[f64],
+) -> Vec<f64> {
+    subject
+        .doses
+        .iter()
+        .map(|d| ode.dose_attr_map.lagtime(d.cmt_raw(), pk_params_flat))
+        .collect()
+}
+
+/// Build the extended parameter slice required for a standalone RHS read at `t`, from
+/// a dose-lagtime vector and first-dose time the caller has already computed (via
+/// [`dose_lagtimes_for`] / [`earliest_dose_time`]) — once per subject, not once per `t`.
 ///
 /// Integrating prediction paths keep this slice live and update its TAD anchor at
 /// each segment boundary. Readout-only callers (the TTE hazard derivative) do not
@@ -2608,14 +2629,14 @@ fn subject_dose_attrs(
 #[cfg(feature = "survival")]
 #[inline]
 pub(crate) fn rhs_ext_params_at(
-    ode: &OdeSpec,
-    subject: &Subject,
+    doses: &[DoseEvent],
+    dose_lagtimes: &[f64],
+    first_dose_time: f64,
     pk_params_flat: &[f64],
     t: f64,
 ) -> [f64; crate::types::MAX_PK_PARAMS + 2] {
-    let (dose_lagtimes, _) = subject_dose_attrs(subject, ode, pk_params_flat);
-    let mut ext_params = seed_ext_params(pk_params_flat, earliest_dose_time(&subject.doses));
-    ext_params[crate::types::MAX_PK_PARAMS + 1] = tad_anchor_for(&subject.doses, &dose_lagtimes, t);
+    let mut ext_params = seed_ext_params(pk_params_flat, first_dose_time);
+    ext_params[crate::types::MAX_PK_PARAMS + 1] = tad_anchor_for(doses, dose_lagtimes, t);
     ext_params
 }
 

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -11879,6 +11879,19 @@ fn build_ode_spec(
 
     let rhs: Box<dyn Fn(&[f64], &[f64], f64, &mut [f64]) + Send + Sync> =
         Box::new(move |u: &[f64], params: &[f64], t: f64, du: &mut [f64]| {
+            // The RHS always reserves two trailing slots for dose-time anchors:
+            // TAFD at MAX_PK_PARAMS and TAD at MAX_PK_PARAMS + 1. Passing a bare
+            // PkParams::values array (which ends at MAX_PK_PARAMS) turns either
+            // read into NaN and lets that non-finite value surface much later as a
+            // misleading likelihood sentinel. Keep the interface slice-based, but
+            // make every missing extended-parameter injection fail immediately in
+            // debug/test builds (#1266).
+            debug_assert!(
+                params.len() >= crate::types::MAX_PK_PARAMS + 2,
+                "ODE RHS: params.len() = {} < extended parameter length {} (TAFD/TAD slots)",
+                params.len(),
+                crate::types::MAX_PK_PARAMS + 2,
+            );
             // The integrator always passes a `u` whose length matches the
             // declared state count. The old closure index-panicked on
             // `u[i]` if that contract ever broke; preserve that signal here

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -8341,7 +8341,8 @@ fn test_ode_block_supports_if_statements() {
     let ode = parsed.model.ode_spec.as_ref().expect("ode_spec present");
     // States are [depot, central]; params are [CL, V] (declaration order in
     // [individual_parameters]). du must match n_states.
-    let params = vec![2.0, 10.0];
+    let mut params = vec![f64::NAN; crate::types::MAX_PK_PARAMS + 2];
+    params[..2].copy_from_slice(&[2.0, 10.0]);
 
     // central > 0 → if-branch fires, du[central] = -CL/V * central
     let u_pos = vec![0.0, 5.0];

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -221,6 +221,9 @@ pub(crate) struct JointPkTteSolve {
     chz_states: Vec<Vec<f64>>,
     /// PK-parameter snapshot used for the solve — reused to evaluate `h = dCHZ/dt`.
     pk_values: Vec<f64>,
+    /// Extended parameter snapshots aligned to `times`, including the dose-time anchors
+    /// the RHS reads when evaluating `h = dCHZ/dt` (#1261).
+    rhs_params: Vec<[f64; crate::types::MAX_PK_PARAMS + 2]>,
 }
 
 /// Build the shared joint PK-TTE solve, but only when it is provably equivalent to
@@ -317,6 +320,10 @@ fn try_joint_pktte_shared_solve(
     let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
     let (mut preds, chz_states) =
         crate::ode::ode_predictions_and_chz(ode, &pk.values, theta, eta, subject, &times);
+    let rhs_params = times
+        .iter()
+        .map(|&t| crate::ode::predictions::rhs_ext_params_at(ode, subject, &pk.values, t))
+        .collect();
     // Apply exactly the post-processing the standalone no-TV ODE prediction path does
     // (compute_predictions_with_tv_into_with_schedule): init impulse, [scaling], LTBS.
     // No-op for Form-C / no-init / linear-scale models; FREM is excluded by the guard.
@@ -329,6 +336,7 @@ fn try_joint_pktte_shared_solve(
         times,
         chz_states,
         pk_values: pk.values.to_vec(),
+        rhs_params,
     })
 }
 
@@ -357,7 +365,7 @@ fn tte_ode_nll_from_shared(
             continue;
         }
         cum[i] = st[chz_state];
-        (ode.rhs)(st, &share.pk_values, t, &mut du);
+        (ode.rhs)(st, &share.rhs_params[i], t, &mut du);
         haz[i] = du[chz_state];
     }
     let tol = crate::survival::MonoTol::from_solver(&ode.effective_solver_opts());
@@ -4160,6 +4168,100 @@ mod tests {
     /// `t_last ≥ subject_integration_start` and so routes the pre-start read through the
     /// engines' pre-first-break **fill** rather than through the `k = 0` boundary visit
     /// that covers a degenerate every-time-before-the-dose timeline (#1218).
+    /// #1261: a TTE hazard readout must receive the dose-time anchors the ODE
+    /// integration used. A bare `PkParams::values` slice made TAD NaN, which the
+    /// scorer converted into its finite 1e20 rejection sentinel.
+    #[cfg(feature = "survival")]
+    #[test]
+    fn tte_hazard_readout_uses_the_current_tad_anchor() {
+        use crate::parser::model_parser::parse_model_string;
+        use crate::types::{EventType, ObsRecord};
+
+        let model = parse_model_string(
+            r"
+[parameters]
+theta TVCL(1.0, 0.01, 100.0)
+theta TVV(10.0, 0.1, 500.0)
+theta TVH0(0.1, 0.001, 10.0)
+theta TVKT(0.01, 0.0001, 1.0)
+sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+CL = TVCL
+V = TVV
+H0 = TVH0
+KT = TVKT
+[structural_model]
+ode(obs_cmt=central, states=[central])
+[odes]
+d/dt(central) = -CL / V * central
+[event_model]
+cmt = 3
+hazard = H0 * (1.0 + KT * TAD)
+[error_model]
+DV ~ proportional(PROP_ERR)
+",
+        )
+        .expect("TAD-reading ODE hazard must parse");
+        let (chz_state, hazard) = match model.endpoints.get(&3) {
+            Some(EndpointLikelihood::Tte {
+                hazard: h @ HazardSpec::OdeAccumulated { chz_state },
+                ..
+            }) => (*chz_state, h),
+            _ => panic!("expected ODE-accumulated endpoint"),
+        };
+        let mut subject = make_simple_subject();
+        subject.doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+        ];
+        subject.obs_times = vec![30.0];
+        subject.observations = vec![0.0];
+        subject.obs_cmts = vec![1];
+        subject.cens = vec![0];
+        subject.occasions = vec![1];
+        subject.obs_records = vec![ObsRecord::Event {
+            time: 30.0,
+            event_type: EventType::Exact,
+            entry_time: 0.0,
+            cmt: 3,
+        }];
+        let p = &model.default_params;
+        let eta = [];
+        let nll = tte_endpoint_nll(
+            &model,
+            &subject,
+            hazard,
+            crate::types::TteRecurrence::Single,
+            &subject.obs_records,
+            &p.theta,
+            &eta,
+        );
+
+        // H(30) = .1 * [integral_0^12(1 + .01t) + integral_12^30(1 + .01(t - 12))] = 3.234.
+        // h(30) = .1 * (1 + .01 * 18) = .118. Two doses prevent TAD and TAFD aliasing.
+        // The 1e10 guard is ten orders below the old 2e20 sentinel and nine orders above
+        // this roughly 5.37 objective, so it rejects the masked NaN without overfitting
+        // to solver-level round-off.
+        let expected = 3.234_f64 - 0.118_f64.ln();
+        assert_relative_eq!(nll, expected, epsilon = 2e-4);
+        assert!(
+            nll < 1e10,
+            "the old NaN path returns the finite 1e20 sentinel, not an infinite NLL; got {nll}"
+        );
+
+        let (cum, haz) = crate::survival::ode_cumhaz_hazard(
+            &model,
+            &subject,
+            chz_state,
+            &p.theta,
+            &eta,
+            &[30.0],
+        );
+        assert_relative_eq!(cum[0], 3.234, epsilon = 2e-4);
+        assert_relative_eq!(haz[0], 0.118, epsilon = 2e-6);
+    }
+
+    /// Construct a subject with a positive pre-start TTE time and later PK observations.
     #[cfg(feature = "survival")]
     fn late_start_joint_subject(records: Vec<ObsRecord>) -> Subject {
         let mut subject = make_simple_subject();
@@ -4339,7 +4441,7 @@ mod tests {
             }
             // `H` and `h` read exactly as `tte_ode_nll_from_shared` reads them.
             let mut du = vec![0.0; ode.n_states];
-            (ode.rhs)(st, &share.pk_values, t_pre, &mut du);
+            (ode.rhs)(st, &share.rhs_params[i], t_pre, &mut du);
             let (share_cum, share_haz) = (st[chz_state], du[chz_state]);
 
             // Engine 2 — the dedicated two-solve arm.

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -320,9 +320,19 @@ fn try_joint_pktte_shared_solve(
     let pk = (model.pk_param_fn)(theta, eta, &subject.covariates, 0.0);
     let (mut preds, chz_states) =
         crate::ode::ode_predictions_and_chz(ode, &pk.values, theta, eta, subject, &times);
+    let dose_lagtimes = crate::ode::predictions::dose_lagtimes_for(subject, ode, &pk.values);
+    let first_dose_time = crate::ode::predictions::earliest_dose_time(&subject.doses);
     let rhs_params = times
         .iter()
-        .map(|&t| crate::ode::predictions::rhs_ext_params_at(ode, subject, &pk.values, t))
+        .map(|&t| {
+            crate::ode::predictions::rhs_ext_params_at(
+                &subject.doses,
+                &dose_lagtimes,
+                first_dose_time,
+                &pk.values,
+                t,
+            )
+        })
         .collect();
     // Apply exactly the post-processing the standalone no-TV ODE prediction path does
     // (compute_predictions_with_tv_into_with_schedule): init impulse, [scaling], LTBS.
@@ -4159,25 +4169,17 @@ mod tests {
         .expect("joint PK-TTE model must parse")
     }
 
-    /// A joint PK-TTE subject whose first record is a dose at **t = 10** — so the
-    /// integration starts at 10 and a TTE time below it is genuinely pre-start.
-    ///
-    /// `make_simple_subject` cannot host one: it doses at `t = 0`, and `entry_time` is
-    /// gated `> 0.0` ("no truncation"), so there is no positive time before its start.
-    /// PK observations sit at 12 / 16 / 24, all *after* the dose, which keeps
-    /// `t_last ≥ subject_integration_start` and so routes the pre-start read through the
-    /// engines' pre-first-break **fill** rather than through the `k = 0` boundary visit
-    /// that covers a degenerate every-time-before-the-dose timeline (#1218).
-    /// #1261: a TTE hazard readout must receive the dose-time anchors the ODE
-    /// integration used. A bare `PkParams::values` slice made TAD NaN, which the
-    /// scorer converted into its finite 1e20 rejection sentinel.
+    /// Plain no-TV `[odes]` block (does not itself read `TAD`) plus an `OdeAccumulated`
+    /// hazard that does — the exact model shape `try_joint_pktte_shared_solve`'s
+    /// `model_uses_time_anywhere` guard admits to the #570 shared solve, since that
+    /// check is scoped to the PK program and does not inspect the injected
+    /// `d/dt(__chz_*)` hazard line. Shared by the two tests below: one exercising
+    /// `tte_endpoint_nll` / `ode_cumhaz_hazard` directly, the other the production
+    /// `individual_nll_into_with_schedule` entry point FOCE/FOCEI actually calls.
     #[cfg(feature = "survival")]
-    #[test]
-    fn tte_hazard_readout_uses_the_current_tad_anchor() {
+    fn tad_hazard_two_dose_model() -> CompiledModel {
         use crate::parser::model_parser::parse_model_string;
-        use crate::types::{EventType, ObsRecord};
-
-        let model = parse_model_string(
+        parse_model_string(
             r"
 [parameters]
 theta TVCL(1.0, 0.01, 100.0)
@@ -4201,7 +4203,27 @@ hazard = H0 * (1.0 + KT * TAD)
 DV ~ proportional(PROP_ERR)
 ",
         )
-        .expect("TAD-reading ODE hazard must parse");
+        .expect("TAD-reading ODE hazard must parse")
+    }
+
+    /// A joint PK-TTE subject whose first record is a dose at **t = 10** — so the
+    /// integration starts at 10 and a TTE time below it is genuinely pre-start.
+    ///
+    /// `make_simple_subject` cannot host one: it doses at `t = 0`, and `entry_time` is
+    /// gated `> 0.0` ("no truncation"), so there is no positive time before its start.
+    /// PK observations sit at 12 / 16 / 24, all *after* the dose, which keeps
+    /// `t_last ≥ subject_integration_start` and so routes the pre-start read through the
+    /// engines' pre-first-break **fill** rather than through the `k = 0` boundary visit
+    /// that covers a degenerate every-time-before-the-dose timeline (#1218).
+    /// #1261: a TTE hazard readout must receive the dose-time anchors the ODE
+    /// integration used. A bare `PkParams::values` slice made TAD NaN, which the
+    /// scorer converted into its finite 1e20 rejection sentinel.
+    #[cfg(feature = "survival")]
+    #[test]
+    fn tte_hazard_readout_uses_the_current_tad_anchor() {
+        use crate::types::{EventType, ObsRecord};
+
+        let model = tad_hazard_two_dose_model();
         let (chz_state, hazard) = match model.endpoints.get(&3) {
             Some(EndpointLikelihood::Tte {
                 hazard: h @ HazardSpec::OdeAccumulated { chz_state },
@@ -4259,6 +4281,116 @@ DV ~ proportional(PROP_ERR)
         );
         assert_relative_eq!(cum[0], 3.234, epsilon = 2e-4);
         assert_relative_eq!(haz[0], 0.118, epsilon = 2e-6);
+    }
+
+    /// #1261 code-review follow-up: the sibling test above calls `tte_endpoint_nll` and
+    /// `ode_cumhaz_hazard` directly, never the dispatcher FOCE/FOCEI's inner loop
+    /// actually calls. `individual_nll_into_with_schedule` builds `joint_share` for this
+    /// exact model shape (plain no-TV `[odes]` + an `OdeAccumulated` hazard reading
+    /// `TAD`) and routes the TTE term through `tte_ode_nll_from_shared` /
+    /// `share.rhs_params[i]` instead — the #1261 fix's real call site
+    /// (`src/stats/likelihood.rs`, the `(ode.rhs)(st, &share.rhs_params[i], t, &mut du)`
+    /// line). A revert there would go uncaught by every other test in this file.
+    ///
+    /// Isolate the TTE contribution by subtracting a PK-only sibling model/subject that
+    /// drops `[event_model]` and the CMT-3 record entirely: both share the identical
+    /// `[odes]` block, doses, and PK observation, so the Gaussian data term is the same
+    /// between the two calls and cancels in the difference — the #570 shared solve's own
+    /// invariant is that its predictions are bit-identical to the standalone no-TV path
+    /// the PK-only sibling takes (`try_joint_pktte_shared_solve` returns `None` for it,
+    /// since it declares no TTE endpoint to share).
+    #[cfg(feature = "survival")]
+    #[test]
+    fn hot_path_individual_nll_reads_the_shared_solve_tad_anchor() {
+        use crate::parser::model_parser::parse_model_string;
+        use crate::types::{EventType, ObsRecord};
+
+        let model = tad_hazard_two_dose_model();
+        let pk_only_model = parse_model_string(
+            r"
+[parameters]
+theta TVCL(1.0, 0.01, 100.0)
+theta TVV(10.0, 0.1, 500.0)
+sigma PROP_ERR ~ 0.02 (sd)
+[individual_parameters]
+CL = TVCL
+V = TVV
+[structural_model]
+ode(obs_cmt=central, states=[central])
+[odes]
+d/dt(central) = -CL / V * central
+[error_model]
+DV ~ proportional(PROP_ERR)
+",
+        )
+        .expect("PK-only sibling model must parse");
+
+        let mut subject = make_simple_subject();
+        subject.doses = vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+        ];
+        subject.obs_times = vec![30.0];
+        subject.observations = vec![0.0];
+        subject.obs_cmts = vec![1];
+        subject.cens = vec![0];
+        subject.occasions = vec![1];
+        subject.obs_records = vec![ObsRecord::Event {
+            time: 30.0,
+            event_type: EventType::Exact,
+            entry_time: 0.0,
+            cmt: 3,
+        }];
+        let mut pk_only_subject = subject.clone();
+        pk_only_subject.obs_records = Vec::new();
+
+        let eta = [];
+
+        // The fixture must actually reach the shared solve — otherwise this test would
+        // silently exercise the pre-#570 fallback the sibling test already covers,
+        // rather than the `tte_ode_nll_from_shared` dispatch under review here.
+        assert!(
+            try_joint_pktte_shared_solve(&model, &subject, &model.default_params.theta, &eta)
+                .is_some(),
+            "fixture must qualify for the #570 shared solve"
+        );
+
+        let mut scratch = crate::pk::EventPkParams::default();
+        let p = &model.default_params;
+        let nll_full = individual_nll_into_with_schedule(
+            &model,
+            &subject,
+            &p.theta,
+            &eta,
+            &p.omega,
+            &p.sigma.values,
+            &model.residual_correlations,
+            &mut scratch,
+            None,
+        );
+
+        let pk_p = &pk_only_model.default_params;
+        let nll_pk_only = individual_nll_into_with_schedule(
+            &pk_only_model,
+            &pk_only_subject,
+            &pk_p.theta,
+            &eta,
+            &pk_p.omega,
+            &pk_p.sigma.values,
+            &pk_only_model.residual_correlations,
+            &mut scratch,
+            None,
+        );
+
+        // Same H(30) = 3.234, h(30) = .118 as the sibling test — the isolated TTE term
+        // the shared solve must have contributed.
+        let expected_tte = 3.234_f64 - 0.118_f64.ln();
+        assert_relative_eq!(nll_full - nll_pk_only, expected_tte, epsilon = 2e-4);
+        assert!(
+            nll_full < 1e10,
+            "the old NaN-TAD path returns the finite 1e20 sentinel through this exact \
+             dispatcher; got {nll_full}"
+        );
     }
 
     /// Construct a subject with a positive pre-start TTE time and later PK observations.

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -735,7 +735,8 @@ pub(crate) fn ode_cumhaz_hazard(
     let mut du = vec![0.0; ode.n_states];
     for (i, &t) in times.iter().enumerate() {
         cum[i] = states[i][chz_state];
-        (ode.rhs)(&states[i], &pk.values, t, &mut du);
+        let rhs_params = crate::ode::predictions::rhs_ext_params_at(ode, subject, &pk.values, t);
+        (ode.rhs)(&states[i], &rhs_params, t, &mut du);
         haz[i] = du[chz_state];
     }
     (cum, haz)

--- a/src/survival/mod.rs
+++ b/src/survival/mod.rs
@@ -733,9 +733,17 @@ pub(crate) fn ode_cumhaz_hazard(
     // state (dose forcings touch PK compartments, not CHZ). One buffer, reused — only the
     // `chz_state` slot is read, and the RHS always writes it.
     let mut du = vec![0.0; ode.n_states];
+    let dose_lagtimes = crate::ode::predictions::dose_lagtimes_for(subject, ode, &pk.values);
+    let first_dose_time = crate::ode::predictions::earliest_dose_time(&subject.doses);
     for (i, &t) in times.iter().enumerate() {
         cum[i] = states[i][chz_state];
-        let rhs_params = crate::ode::predictions::rhs_ext_params_at(ode, subject, &pk.values, t);
+        let rhs_params = crate::ode::predictions::rhs_ext_params_at(
+            &subject.doses,
+            &dose_lagtimes,
+            first_dose_time,
+            &pk.values,
+            t,
+        );
         (ode.rhs)(&states[i], &rhs_params, t, &mut du);
         haz[i] = du[chz_state];
     }


### PR DESCRIPTION
## Why

ODE-accumulated TTE hazard readout paths called the compiled RHS with a bare `PkParams::values` slice. A RHS that read `TAFD` or `TAD` therefore received `NaN`; the scorer then converted the invalid result into its finite `1e20` rejection sentinel.

Closes #1261 and #1266.

## What changed

- Added a debug/test assertion at the single RHS injection point requiring the two extended dose-time slots.
- Added one private, survival-gated helper that derives TAFD/TAD from the subject regimen at a RHS readout time.
- Routed both TTE likelihood readout paths and public survival readout through extended parameters.
- Added a two-dose regression with exact `H(30) = 3.234`, `h(30) = 0.118`, and the corresponding event NLL.

## Alternatives considered

A newtype for extended RHS parameters would make bare slices unrepresentable, but would widen the change across every `solve_ode` caller. This PR keeps the immediate debug detector and narrowly fixes the three live callers; the stronger type-level redesign should be separate.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] None

## Numerical validation

- [ ] Warfarin example converges estimates within tolerance prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit
- [x] Reference values: hand-computed two-dose TAD hazard: `H(30) = 3.234`, `h(30) = 0.118`, `NLL = 3.234 - ln(0.118)`. The fixture exercises both the likelihood and public survival readout callers.

## Performance

- [x] No significant impact expected

## Tests

- [x] Unit test(s) added in `stats::likelihood`.
- [x] Regression test added; mutation check confirmed it fails with the old bare slice even if the new debug assertion is removed.

## Example (user-facing features only)

- [x] Not applicable (bug fix with no new API surface)

## Docs

- [x] `CHANGELOG.md` `[Unreleased]` entry added.
- [x] No new user-facing syntax or documentation page is required.

## Checklist

- [x] `tools/preflight.sh` green before rebasing; the rebase only reconciled the current changelog section.
- [x] Functions on the `Dual2` sensitivity path stay differentiable (not touched).
- [x] No public API change.

## Docs & examples

- [x] Not applicable: no DSL, example, data, or estimator change.