### PR TITLE
fix(estimation): keep the BFGS partial in the IOV inner-loop fallback [closes #1327]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ section of the SDLC for the versioning policy).
 
 ### Fixed
 
+- Fixed the IOV inner loop discarding a converged-in-all-but-name BFGS solution for a far worse Nelder–Mead restart from the cold seed, which made every cold-started evaluation of a `kappa` model (the reported final OFV, `outer_maxiter = 0` re-evaluations, `.fitrx` reloads) score some subjects thousands of −2LL units above the value the optimizer had minimised — 9 300 on a `[covariate_nn]` + IOV busulfan fit (#1327).
 - Fixed ODE-accumulated survival hazards that read `TAD`, which could reject valid multi-dose subjects with a misleading finite objective (#1261).
 
 ### Performance

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1331,26 +1331,31 @@ fn find_ebe_iov(
         None,
         enable_stall,
     );
-    // On BFGS failure, recover with the same ODE-gated policy as the non-IOV `find_ebe`
-    // (cold seed = prior mode `bsv_psi = μ`, κ = 0): for ODE objectives keep the
-    // lower-objective of {BFGS partial, NM restart} so a correct η̂ floored above `tol` by
-    // solver noise is never discarded (#555); for exact objectives recover with NM from the
-    // cold seed, as prior releases, so a non-stationary low-objective partial can't be kept.
+    // On BFGS failure, recover exactly as the non-IOV `find_ebe` does (cold seed = prior
+    // mode `bsv_psi = μ`, κ = 0): keep the lower-objective of {BFGS partial, NM restart}
+    // (`argmin_inner_fallback`). This holds for ODE objectives (#555, a gradient-noise floor
+    // blocks certification at a genuine mode) AND for exact objectives (#378 for the non-IOV
+    // path; #1327 here): a closed-form BFGS started far from the mode routinely arrives at it
+    // and stalls at a gradient norm just above `tol` (busulfan DCM+IOV subject 261: partial
+    // at the mode, NLL 94.6, |g| ≈ 7e-5 > 1e-5). Until #1327 this branch then replaced that
+    // partial *unconditionally* with an 11-dimensional Nelder–Mead from the cold seed, which
+    // stops at NLL ≈ 5030 with κ tens of prior SDs out — so every cold-started evaluation
+    // (the final inner loop, an `outer_maxiter = 0` re-evaluation) scored a handful of
+    // subjects thousands of −2LL units too high, while the warm-started trajectory (whose
+    // BFGS converges within `tol` from the previous mode) never saw it. The reported OFV
+    // sat 9 300 above the value the optimizer had minimised. IOV + FREM is unsupported
+    // (`foce_subject_nll_iov` returns a sentinel for it), so the FREM-only "take NM
+    // unconditionally to re-center the proposal" arm of the non-IOV path has no twin here.
     let (nm_converged, mut used_fallback) = if !bfgs_converged {
         let partial = x.clone();
         let mut cold = vec![0.0; n_flat];
         cold[..n_eta].copy_from_slice(&mu);
         if skip_ode_iov_nm_fallback(model) {
             (false, false)
-        } else if enable_stall {
+        } else {
             let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol);
             x = best;
             (ok, true)
-        } else {
-            let warm = ebe_warm_start_enabled() && partial.iter().all(|v| v.is_finite());
-            x = if warm { partial } else { cold };
-            let nm_ok = nelder_mead_minimize(&obj, &mut x, n_flat, max_iter * 5, tol);
-            (nm_ok, true)
         }
     } else {
         (false, false)

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -495,16 +495,21 @@ pub struct InnerLoopStats {
 ///
 /// The restart seeds from the BFGS `partial` when `ebe_warm_start` is set (it sits on the
 /// steep prior slope, so NM reaches the mode in fewer steps), else from `cold_seed` (η=0
-/// for non-IOV, `[μ, 0…]` for IOV — the historical reset point). Exactly **one** NM solve
-/// runs, so enabling `ebe_warm_start` is never slower than leaving it off.
+/// for non-IOV, `[μ, 0…]` for IOV — the historical reset point). One NM solve runs when
+/// the restart wins or under `ebe_warm_start`; a second, started from the partial, runs
+/// only when a cold restart loses to the partial (see below).
 ///
-/// Returns `(eta, nm_converged)`. The **value** is the lower-objective of the BFGS partial
+/// Returns `(eta, converged)`. The **value** is the lower-objective of the BFGS partial
 /// and the NM restart — the substantive #555 fix: the previous code overwrote `eta` with the
 /// NM restart unconditionally, discarding a correct partial that BFGS had reached but not
-/// gnorm-verified. `nm_converged` is the Nelder–Mead convergence flag (as the pre-#555 code
-/// reported), so the per-subject convergence/diagnostic semantics are unchanged; the η̂
-/// *value* fed to the FOCEI gradient is what improves. A non-finite `obj(partial)` (NaN/∞)
-/// makes the partial unusable so the NM result is taken.
+/// gnorm-verified. `converged` is the Nelder–Mead flag **of the run that ended at the
+/// returned point** (PR #1337 review): when the restart wins it is that restart's flag;
+/// when the partial wins, the partial — which its own BFGS run did *not* certify — is
+/// polished by an NM started from it, and that run's end point and flag are returned (the
+/// end point is never worse than the partial). Returning the restart's flag with the
+/// partial's point reported a converged EBE whenever NM had converged in a *worse* basin,
+/// which bypassed `max_unconverged_frac` and AGQ's per-subject acceptance. A non-finite
+/// `obj(partial)` (NaN/∞) makes the partial unusable so the NM result is taken.
 fn argmin_inner_fallback(
     obj: &dyn Fn(&[f64]) -> f64,
     partial: &[f64],
@@ -527,12 +532,31 @@ fn argmin_inner_fallback(
     // non-finite `f_nm` (NM diverged) leaves `nm_strictly_better = false` and the finite
     // partial is kept.
     let nm_strictly_better = f_nm < partial_f;
-    let best = if partial_usable && !nm_strictly_better {
-        partial.to_vec()
+    if !partial_usable || nm_strictly_better {
+        return (eta_nm, nm_ok);
+    }
+    // The partial wins on objective. Its own BFGS run did not certify it, and `nm_ok`
+    // describes a point we are not returning (NM may well have *converged* — in a worse
+    // basin), so it must not be reported as this point's status: `EbeResult.converged`
+    // feeds `max_unconverged_frac` and AGQ's per-subject acceptance (PR #1337 review).
+    // Certify the partial the same derivative-free way NM certifies its own result: a
+    // second NM started *from the partial*. Its end point is what is returned (never
+    // worse than the partial, NM keeps its best vertex) and its flag is the flag — a
+    // genuine mode collapses the simplex within `tol` in a few iterations, a
+    // non-stationary partial keeps descending and reports `false` when the budget ends.
+    // Under `ebe_warm_start` the single NM above already ran from the partial and ended
+    // at its value, so that run is the certification and nothing is re-run.
+    if warm {
+        return (partial.to_vec(), nm_ok);
+    }
+    let mut polished = partial.to_vec();
+    let polished_ok = nelder_mead_minimize(obj, &mut polished, n, max_iter * 5, tol);
+    let f_polished = obj(&polished);
+    if f_polished.is_finite() && f_polished <= partial_f {
+        (polished, polished_ok)
     } else {
-        eta_nm
-    };
-    (best, nm_ok)
+        (partial.to_vec(), false)
+    }
 }
 
 /// An ODE-based model that also carries IOV (`κ`) random effects. The inner EBE path for

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -3571,3 +3571,63 @@ fn iov_inner_fallback_keeps_bfgs_partial_over_worse_cold_nm() {
         cold_nll
     );
 }
+
+/// PR #1337 review (P1): the convergence flag must belong to the point that is returned.
+///
+/// Scenario: the BFGS partial sits on the slope of the deep well (not a mode) and wins on
+/// objective; the cold NM restart, seeded exactly at the shallow well's minimum, converges
+/// there. The old helper returned the partial with the *restart's* `true`, reporting a
+/// non-stationary point as a converged EBE — which bypasses `max_unconverged_frac` and
+/// AGQ's per-subject acceptance. Two assertions, one per half of the fix:
+///
+/// * with a budget too small to polish the partial to the mode, the returned point is at
+///   least as good as the partial and the flag is `false` (the restart's `true` must not
+///   leak through);
+/// * with a normal budget the polish reaches the deep mode and reports `true` — the flag is
+///   earned by the returned point, not inherited.
+///
+/// Objective: deep well at x = −2 (f = −10), shallow well at x = +2 (f = −1). Budgets:
+/// `max_iter = 1` gives each NM 5 iterations — enough for a restart seeded on the shallow
+/// minimum to collapse its 0.1-wide simplex under `tol = 1e-3`, not enough for a polish
+/// from x = −1.5 to reach x = −2 within `tol`. Verified by mutation: returning the
+/// restart's flag turns the first half red.
+#[test]
+fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
+    let obj = |x: &[f64]| -> f64 {
+        let v = x[0];
+        if v < 0.0 {
+            (v + 2.0).powi(2) - 10.0
+        } else {
+            (v - 2.0).powi(2) - 1.0
+        }
+    };
+    set_ebe_warm_start(false);
+    let partial = [-1.5];
+    let f_partial = obj(&partial);
+
+    // Tiny budget: the cold restart converges in the shallow well, the partial wins, the
+    // polish cannot certify it.
+    let (eta, ok) = argmin_inner_fallback(&obj, &partial, &[2.0], 1, 1, 1e-3);
+    assert!(eta[0] < 0.0, "must stay in the deep well, got {eta:?}");
+    assert!(
+        obj(&eta) <= f_partial,
+        "returned point ({:.4}) must not be worse than the partial ({f_partial:.4})",
+        obj(&eta)
+    );
+    assert!(
+        !ok,
+        "a partial that was neither BFGS- nor NM-certified must not report converged \
+         (the restart converged in the shallow well; its flag must not leak)"
+    );
+
+    // Normal budget: the polish reaches the deep mode and earns the flag.
+    let (eta2, ok2) = argmin_inner_fallback(&obj, &partial, &[2.0], 1, 200, 1e-8);
+    assert!(
+        (eta2[0] + 2.0).abs() < 1e-2,
+        "polish must reach the deep mode, got {eta2:?}"
+    );
+    assert!(
+        ok2,
+        "an NM run that ended at the returned point certifies it"
+    );
+}

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -3445,3 +3445,129 @@ fn power_exponent_inner_eta_gradient_matches_fd() {
         approx::assert_relative_eq!(analytic[k], fd, max_relative = 1e-5, epsilon = 1e-6);
     }
 }
+
+/// #1327: on an **exact** (closed-form) IOV objective, a BFGS "failure" must keep the
+/// lower-objective of {BFGS partial, Nelder–Mead restart} — the `argmin_inner_fallback`
+/// policy the non-IOV `find_ebe` has used since #378 — rather than adopt the NM result
+/// unconditionally.
+///
+/// What it catches: a cold-started closed-form BFGS that arrives at the mode and stalls at a
+/// gradient norm just above `tol` (busulfan DCM+IOV subject 261: partial at NLL 94.6,
+/// |g| ≈ 7e-5 > 1e-5) was replaced by an NM from the cold seed that stops at NLL ≈ 5030.
+/// Every cold-started evaluation — the final inner loop, an `outer_maxiter = 0`
+/// re-evaluation — then scored such subjects thousands of −2LL units too high, while the
+/// warm-started trajectory (BFGS converging within `tol` from the previous mode) never
+/// tripped the fallback: the reported OFV sat 9 300 above the value the optimizer minimised.
+///
+/// The fixture forces the fallback deterministically: `max_iter = 1` makes BFGS report
+/// non-convergence after a single exact-gradient line search, which already moves the
+/// objective well below the cold seed's; the NM restart it triggers runs `5 · max_iter`
+/// iterations from the zero seed with NM's `0.00025` initial simplex step, so it barely
+/// leaves the seed (NLL 504.9 → 501.0). Under the pre-#1327 policy that NM point is
+/// returned; under the fix the partial (NLL −1.1, against a converged mode of −4.1) is
+/// kept. Verified by mutation: restoring the unconditional-NM arm turns this red.
+#[test]
+fn iov_inner_fallback_keeps_bfgs_partial_over_worse_cold_nm() {
+    use crate::parser::model_parser::parse_model_string;
+    let model = parse_model_string(
+        r#"
+[parameters]
+  theta TVCL(5.0, 0.01, 100.0)
+  theta TVV(50.0, 1.0, 500.0)
+  omega ETA_CL ~ 0.09
+  kappa KAPPA_CL ~ 0.04
+  sigma PROP_ERR ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL + KAPPA_CL)
+  V  = TVV
+
+[structural_model]
+  pk one_cpt_iv(cl=CL, v=V)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method = focei
+  iov_column = OCC
+"#,
+    )
+    .expect("closed-form IOV model parses");
+    assert!(
+        !skip_ode_iov_nm_fallback(&model),
+        "fixture must take the closed-form NM fallback arm"
+    );
+    set_ebe_warm_start(false);
+
+    // Two occasions, one 100 mg IV bolus each; observations simulated at
+    // CL = 5·exp(−1.5), V = 50 (see the test doc) so the mode is far from the zero seed.
+    let subject = Subject {
+        id: "1".into(),
+        doses: vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(24.0, 100.0, 1, 0.0, false, 0.0),
+        ],
+        obs_times: vec![2.0, 6.0, 26.0, 30.0],
+        obs_raw_times: Vec::new(),
+        observations: vec![1.913, 1.749, 3.032, 2.773],
+        obs_cmts: vec![1; 4],
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        reset_covariates: Vec::new(),
+        reset_occasions: Vec::new(),
+        cens: vec![0; 4],
+        occasions: vec![1, 1, 2, 2],
+        obs_l2: Vec::new(),
+        dose_occasions: vec![1, 2],
+        fremtype: Vec::new(),
+        obs_records: vec![],
+    };
+    let params = model.default_params.clone();
+    let cold_nll = individual_nll_iov(
+        &model,
+        &subject,
+        &params.theta,
+        &[0.0],
+        &[vec![0.0], vec![0.0]],
+        &params.omega,
+        params.omega_iov.as_ref(),
+        &params.sigma.values,
+    );
+
+    // `max_iter = 1`: BFGS cannot certify convergence, so the fallback fires.
+    let ebe = find_ebe_iov(&model, &subject, &params, 1, 1e-5, None, None);
+    assert!(
+        !ebe.converged && ebe.used_fallback,
+        "fixture must trip the NM fallback (converged={}, fallback={})",
+        ebe.converged,
+        ebe.used_fallback
+    );
+    assert!(ebe.nll.is_finite(), "fallback returned a non-finite NLL");
+
+    // The converged solve is the floor and the yardstick. Measured on this fixture:
+    // cold-seed NLL 504.88; converged mode −4.13; the one-line-search BFGS partial −1.11
+    // (gap 3.0); the unconditionally-adopted 5-iteration NM from the zero seed 500.98
+    // (gap 505). The bound is ~3× the realised gap of the kept partial and 50× below the
+    // old policy's, so it fails on exactly the mutation it exists to catch and nothing else.
+    let full = find_ebe_iov(&model, &subject, &params, 200, 1e-5, None, None);
+    assert!(full.converged, "reference solve must converge");
+    assert!(
+        ebe.nll >= full.nll - 1e-9,
+        "kept partial ({:.4}) cannot undercut the converged mode ({:.4})",
+        ebe.nll,
+        full.nll
+    );
+    assert!(
+        ebe.nll < full.nll + 10.0,
+        "the BFGS partial must survive the fallback: returned NLL {:.4}, converged mode {:.4}, \
+         cold-seed NLL {:.4} (the pre-#1327 unconditional NM restart returns ≈ 501)",
+        ebe.nll,
+        full.nll,
+        cold_nll
+    );
+}


