### PR TITLE
docs(changelog): merge the duplicated, truncated #1077 entry into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,15 +306,13 @@ section of the SDLC for the versioning policy).
   drop such a row and `check_dose_compartments` rejects it outright
   (`E_DOSE_CMT_NOT_INFUSABLE`) — but when the dose also carried a lagtime the gradient
   walk still fired the infusion-end saltation, reporting a finite `∂f/∂η_LAG` (+1.89 at
-  the first sample past the window end) for a subject that receives no drug and predicts
-  `0.0` everywhere. Reachable only from a hand-built model spec that runs no validation;
-  no validated fit changes. The compartment test is now one shared predicate asked by
-- The analytic ODE sensitivity walk no longer injects a rate-off boundary term for `CMT=0`
-  infusions on an unbound compartment (#1077). `check_dose_compartments` already rejects
-  such zero-order `CMT=0` infusions with `E_DOSE_CMT_NOT_INFUSABLE`, so this change is
-  user-visible only through hand-built specs. The walk now uses the same shared
-  `infusion_has_rate_channel` predicate as production, preventing spurious
-  `∂f/∂η_LAG` jumps when both engines predict `f ≡ 0`.
+  the first sample past the window end, against a central-difference reference of exactly
+  `0.0`) for a subject that receives no drug and predicts `0.0` everywhere. Reachable only
+  from a hand-built model spec that runs no validation; no validated fit changes. The
+  compartment test is now one shared predicate (`dosing::infusion_has_rate_channel`), asked
+  by every site on either engine that turns a rate on or off: four of the walk's rate-*on*
+  sites spelled it inline as `cmt_raw() >= 1` and the rate-*off* saltation at the
+  infusion-window end asked nothing at all.
 - A fit no longer stops on its first evaluation and reports every parameter at its
   initial value (#1290). The outer loop's EBE warm-start cache adopted the empirical
   Bayes estimates of *every* evaluation, including the ones the line search rejects, so


### PR DESCRIPTION
## Why

`CHANGELOG.md` on `main` carries **two consecutive bullets for #1077** under
`## [Unreleased]` → `### Fixed`, and the first one **stops mid-sentence**:

```
  no validated fit changes. The compartment test is now one shared predicate asked by
- The analytic ODE sensitivity walk no longer injects a rate-off boundary term for `CMT=0`
```

There is no completion — the next line starts the second bullet. Introduced by #1320,
and present on `origin/main` (`4a7521dd`), so it is not a local artifact. Found while
rebasing #1309, which touches the same heading.

## What changed

The two bullets are merged into one. The first has the better detail — the measured
`+1.89` `∂f/∂η_LAG`, the `f ≡ 0` subject, the hand-built-spec reachability — and the
second is the one that reads complete, so the merge keeps the first's substance and
finishes its sentence.

The completion is **read off the change, not invented**. `dosing::infusion_has_rate_channel`
is `d.cmt_raw() != 0`; `src/sens/ode_provider.rs` asks it at five sites against
`ode::predictions::infusion_contributes`' one. The defect #1320 closed was the walk
disagreeing with *itself*: four rate-**on** sites spelled the compartment test inline as
`cmt_raw() >= 1`, and the rate-**off** saltation at the infusion-window end asked nothing
at all — so a lagged `CMT=0` infusion delivered no drug yet moved the gradient. That is
what the finished sentence now says.

Two smaller edits inside the same bullet, both recovering something the truncation lost:
the central-difference reference of exactly `0.0` that the `+1.89` is measured against,
and the predicate's name, which only the second bullet carried.

## Alternatives considered

**Delete the truncated bullet and keep the complete one.** Cheaper, and it loses the only
numbers in the entry — the `+1.89` against `0.0` is what makes the fix legible a year from
now.

**Fix it inside #1309**, which already resolves a conflict in this exact block. Rejected:
it is someone else's entry and unrelated to that PR's subject, and burying it in a
ten-finding review round is how it stops being reviewable.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed | — |

`ferx-r` tracks its own user-facing changes in `NEWS.md` and does not read this file.

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`)
- [x] None

## Numerical validation
- [x] Not applicable (docs / refactor / CI only)

No source file is touched. `git diff --name-only` is `CHANGELOG.md` alone, in a single hunk.

## Performance
- [x] No significant impact expected

## Tests
- [x] No new tests needed (why: prose in `CHANGELOG.md`, which no gate lints — `docs-lint`
      scopes to `docs/**/*.qmd`. There is nothing here a test could assert.)

## Example (user-facing features only)
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml`
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A — this PR *is*
      the changelog edit; it corrects an existing entry rather than adding one, so it needs
      no entry of its own.
- [ ] No user-visible change

## Checklist
- [x] `tools/preflight.sh` green — ran the `docs` group (`cargo test -p docs-lint`,
      `cargo clippy -p docs-lint`), which is the only group this diff can reach. No Rust
      file changes, so the `check` / `clippy` / `rustdoc` / `public-api` groups have nothing
      to say; CI runs them all regardless.
- [x] Functions on the `Dual2` sensitivity path stay differentiable — no code touched
- [x] `Cargo.toml` version bumped if breaking — not breaking

## Docs & examples

### ferx-site
- [x] No new DSL syntax, `[fit_options]` key, example, or data file

### ferx-book
- [x] No new estimator, DSL feature, or fit option

### Example execution
- [x] No example execution step needed (docs-only, no user-visible behaviour change)

## Reviewer hints

The whole diff is one hunk. The only thing worth checking is whether the completed
sentence is **true**: `src/dosing.rs:826` for the predicate, and
`src/sens/ode_provider.rs:6248` for the comment naming the rate-off saltation as "the half
of #1077 that survived #1196 step 3". The five walk call sites are at
`ode_provider.rs:5096, 5340, 5743, 6269, 6961`.

## Open questions

**Ordering with #1309.** That PR also edits `### Fixed` under `[Unreleased]` and will
conflict textually with this one — trivially, and in `CHANGELOG.md` only. Either order
works; whichever lands second rebases. If #1309 goes first I will rebase this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