### PR DESCRIPTION
## Why

#1327: a `[covariate_nn]` + IOV FOCEI fit reported a final OFV **9 300 above** the value the optimizer had been minimising (best-seen 71 456.17 → final 80 766.57 on `busulfan_dominic/dcm_h2_iov_s600`, 600 subjects), and an `outer_maxiter = 0` re-evaluation from the `.fitrx` reproduced the bad number. The issue suspected the η-only IOV gradient (`iov_eta_only_derivs_dyn`) or κ warm-start bookkeeping. Neither is it: at the initial θ and at the reported final θ the analytic stacked-`[η, κ]` gradient matches central FD to ≤ 1e-6 relative on every coordinate of the first 12 subjects, and `find_ebe_iov` from a cold seed and from a perturbed warm seed land on the same point.

The defect is the **inner-loop failure policy on the IOV path**. `find_ebe_iov`'s exact-objective arm ran a Nelder–Mead restart from the cold seed and adopted it *unconditionally* whenever BFGS reported non-convergence. Instrumenting the outer objective to re-solve every subject cold and diff per-subject contributions showed what that means in practice at eval 25 of the reproduction (Ω_V1 probed at 0.43 with corr(η_CL, η_V1) ≈ 0.98):

```
subject 261: warm  FOCEI contrib 125.8   inner NLL   94.6   η = (−2.04, −5.06, −0.71), κ within 0.25
             cold  FOCEI contrib 5060.3  inner NLL 5030.0   η = (−3.85, −0.55,  0.10), κ up to 2.5 (≈ 23 prior SD)
```

A bare BFGS from the cold seed reaches that mode (NLL 94.644, |g| = 6.6e-5) but cannot certify `|g| < 1e-5`, so the old arm threw it away for an 11-dimensional NM from zero (initial simplex step 0.00025) that stops at NLL 5030. Five subjects like this account for the −15 397 warm-vs-cold gap at that eval; the reported final and every cold re-evaluation carry the same failure. Warm-started evaluations converge within `tol` from the previous mode and never trip the fallback, which is why the trajectory looked fine and the final did not. The non-IOV `find_ebe` fixed exactly this in #378 (`argmin_inner_fallback`: keep the lower-objective of {BFGS partial, NM}); the IOV branch kept the pre-#378 policy.

## What changed

- `src/estimation/inner_optimizer.rs` — `find_ebe_iov`'s non-ODE fallback arm now calls `argmin_inner_fallback` (the same helper its ODE arm and the non-IOV path already use), so a BFGS partial is only replaced by an NM restart that is strictly better. The FREM-only "take NM unconditionally to re-center the proposal" arm of the non-IOV path has no IOV twin because IOV + FREM is unsupported (`foce_subject_nll_iov` returns a sentinel for it). Runaway guard, ODE-IOV NM skip, and the H-matrix assembly are untouched.
- Regression test `iov_inner_fallback_keeps_bfgs_partial_over_worse_cold_nm` (sibling `inner_optimizer_iov_tests.rs`).
- `CHANGELOG.md` entry under Fixed.

## Alternatives considered

- **Warm-start the final inner loop from the best-seen EBEs.** Would make the reported OFV match the trajectory but leave every cold entry point (`outer_maxiter = 0`, `.fitrx` reload, bootstrap/SSE re-fits) wrong. The fallback is the defect; fixing it makes cold and warm agree.
- **Loosen `inner_tol` / raise `inner_maxiter`.** Subject 261's BFGS stalls at 6.6e-5 with 200, 1 000 and 5 000 iterations alike — a line-search floor, not an iteration budget.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation

Reproduction: `ferx-testdata/busulfan_dominic/ferx/dcm/dcm_h2_iov_s600.ferx` on `data/train_s600.csv`, FOCEI, BOBYQA (the model's `iov_sens_supported` is false, so the outer is derivative-free), `--features ferx-core/nn`.

**Per-eval warm-vs-cold self-consistency** (outer objective instrumented to re-solve every subject cold, first 30 evals; `n|d|>1` = subjects whose contribution differs by more than 1):

```
                      before (main)                         after
eval  4–11   warm 107807.10  cold 107541.70  n=1     warm = cold = 107541.70  n=0
eval  16     warm 107564.58  cold 109247.48  n=1     warm = cold = 107564.58  n=0
eval  19     warm 106911.82  cold 113522.56  n=1     warm = cold = 106911.82  n=0
eval  25     warm  75914.70  cold  91312.21  n=5     warm = cold =  75667.92  n=0
eval  28     warm  87931.27  cold 105057.46  n=2     warm = cold =  86994.53  n=0
eval  31     warm 107259.38  cold 110935.40  n=3     warm = cold = 107259.38  n=0
```

Every eval 1–30 after the fix reports `diff = 0.0000`. (Evals 25 and 28 are also *lower* than before on the warm side: the warm path had the same defect on one subject each.)

**Full fit, best-seen (warm trajectory) vs cold final**, same model/data, 4 threads, release with `nn`:

| run | optimizer | evals | best-seen (trajectory) | final (cold inner) | gap |
|---|---|---|---|---|---|
| DCM h2 + IOV, main `86948249` | BOBYQA (32) | 386 | 71 456.17 | **80 766.57** | +9 310 |
| DCM h2 + IOV, this PR | BOBYQA (32) | 546 | 59 470.181501 | 59 470.181499 | 2e-6 |
| analytic IOV base, this PR | L-BFGS (14) | 41 | 56 915.799398 | 56 915.799398 | 0 |

The DCM+IOV fit now reports what it minimised, and its objective moves from 80 767 to 59 470; the debug-instrumented run shows `warm − cold = 0.0000` on all 170 evals it reached. The negative EPS shrinkage warning (−12.9%) is gone (+20.4%). It still lands 2 554 above the analytic IOV base, which is the open optimizer question below (derivative-free BOBYQA over 32 coordinates), not the inner-loop defect this PR fixes.

- [x] Compared against: prior ferx commit `86948249` (main) on the same model/data
- [x] Regression fixture: closed-form 1-cpt IOV, 2 occasions, `max_iter = 1` — cold-seed NLL 504.88, converged mode −4.13, kept BFGS partial −1.11, old-policy NM 500.98 (bound: within 10 of the mode; mutation-verified red under the old arm)

## Performance
- [x] No significant impact expected — the fallback arm runs the same single NM it ran before, plus two objective evaluations (`argmin_inner_fallback`), and only when BFGS reports non-convergence.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib --features nn`: 4490 passed)
- [x] Regression test added that fails without this fix (mutation: restoring the unconditional-NM arm → `returned NLL 500.9791, converged mode -4.1340`)

## Example (user-facing features only)
- [x] Not applicable (fix with no new API surface)

## Docs
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] No docs page change (no user-visible option changed)

## Checklist
- [x] `tools/preflight.sh` green
- [x] Not touching the `Dual2` sensitivity path
- [x] No version bump (not breaking)

## Docs & examples
- [x] No example execution step needed (fix, no user-visible change)

## Reviewer hints

The whole fix is the `else` arm of the BFGS-failure block in `find_ebe_iov`; compare with the non-FREM `else` arm of `find_ebe` ~50 lines earlier — they are now the same call. The interesting part is the regression fixture's discriminating bound (see its doc comment for the four measured numbers).

## Open questions

Not addressed here, tracked in #1339: for a `[covariate_nn]` + IOV model the outer optimizer is BOBYQA and the outer gradient (when requested) is FD-reconverge, because `iov_sens_supported` is the strict θ-axis predicate. That is the 27× per-eval cost and the reason the DCM+IOV fit converges so slowly — the #1300 `ModelNnAxisGuard` walk would need an IOV twin to make it analytic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FRLKuZgXYVSaate7V813FM
