### PR TITLE
fix(parser): reject an unknown function name instead of evaluating it as the identity [closes #1332]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,12 @@ section of the SDLC for the versioning policy).
 ### Changed
 
 - **SAEM now averages the residual sufficient statistic for eligible single additive and proportional error models, reducing final-draw Monte Carlo noise in the residual SD estimate (#1321).**
+- **Calling a function ferx does not have is now a parse error naming the call and listing what is available, instead of silently evaluating as the identity.** `CL = TVCL * tanh(ETA_CL)` used to parse, pass `ferx check`, fit and converge while computing `TVCL * ETA_CL`. This applies to every block that parses expressions (`[individual_parameters]`, `[odes]`, `[scaling]`, `[derived]`, `[error_model]` magnitudes) and to conditions. Model files that relied on the no-op were already computing something other than what they read as, so the new errors are all true positives. Names remain case-insensitive, so `EXP(...)` / `LOG(...)` are unaffected; `present(x)` in value position now points at condition position (#1332).
 
 ### Fixed
 
 - Fixed ODE-accumulated survival hazards that read `TAD`, which could reject valid multi-dose subjects with a misleading finite objective (#1261).
+- `floor(x)`, `ceil(x)` and `round(x)` now differentiate to `0` rather than to `x`'s own derivative. An `[individual_parameters]` or `[odes]` expression that rounds — a dose-band lookup, an occasion index derived from `TIME` — was feeding a wrong analytic gradient to the estimator while its value path was correct (#1332).
 
 ### Performance
 

--- a/docs/model-file/individual-parameters.qmd
+++ b/docs/model-file/individual-parameters.qmd
@@ -49,6 +49,9 @@ name from quietly reading as zero and collapsing the formula.
 | `log()`, `ln()` | `log(TVCL)` |
 | `sqrt()` | `sqrt(WT)` |
 | `abs()` | `abs(ETA_CL)` |
+| `floor()`, `ceil()`, `round()` | `floor(AGE / 10)` |
+| `logit()` | `logit(THETA_F)` |
+| `inv_logit()`, `expit()` | `inv_logit(logit(THETA_F) + ETA_F)` |
 | `min(a, b)`, `max(a, b)` | `max(TVCL * WT / 70, 0.1)` |
 | `clamp(x, lo, hi)` | `clamp(ACR20, 0.01, 0.99)` |
 | `present(x)` (condition only) | `if (present(WT)) (WT/70)^0.75 else 1.0` |
@@ -72,6 +75,32 @@ arity is a parse error, and literal bounds the wrong way round
 (`clamp(x, 0.9, 0.1)`) are rejected rather than silently returning `0.9` for
 every `x`; bounds that are not both literals are not checked
 ([#1092](https://github.com/FeRx-NLME/ferx-core/issues/1092)).
+
+The table above is the **complete** list. Calling anything else is a parse error
+naming the call and listing what is available:
+
+```
+unknown function `tanh`. Supported: exp, log, ln, sqrt, abs, floor, ceil, round,
+logit, inv_logit, expit, min(a, b), max(a, b), clamp(x, lo, hi),
+present(x) (conditions only)
+```
+
+Before ferx 0.5 an unrecognised name was silently the **identity**, so
+`CL = TVCL * tanh(ETA_CL)` parsed, passed `ferx check`, fitted and converged
+while computing `TVCL * ETA_CL` — a consistently wrong model with no warning
+anywhere ([#1332](https://github.com/FeRx-NLME/ferx-core/issues/1332)). The
+realistic triggers were ordinary: a function that exists in NONMEM, nlmixr2 or
+mrgsolve but not here (`tanh`, `sinh`, `sign`, `log10`), and plain typos
+(`sqr(x)`, `exp1(x)`). Names are matched case-insensitively, so the NONMEM `$PK`
+spellings `EXP(...)` / `LOG(...)` keep working; `TANH(...)` is rejected exactly
+like `tanh(...)`.
+
+`floor`, `ceil` and `round` are piecewise constant, so their analytic derivative
+is **0** away from a step (the integer boundaries are undefined and ignored, as
+for `%`). A parameter that rounds is therefore flat with respect to the value it
+rounds, which is usually what a dose-band or occasion-index lookup wants — but it
+does mean an `η` that only enters through a rounded quantity gets a zero
+gradient.
 
 ## Continuation Lines
 

--- a/docs/model-file/scaling.qmd
+++ b/docs/model-file/scaling.qmd
@@ -414,6 +414,12 @@ expression the DSL parses — `[scaling]`, `[individual_parameters]`, `[odes]`,
 `if (a >= b) a else b`), so they differentiate and compile exactly like the
 hand-written form.
 
+The set of callable names is closed, and the same in every one of those blocks —
+see [Supported Operators and
+Functions](individual-parameters.qmd#supported-operators-and-functions). Anything
+outside it is a parse error rather than the silent identity it used to be
+([#1332](https://github.com/FeRx-NLME/ferx-core/issues/1332)).
+
 The desugaring puts **both** arguments in the guard *and* in a branch, so each one
 appears twice in the compiled tree, and the duplication multiplies through nesting:
 `min(max(x, 0.01), 0.99)` contains four copies of `x`, and reading that clamp from

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -16102,6 +16102,58 @@ fn build_pk_param_fn(
 // `types.rs`). They remain unexported from the crate root — external users
 // can't construct or pattern-match them.
 
+/// Every function name `Expression::UnaryFn` may carry (#1332).
+///
+/// `parse_atom` rejects any other `name(...)` in expression position, so this
+/// list is the *complete* domain of the `UnaryFn` dispatch in the three
+/// consumers that give the node meaning — `eval_expr`, `compile_expr_into` and
+/// `differentiate_with_chain`. Each of those ends its match on
+/// `unreachable!(UNARY_FN_ARM_MISSING)` rather than on the identity
+/// fallthrough it used to carry: an unrecognised name used to be silently the
+/// identity, so `CL = TVCL * tanh(ETA_CL)` parsed, fitted, converged and
+/// computed `TVCL * ETA_CL` with no warning anywhere.
+///
+/// The list and the three matches are pinned against each other by
+/// `every_supported_unary_fn_has_an_arm_in_all_three_consumers`, so adding a
+/// name here without an arm in all three is a red test rather than a
+/// production panic. `Expression` is `pub(crate)` and the parser is its only
+/// constructor, which is what makes the `unreachable!` sound.
+///
+/// `min`/`max`/`clamp` are absent on purpose: they take 2/3 arguments and
+/// `parse_atom` desugars them to `Expression::Conditional`, so they never
+/// reach `UnaryFn`. `present(x)` is a *condition*, parsed by `parse_cond_atom`.
+pub(crate) const SUPPORTED_UNARY_FNS: &[&str] = &[
+    "exp",
+    "log",
+    "ln",
+    "sqrt",
+    "abs",
+    "floor",
+    "ceil",
+    "round",
+    "logit",
+    "inv_logit",
+    "expit",
+];
+
+/// Panic message for the (parser-guaranteed unreachable) tail of each
+/// `UnaryFn` match. Named so all three consumers report the same failure.
+const UNARY_FN_ARM_MISSING: &str =
+    "UnaryFn carries a name outside SUPPORTED_UNARY_FNS — parse_atom is the only \
+     constructor and rejects unknown names (#1332); a name added to the whitelist \
+     needs an arm in eval_expr, compile_expr_into and differentiate_with_chain";
+
+/// The human-facing catalogue of callable names, used by the parse-time
+/// rejection. Kept next to `SUPPORTED_UNARY_FNS` so a new builtin is one edit
+/// away from being advertised, and includes the multi-argument forms the
+/// parser desugars plus the conditions-only `present`.
+fn supported_function_list() -> String {
+    format!(
+        "{}, min(a, b), max(a, b), clamp(x, lo, hi), present(x) (conditions only)",
+        SUPPORTED_UNARY_FNS.join(", ")
+    )
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum Expression {
     Literal(f64),
@@ -18463,7 +18515,8 @@ fn eval_expr<E: EvalEnv>(
                     let clamped = v.clamp(1e-15, 1.0 - 1e-15);
                     (clamped / (1.0 - clamped)).ln()
                 }
-                _ => v,
+                // Unreachable: `parse_atom` admits only `SUPPORTED_UNARY_FNS`.
+                _ => unreachable!("{UNARY_FN_ARM_MISSING} (eval_expr, `{name}`)"),
             }
         }
         Expression::Power(base, exp) => {
@@ -18901,9 +18954,8 @@ fn compile_expr_into(bc: &mut Bytecode, expr: &Expression) {
         Expression::UnaryFn(name, arg) => {
             compile_expr_into(bc, arg);
             // Names matched here mirror `eval_expression_indexed`'s UnaryFn
-            // dispatch. Anything else becomes a no-op (the slow path returns
-            // the argument unchanged); preserve that with `Op::Abs` of `Abs`
-            // we can't — fall through to push the value as-is.
+            // dispatch, and the match is total over `SUPPORTED_UNARY_FNS`
+            // because `parse_atom` admits nothing else (#1332).
             match name.as_str() {
                 "exp" => bc.ops.push(Op::Exp),
                 "log" | "ln" => bc.ops.push(Op::Ln),
@@ -18914,7 +18966,7 @@ fn compile_expr_into(bc: &mut Bytecode, expr: &Expression) {
                 "floor" => bc.ops.push(Op::Floor),
                 "ceil" => bc.ops.push(Op::Ceil),
                 "round" => bc.ops.push(Op::Round),
-                _ => { /* unknown function → leave the argument on the stack */ }
+                _ => unreachable!("{UNARY_FN_ARM_MISSING} (compile_expr_into, `{name}`)"),
             }
         }
         Expression::Conditional(cond, t_expr, e_expr) => {
@@ -21220,7 +21272,8 @@ fn resolve_condition_indices(
 //   UnaryFn("abs", a)      : if a ≥ 0 then a' else −a' (boundary undefined)
 //   UnaryFn("inv_logit"|"expit", a) : inv_logit(a) · (1 − inv_logit(a)) · a'
 //   UnaryFn("logit", a)    : a' / (a · (1 − a))
-//   UnaryFn(unknown, a)    : a' (mirrors the slow path's identity fallthrough)
+//   UnaryFn("floor"|"ceil"|"round", a) : 0 (piecewise constant; the integer
+//                            boundaries are undefined and ignored, as for Mod)
 //   Power(b, e)            : b^e · (e'·ln(b) + e · b'/b)  (general; subsumes
 //                            both constant-base and constant-exponent cases)
 //   Conditional(c, t, e)   : Conditional(c, t', e')   (boundary discontinuity
@@ -21431,13 +21484,18 @@ fn differentiate_with_chain(
                     let denom = mul((**arg).clone(), one_minus_a);
                     div(da, denom)
                 }
-                _ => {
-                    // Unknown name — the slow path returns the argument
-                    // unchanged, so the derivative is its argument's
-                    // derivative. (See `eval_expression_indexed`'s
-                    // `_ => v` fallthrough.)
-                    da
+                "floor" | "ceil" | "round" => {
+                    // Piecewise constant: 0 almost everywhere, undefined on the
+                    // integer boundaries (the same convention `BinOp::Mod` takes
+                    // just above). These three had arms in `eval_expr` and in the
+                    // bytecode compiler but none here, so they landed on the
+                    // identity fallthrough and differentiated as `a'` — a value
+                    // path that rounds against an analytic gradient that does not
+                    // (#1332).
+                    Expression::Literal(0.0)
                 }
+                // Unreachable: `parse_atom` admits only `SUPPORTED_UNARY_FNS`.
+                _ => unreachable!("{UNARY_FN_ARM_MISSING} (differentiate_with_chain, `{name}`)"),
             }
         }
         Expression::Power(b, e) => {
@@ -22467,6 +22525,27 @@ fn parse_atom(
                     // numbers (#1092). Reject it by name.
                     return Err(format!(
                         "`{func_name}` takes exactly three arguments: `clamp(x, lo, hi)`."
+                    ));
+                }
+                // Any name reaching here is a one-argument call. Reject it unless
+                // it is a builtin the three `UnaryFn` consumers actually implement
+                // (#1332): an unrecognised name used to become `UnaryFn(name, arg)`,
+                // which every consumer evaluated as the identity, so
+                // `CL = TVCL * tanh(ETA_CL)` parsed, fitted, converged and computed
+                // `TVCL * ETA_CL`. The check lives here — the single site that builds
+                // the node — so it covers every block whose expressions go through
+                // `parse_atom`, not one block's path.
+                if !SUPPORTED_UNARY_FNS.contains(&func_name.as_str()) {
+                    if func_name == "present" {
+                        return Err(format!(
+                            "`present(...)` is a condition, not a value — write it as a test, \
+                             e.g. `if (present(WT)) ... else ...`, rather than in `{name}(...)` \
+                             value position."
+                        ));
+                    }
+                    return Err(format!(
+                        "unknown function `{name}`. Supported: {}",
+                        supported_function_list()
                     ));
                 }
                 return Ok((Expression::UnaryFn(func_name, Box::new(arg)), p + 1));

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -22400,6 +22400,35 @@ fn parse_atom(
                 let func_name = name.to_lowercase();
                 let is_min_max = matches!(func_name.as_str(), "min" | "max");
                 let is_clamp = func_name == "clamp";
+                // Reject an unrecognised name here — *before* any argument is
+                // parsed (#1332). An unrecognised name used to become
+                // `UnaryFn(name, arg)`, which every consumer evaluated as the
+                // identity, so `CL = TVCL * tanh(ETA_CL)` parsed, fitted,
+                // converged and computed `TVCL * ETA_CL`. This is the single site
+                // that builds the node, so the check covers every block whose
+                // expressions go through `parse_atom`, not one block's path.
+                //
+                // Placed above the argument loop rather than next to the `UnaryFn`
+                // return so the *name* is judged before the *arity*: a
+                // two-argument `pow(x, y)` would otherwise fall into the comma
+                // branch below and be reported as "`pow` takes 1 argument", which
+                // sends the reader looking for an arity bug in a function ferx
+                // does not have. `min`/`max`/`clamp` are exempt because they are
+                // desugared below and never reach `UnaryFn`; they keep their own
+                // arity diagnostics.
+                if !is_min_max && !is_clamp && !SUPPORTED_UNARY_FNS.contains(&func_name.as_str()) {
+                    if func_name == "present" {
+                        return Err(format!(
+                            "`present(...)` is a condition, not a value — write it as a test, \
+                             e.g. `if (present(WT)) ... else ...`, rather than in `{name}(...)` \
+                             value position."
+                        ));
+                    }
+                    return Err(format!(
+                        "unknown function `{name}`. Supported: {}",
+                        supported_function_list()
+                    ));
+                }
                 let (arg, p) = parse_add_sub(tokens, pos + 2, ctx)?;
                 if (is_min_max || is_clamp) && tokens.get(p) == Some(&Token::Comma) {
                     let (arg2, p) = parse_add_sub(tokens, p + 1, ctx)?;
@@ -22527,27 +22556,11 @@ fn parse_atom(
                         "`{func_name}` takes exactly three arguments: `clamp(x, lo, hi)`."
                     ));
                 }
-                // Any name reaching here is a one-argument call. Reject it unless
-                // it is a builtin the three `UnaryFn` consumers actually implement
-                // (#1332): an unrecognised name used to become `UnaryFn(name, arg)`,
-                // which every consumer evaluated as the identity, so
-                // `CL = TVCL * tanh(ETA_CL)` parsed, fitted, converged and computed
-                // `TVCL * ETA_CL`. The check lives here — the single site that builds
-                // the node — so it covers every block whose expressions go through
-                // `parse_atom`, not one block's path.
-                if !SUPPORTED_UNARY_FNS.contains(&func_name.as_str()) {
-                    if func_name == "present" {
-                        return Err(format!(
-                            "`present(...)` is a condition, not a value — write it as a test, \
-                             e.g. `if (present(WT)) ... else ...`, rather than in `{name}(...)` \
-                             value position."
-                        ));
-                    }
-                    return Err(format!(
-                        "unknown function `{name}`. Supported: {}",
-                        supported_function_list()
-                    ));
-                }
+                // `func_name` is whitelisted: the guard above rejected anything
+                // else, and `min`/`max`/`clamp` have returned by now. Deliberately
+                // *not* re-checked here — two gates rejecting the same inputs
+                // would cover for each other, and deleting either would leave the
+                // suite green.
                 return Ok((Expression::UnaryFn(func_name, Box::new(arg)), p + 1));
             }
 

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -22226,3 +22226,49 @@ fn every_supported_unary_fn_parses_in_a_model_file() {
             .unwrap_or_else(|e| panic!("`{name}(...)` is whitelisted but does not parse: {e}"));
     }
 }
+
+/// The other half of the `unreachable!` contract: what the three `UnaryFn`
+/// consumers do when the invariant is violated anyway.
+///
+/// `every_supported_unary_fn_has_an_arm_in_all_three_consumers` pins that each
+/// whitelisted name has a real arm. These pin that a name *without* one is a
+/// loud panic naming the consumer that lacks it — the property the whole fix
+/// rests on, since the alternative (`_ => v` / `_ => da`) is the silent
+/// identity #1332 is about. Tests can build the node directly, which production
+/// cannot: `parse_atom` is `Expression`'s only constructor and rejects the name
+/// first.
+///
+/// One test per consumer, each asserting *its own* name in the message, because
+/// a single combined test would be satisfied by whichever consumer panicked
+/// first and would stay green with the other two arms deleted.
+mod unreachable_unary_fn_arms {
+    use super::*;
+
+    /// A name that is deliberately not in `SUPPORTED_UNARY_FNS`.
+    fn out_of_whitelist() -> Expression {
+        assert!(
+            !SUPPORTED_UNARY_FNS.contains(&"tanh"),
+            "this test needs `tanh` to stay outside the whitelist; if it became a \
+             builtin, pick another name rather than deleting the test"
+        );
+        unary("tanh", lit(0.5))
+    }
+
+    #[test]
+    #[should_panic(expected = "eval_expr, `tanh`")]
+    fn eval_expr_panics_rather_than_returning_the_argument() {
+        eval_at(&out_of_whitelist(), &[], &[], &[], &[]);
+    }
+
+    #[test]
+    #[should_panic(expected = "compile_expr_into, `tanh`")]
+    fn the_bytecode_compiler_panics_rather_than_emitting_a_no_op() {
+        compile_bytecode(&out_of_whitelist());
+    }
+
+    #[test]
+    #[should_panic(expected = "differentiate_with_chain, `tanh`")]
+    fn the_differentiator_panics_rather_than_passing_the_derivative_through() {
+        differentiate(&out_of_whitelist(), DiffAxis::Theta(0));
+    }
+}

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -14370,9 +14370,15 @@ fn bytecode_matches_ast_on_unary_guards() {
     bc_vs_ast(unary("logit", lit(0.3)), v, t, e, c);
     bc_vs_ast(unary("logit", lit(0.0)), v, t, e, c);
     bc_vs_ast(unary("logit", lit(1.0)), v, t, e, c);
-    // Unknown unary name — slow path returns the argument unchanged;
-    // the bytecode no-op'd UnaryFn arm must too.
-    bc_vs_ast(unary("expn", lit(42.0)), v, t, e, c);
+    // `floor` / `ceil` / `round` — the rounding opcodes, checked on both sides
+    // of `.5` and on a negative value (Rust rounds half away from zero).
+    for name in ["floor", "ceil", "round"] {
+        for x in [6.9, -6.9, 2.5, -2.5, 3.0] {
+            bc_vs_ast(unary(name, lit(x)), v, t, e, c);
+        }
+    }
+    // No unknown-name case: since #1332 `parse_atom` cannot build one, and both
+    // evaluators answer an out-of-whitelist name with `unreachable!`.
 }
 
 #[test]
@@ -14769,16 +14775,44 @@ fn differentiate_abs_branches_on_sign() {
     assert_diff_matches_fd(expr, DiffAxis::Theta(0), &[0.3], eta, vars, covs);
 }
 
+/// `floor` / `ceil` / `round` are piecewise constant, so their derivative is 0
+/// away from an integer boundary. They had arms in `eval_expr` and in the
+/// bytecode compiler but none in `differentiate_with_chain`, so they landed on
+/// the old unknown-name identity fallthrough and differentiated as `a'` — a
+/// value path that rounds against an analytic gradient that does not (#1332).
+///
+/// The mutation this exists to catch is deleting the `"floor" | "ceil" |
+/// "round"` arm: the name then hits `unreachable!` and the test panics. The
+/// *pre-#1332* mutation — that arm falling through to `da` — is what the FD
+/// comparison itself catches, which is why the point is chosen strictly inside
+/// a step (`3.0 * θ_0 = 6.9`, FD half-width `3e-5`) where the argument's own
+/// derivative is 3 and the true derivative is 0. On an integer boundary FD
+/// would report `1/(2h)` and measure the discontinuity rather than the arm.
 #[test]
-fn differentiate_unknown_unary_passes_through() {
-    // The slow path returns the argument unchanged for unknown names;
-    // the differentiator must return the argument's derivative.
-    let theta = &[2.0];
+fn differentiate_floor_ceil_round_is_zero_away_from_a_step() {
+    let theta = &[2.3]; // 3·θ₀ = 6.9 — no integer within FD's h = 1e-5
     let eta = &[];
     let vars = &[];
     let covs = &[];
-    let expr = unary("expn", binop(BinOp::Mul, Expression::Theta(0), lit(3.0)));
-    assert_diff_matches_fd(expr, DiffAxis::Theta(0), theta, eta, vars, covs);
+    for (name, want) in [("floor", 6.0), ("ceil", 7.0), ("round", 7.0)] {
+        let expr = unary(name, binop(BinOp::Mul, Expression::Theta(0), lit(3.0)));
+        // The value path really does round — otherwise the derivative being 0
+        // would be trivially right for the wrong reason.
+        let v = eval_at(&expr, theta, eta, vars, covs);
+        assert_eq!(v, want, "`{name}(6.9)` must round to {want}, got {v}");
+        assert_eq!(
+            eval_at(
+                &differentiate(&expr, DiffAxis::Theta(0)),
+                theta,
+                eta,
+                vars,
+                covs
+            ),
+            0.0,
+            "d/dθ₀ {name}(3·θ₀) must be 0, not the argument's derivative (3)"
+        );
+        assert_diff_matches_fd(expr, DiffAxis::Theta(0), theta, eta, vars, covs);
+    }
 }
 
 #[test]
@@ -21871,4 +21905,324 @@ fn power_form_rejects_per_cmt() {
 "#;
     let err = expect_parse_err(content);
     assert!(err.contains("not supported with per-CMT"), "got: {err}");
+}
+
+// ── #1332: an unknown function name is a parse error, not the identity ──────
+//
+// `parse_atom` used to build `Expression::UnaryFn(name, arg)` for *any*
+// identifier followed by `(`, and all three consumers ended their match on a
+// fallthrough that returned the argument unchanged. So `CL = TVCL *
+// tanh(ETA_CL)` parsed, passed `ferx check`, fitted, converged and computed
+// `TVCL * ETA_CL` — the value path and the derivative path agreeing on the
+// *wrong* model, with nothing in `FitResult.warnings` naming the dropped call.
+
+/// A model with one hole per block that routes free expressions through
+/// `parse_atom`. Every hole defaults to something benign, so a probe changes
+/// exactly one block at a time.
+fn unknown_fn_probe_model(ip: &str, ode: &str, scaling: &str, derived: &str, err: &str) -> String {
+    format!(
+        "\
+[parameters]
+  theta TVCL(1.0, 0.001, 100.0)
+  theta TVV(50.0, 0.1, 500.0)
+  theta TVKA(1.0, 0.01, 50.0)
+  omega ETA_CL ~ 0.09
+  sigma PROP_ERR ~ 0.05 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV
+  KA = TVKA
+{ip}
+[structural_model]
+  ode(states=[depot, central])
+
+[odes]
+{ode}  d/dt(depot)   = -KA * depot
+  d/dt(central) = KA * depot - CL/V * central
+
+[scaling]
+  y = central / V{scaling}
+
+[derived]
+  CLi = CL{derived}
+
+[error_model]
+  DV ~ {err}
+
+[fit_options]
+  method  = focei
+  maxiter = 10
+"
+    )
+}
+
+/// The blocks a one-argument call can appear in, each carrying `fname(...)`
+/// where the call goes. The check sits at the single site that builds the node,
+/// so it has to bite in all of them — an earlier arity fix that lived on one
+/// block's path would leave the rest silent.
+///
+/// The argument differs by block on purpose: an `[odes]` RHS may not reference a
+/// θ (it is rejected by name resolution before the call is ever evaluated), so
+/// the ODE / scaling / derived probes take the individual parameter `CL`. Using
+/// `TVCL` there would make the *straddle* fixture invalid while the rejection
+/// test still passed, on a different error.
+fn unknown_fn_probe_sources(fname: &str) -> Vec<(&'static str, String)> {
+    let prop = "proportional(PROP_ERR)";
+    vec![
+        (
+            "[individual_parameters]",
+            unknown_fn_probe_model(&format!("  KE = {fname}(TVCL)\n"), "", "", "", prop),
+        ),
+        (
+            "[individual_parameters], inline `if` arm",
+            unknown_fn_probe_model(
+                &format!("  KE = if (TVCL > 0.5) {fname}(TVCL) else 1.0\n"),
+                "",
+                "",
+                "",
+                prop,
+            ),
+        ),
+        (
+            "[odes] statement",
+            unknown_fn_probe_model("", &format!("  KE = {fname}(CL)\n"), "", "", prop),
+        ),
+        (
+            "[odes] condition",
+            unknown_fn_probe_model(
+                "",
+                &format!("  KE = CL/V\n  if ({fname}(CL) > 1.0) {{ KE = 2.0*CL/V }}\n"),
+                "",
+                "",
+                prop,
+            ),
+        ),
+        (
+            "[scaling]",
+            unknown_fn_probe_model("", "", &format!(" * {fname}(CL)"), "", prop),
+        ),
+        (
+            "[derived]",
+            unknown_fn_probe_model("", "", "", &format!("\n  CLd = {fname}(CL)"), prop),
+        ),
+        (
+            "[error_model] magnitude expression",
+            unknown_fn_probe_model(
+                "",
+                "",
+                "",
+                "",
+                &format!("proportional(PROP_ERR * {fname}(TVCL))"),
+            ),
+        ),
+    ]
+}
+
+/// Every realistic trigger — a function that exists in another tool, a typo,
+/// and the `tanh` / `softplus` pair the DCM export (#1331) emits — must be a
+/// hard parse error naming the call, in every block that parses expressions.
+///
+/// The regression this exists to catch is deleting the `SUPPORTED_UNARY_FNS`
+/// guard in `parse_atom`: each case then parses clean and evaluates as the
+/// identity, so every assertion below reddens. That the fixtures *reach* the
+/// guard is pinned by `unknown_fn_probe_sources_parse_when_the_probe_is_known`
+/// below — the same models with a whitelisted name in the hole must parse, so
+/// a rejection here cannot be some earlier validation error on the same line.
+#[test]
+fn unknown_function_name_is_a_parse_error_in_every_block() {
+    for fname in [
+        "tanh",     // exists in NONMEM / mrgsolve, not in ferx
+        "softplus", // emitted by the DCM → population-PK export (#1331)
+        "sinh",
+        "sign",
+        "heaviside",
+        "log10",
+        "sqr",  // typo for sqrt
+        "exp1", // typo for exp
+        "lgo",  // typo for log
+    ] {
+        for (block, src) in unknown_fn_probe_sources(fname) {
+            let err = parse_model_string(&src).err().unwrap_or_else(|| {
+                panic!("`{fname}(...)` in {block} must be rejected, not silently the identity")
+            });
+            assert!(
+                err.contains("unknown function") && err.contains(fname),
+                "`{fname}(...)` in {block}: error must name the call, got: {err}"
+            );
+            assert!(
+                err.contains("Supported:") && err.contains("exp"),
+                "`{fname}(...)` in {block}: error must list what is available, got: {err}"
+            );
+        }
+    }
+}
+
+/// The straddle for the test above: the *same* fixtures with a whitelisted name
+/// in the hole must parse. Without this, a rejection could be coming from an
+/// unrelated error on the probe line and the mutation "delete the guard" would
+/// leave the suite green.
+#[test]
+fn unknown_fn_probe_sources_parse_when_the_probe_is_known() {
+    for (block, src) in unknown_fn_probe_sources("sqrt") {
+        parse_model_string(&src)
+            .unwrap_or_else(|e| panic!("`sqrt(...)` in {block} must parse, got: {e}\n{src}"));
+    }
+}
+
+/// Function names are lower-cased before dispatch, so the NONMEM `$PK`
+/// spellings a model file gets pasted from keep working — `EXP(ETA_CL)` is
+/// `exp`, not an unknown name. The rejection is case-insensitive in the same
+/// way, so `TANH(` is rejected exactly like `tanh(`.
+#[test]
+fn function_name_matching_is_case_insensitive_on_both_sides() {
+    for good in ["EXP(ETA_CL)", "Log(TVCL)", "SQRT(TVCL)", "Inv_Logit(TVCL)"] {
+        let src = unknown_fn_probe_model(
+            &format!("  KE = {good}\n"),
+            "",
+            "",
+            "",
+            "proportional(PROP_ERR)",
+        );
+        parse_model_string(&src)
+            .unwrap_or_else(|e| panic!("`{good}` must parse (names are lower-cased): {e}"));
+    }
+    for bad in ["TANH(TVCL)", "Tanh(TVCL)"] {
+        let src = unknown_fn_probe_model(
+            &format!("  KE = {bad}\n"),
+            "",
+            "",
+            "",
+            "proportional(PROP_ERR)",
+        );
+        let err = parse_model_string(&src).expect_err(&format!("`{bad}` must be rejected"));
+        assert!(
+            err.contains("unknown function"),
+            "`{bad}`: got the wrong error: {err}"
+        );
+    }
+}
+
+/// `present(x)` is a condition, not a value (#1111). In value position it used
+/// to become `UnaryFn("present", x)` and hand back `x`; it is now rejected with
+/// a message that points at condition position rather than at the generic
+/// "unknown function" list, since the name *is* known — just not here.
+#[test]
+fn present_in_value_position_is_rejected_and_points_at_conditions() {
+    let src = unknown_fn_probe_model("  KE = present(WT)\n", "", "", "", "proportional(PROP_ERR)");
+    let err = parse_model_string(&src).expect_err("`present` in value position must be rejected");
+    assert!(
+        err.contains("condition") && err.contains("present"),
+        "expected a conditions-only message for `present`, got: {err}"
+    );
+    // …and it still works where it belongs.
+    let ok = unknown_fn_probe_model(
+        "  KE = if (present(WT)) 1.0 else 2.0\n",
+        "",
+        "",
+        "",
+        "proportional(PROP_ERR)",
+    );
+    parse_model_string(&ok).expect("`present` in condition position must still parse");
+}
+
+/// The whitelist ↔ implementation pin. `SUPPORTED_UNARY_FNS` is the complete
+/// domain of the `UnaryFn` dispatch in `eval_expr`, `compile_expr_into` and
+/// `differentiate_with_chain`; each of those now ends on `unreachable!`, so a
+/// name added to the list without an arm in one of them panics here rather than
+/// evaluating as the identity in production.
+///
+/// Panicking is only half the pin — a reintroduced `_ => v` / `_ => da`
+/// fallthrough would not panic, so each probe is also asserted to be
+/// *non*-identity on both the value and the derivative side. The argument is
+/// `2·θ₀`, so the identity fallthrough would give value `x` and derivative `2`;
+/// every probe below is chosen so the true answers are neither.
+///
+/// The `probes` table is required to cover the list exactly, so adding a name
+/// to `SUPPORTED_UNARY_FNS` without a probe here is a red test too.
+#[test]
+fn every_supported_unary_fn_has_an_arm_in_all_three_consumers() {
+    // (name, x) — `x` is the value the argument takes; θ₀ = x/2.
+    let probes: &[(&str, f64)] = &[
+        ("exp", 0.5),
+        ("log", 2.0),
+        ("ln", 2.0),
+        ("sqrt", 9.0),
+        ("abs", -3.0),
+        ("floor", 6.9),
+        ("ceil", 6.9),
+        ("round", 6.9),
+        ("logit", 0.25),
+        ("inv_logit", 0.5),
+        ("expit", 0.5),
+    ];
+    assert_eq!(
+        probes.len(),
+        SUPPORTED_UNARY_FNS.len(),
+        "every whitelisted name needs a probe here"
+    );
+    for n in SUPPORTED_UNARY_FNS {
+        assert!(
+            probes.iter().any(|(p, _)| p == n),
+            "`{n}` is whitelisted but has no probe"
+        );
+    }
+
+    let eta: &[f64] = &[];
+    let vars: &[f64] = &[];
+    let covs: &[f64] = &[];
+    for &(name, x) in probes {
+        let theta = &[x / 2.0];
+        let arg = binop(BinOp::Mul, Expression::Theta(0), lit(2.0));
+        let expr = unary(name, arg);
+
+        // 1. `eval_expr` has an arm: the value is not the argument.
+        let v = eval_at(&expr, theta, eta, vars, covs);
+        assert!(v.is_finite(), "`{name}({x})` must be finite, got {v}");
+        assert_ne!(
+            v, x,
+            "`{name}({x})` returned its argument — the identity fallthrough is back"
+        );
+
+        // 2. `compile_expr_into` has an arm: the bytecode agrees bit-for-bit.
+        bc_vs_ast(expr.clone(), vars, theta, eta, covs);
+
+        // 3. `differentiate_with_chain` has an arm: the derivative is neither
+        //    the argument's derivative (2) nor NaN, and it matches FD.
+        let d = eval_at(
+            &differentiate(&expr, DiffAxis::Theta(0)),
+            theta,
+            eta,
+            vars,
+            covs,
+        );
+        assert!(
+            d.is_finite(),
+            "d/dθ₀ `{name}(2·θ₀)` must be finite, got {d}"
+        );
+        assert_ne!(
+            d, 2.0,
+            "d/dθ₀ `{name}(2·θ₀)` is the argument's derivative — the `_ => da` fallthrough is back"
+        );
+        assert_diff_matches_fd(expr, DiffAxis::Theta(0), theta, eta, vars, covs);
+    }
+}
+
+/// Every name in `SUPPORTED_UNARY_FNS` must also be *accepted* by the parser.
+/// Together with the test above this closes the loop: whitelisted ⇒ parses ⇒
+/// has a real arm in all three consumers. A name dropped from the parser's
+/// check (or a check written against a second, drifting list) fails here.
+#[test]
+fn every_supported_unary_fn_parses_in_a_model_file() {
+    for name in SUPPORTED_UNARY_FNS {
+        let src = unknown_fn_probe_model(
+            &format!("  KE = {name}(TVCL)\n"),
+            "",
+            "",
+            "",
+            "proportional(PROP_ERR)",
+        );
+        parse_model_string(&src)
+            .unwrap_or_else(|e| panic!("`{name}(...)` is whitelisted but does not parse: {e}"));
+    }
 }

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -22058,6 +22058,66 @@ fn unknown_function_name_is_a_parse_error_in_every_block() {
     }
 }
 
+/// An unknown name is judged as a *name*, whatever arity it is called with.
+///
+/// `pow(x, y)` is one of the migration triggers #1332 names, and it used to
+/// reach the comma branch first and be reported as "`pow` takes 1 argument" —
+/// a hard error, so never the dangerous silent identity, but one that sends the
+/// reader looking for an arity bug in a function ferx does not have. The guard
+/// now sits above the argument loop, so the diagnostic is the same for every
+/// arity.
+///
+/// The three names ferx *does* take with more than one argument keep their own
+/// arity messages, asserted here so moving the guard cannot have swallowed them
+/// (`test_clamp_arity_diagnostics` pins the rest).
+#[test]
+fn an_unknown_name_is_rejected_at_every_arity() {
+    for call in [
+        "pow(TVCL, 2.0)",
+        "atan2(TVCL, TVV)",
+        "fma(TVCL, TVV, 1.0)",
+        "tanh()",
+    ] {
+        let src = unknown_fn_probe_model(
+            &format!("  KE = {call}\n"),
+            "",
+            "",
+            "",
+            "proportional(PROP_ERR)",
+        );
+        let err = parse_model_string(&src).expect_err(&format!("`{call}` must be rejected"));
+        let fname = call.split('(').next().unwrap();
+        assert!(
+            err.contains("unknown function") && err.contains(fname),
+            "`{call}`: expected the unknown-function diagnostic, got: {err}"
+        );
+        assert!(
+            !err.contains("takes 1 argument"),
+            "`{call}`: reported an arity for a function ferx does not have: {err}"
+        );
+    }
+
+    // min / max / clamp are exempt from the name guard and keep arity messages.
+    for (call, want) in [
+        ("min(TVCL)", "exactly two arguments"),
+        ("max(TVCL)", "exactly two arguments"),
+        ("clamp(TVCL)", "three arguments"),
+    ] {
+        let src = unknown_fn_probe_model(
+            &format!("  KE = {call}\n"),
+            "",
+            "",
+            "",
+            "proportional(PROP_ERR)",
+        );
+        let err = parse_model_string(&src).expect_err(&format!("`{call}` must be rejected"));
+        assert!(
+            err.contains(want) && !err.contains("unknown function"),
+            "`{call}`: expected the arity message, got: {err}"
+        );
+    }
+}
+
 /// The straddle for the test above: the *same* fixtures with a whitelisted name
 /// in the hole must parse. Without this, a rejection could be coming from an
 /// unrelated error on the probe line and the mutation "delete the guard" would
@@ -22156,17 +22216,26 @@ fn every_supported_unary_fn_has_an_arm_in_all_three_consumers() {
         ("inv_logit", 0.5),
         ("expit", 0.5),
     ];
+    // The probe table must equal the const as a *multiset*, asserted as one
+    // comparison of sorted vectors rather than as a set of membership and
+    // length checks. The earlier spelling — equal lengths plus "every const
+    // name has a probe" — was not exact: replacing one const entry with a copy
+    // of another keeps the length and keeps every (surviving) const name
+    // present in the probes, so it stayed green while silently dropping the
+    // replaced function from the whitelist and making `ceil(...)` a parse
+    // error. Sorted-vector equality catches that, a name added to either side,
+    // and a duplicated row on either side, in a single gate — separate
+    // membership and uniqueness assertions would reject several of those inputs
+    // twice over and cover for each other.
+    let mut want: Vec<&str> = SUPPORTED_UNARY_FNS.to_vec();
+    want.sort_unstable();
+    let mut got: Vec<&str> = probes.iter().map(|(p, _)| *p).collect();
+    got.sort_unstable();
     assert_eq!(
-        probes.len(),
-        SUPPORTED_UNARY_FNS.len(),
-        "every whitelisted name needs a probe here"
+        got, want,
+        "the probe table and SUPPORTED_UNARY_FNS have drifted; every whitelisted name \
+         needs exactly one probe here, and every probe a whitelist entry"
     );
-    for n in SUPPORTED_UNARY_FNS {
-        assert!(
-            probes.iter().any(|(p, _)| p == n),
-            "`{n}` is whitelisted but has no probe"
-        );
-    }
 
     let eta: &[f64] = &[];
     let vars: &[f64] = &[];

--- a/tests/vi_dcm_omega_recovery.rs
+++ b/tests/vi_dcm_omega_recovery.rs
@@ -184,9 +184,10 @@ impl CovariateDesign {
 ///
 /// The `CRCL` term is busulfan's, `1 + 0.4·tanh((CRCL − 90)/40)`, written out as
 /// `2·inv_logit(2u) − 1` because **`tanh` is not in the `[individual_parameters]` function
-/// set and unknown unary functions there evaluate to their argument rather than erroring**
-/// — so the natural spelling would silently simulate a *linear* `CRCL` effect. (That
-/// silent-identity behaviour is worth fixing on its own; it is not this file's job.)
+/// set**. Since #1332 the natural spelling is a parse error rather than a silent identity
+/// that would have simulated a *linear* `CRCL` effect, so this rewrite is now a
+/// convenience rather than the only thing standing between the fixture and a wrong
+/// data-generating model.
 const TRUTH_SRC: &str = r"
 [parameters]
   theta TVCL(1.0, 0.01, 50.0)


### PR DESCRIPTION
## Why

`parse_atom` built `Expression::UnaryFn(name, arg)` for **any** identifier followed by `(`, with no check that the name was a function ferx knows. All three consumers then ended their match on a fallthrough that returned the argument unchanged, so an unrecognised function was silently the **identity**:

```
[individual_parameters]
  CL = TVCL * tanh(ETA_CL)      # tanh is not a ferx builtin
```

parsed, passed `ferx check`, fitted, converged and computed `TVCL * ETA_CL`. The derivative path agreed with the value path, so no internal check disagreed either — the model was *consistently* the wrong model, with no warning, no `FitResult.warnings` entry, and nothing in the output naming the dropped call.

This is the same failure class the parser has already fixed twice by rejecting a spelling **by name** — #1030 (one-argument `max(x)`) and #1092 (one-argument `clamp(x)`, *"a no-op that fits, converges and gives wrong numbers"*). Neither closed the general case. The realistic triggers are ordinary: a function that exists in NONMEM / nlmixr2 / mrgsolve but not here (`tanh`, `sinh`, `sign`, `log10`), or a plain typo (`sqr(x)`, `exp1(x)`).

Blocks #1331 (DCM → plain population PK export), which emits `tanh(...)` / `softplus(...)` into `[individual_parameters]`. Without a parse-time rejection, an export that runs ahead of a `tanh` builtin makes the exporter a generator of exactly this bug.

Closes #1332.

## What changed

**One whitelist, consulted at the single site that builds the node.** `SUPPORTED_UNARY_FNS` is the closed list of callable one-argument names (`exp`, `log`, `ln`, `sqrt`, `abs`, `floor`, `ceil`, `round`, `logit`, `inv_logit`, `expit`). Because the check sits at the one `return Ok((Expression::UnaryFn(...)))` in `parse_atom`, it covers every block whose expressions go through the expression parser rather than one block's path:

```
unknown function `tanh`. Supported: exp, log, ln, sqrt, abs, floor, ceil, round,
logit, inv_logit, expit, min(a, b), max(a, b), clamp(x, lo, hi),
present(x) (conditions only)
```

`min`/`max`/`clamp` are deliberately absent from the const: `parse_atom` desugars them to `Expression::Conditional`, so they never reach `UnaryFn`. Their existing arity errors still fire first and keep their own, more specific messages (checked — deleting either reddens `test_clamp_arity_diagnostics`, so these are not two gates covering for each other). `present(x)` in **value** position gets its own message pointing at condition position, since the name is known, just not there.

**The three `_ =>` arms become `unreachable!()`.** `Expression` is `pub(crate)` and the parser is its only constructor, so the whitelist makes the tails genuinely unreachable — a name added to the list without an arm in `eval_expr`, `compile_expr_into` *and* `differentiate_with_chain` is a panic in test rather than a silent identity in production. All three share one named panic message so the failure reads the same wherever it comes from, and each interpolates which consumer it was.

**Secondary defect, fixed alongside:** `floor` / `ceil` / `round` had arms in `eval_expr` and in the bytecode compiler but **none** in the symbolic differentiator, so they landed on the same identity fallthrough and `d/dx floor(x)` was `1`, not `0`. Any `[individual_parameters]` or `[odes]` expression that rounds — a dose-band lookup, an occasion index derived from `TIME` — was feeding a wrong analytic gradient to the estimator while its value path was correct. They now differentiate to `0`, the integer boundaries undefined and ignored exactly as `BinOp::Mod` already does.

## Alternatives considered

- **Warn instead of reject.** Rejected: the whole failure mode is that the wrong model *converges*, and a warning in a fit that reports a plausible OFV is exactly what got missed. A file that relies on the no-op is already computing something other than what it reads as.
- **Leave the `_ =>` arms as the identity and only gate at parse time.** That keeps the gate one-sided: a future builtin added to the whitelist but wired into only two of the three consumers would silently differentiate (or evaluate) as the identity again — the #1332 shape, reintroduced through the front door. `unreachable!()` turns that into a test failure.
- **`#[doc(hidden)]`-style escape hatch / a second list per consumer.** Rejected on the "when two implementations disagree, the fix is one implementation" rule — the const is the single source and the pin test forces the three matches to agree with it.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

No public Rust API change (`Expression` is `pub(crate)`; `cargo public-api` baseline unchanged), so ferx-r needs no lock bump for this.

## Breaking changes
- [x] `.ferx` model file format (migration note below)
- [ ] `FitResult` / sdtab fields changed
- [ ] Public Rust API
- [ ] None

<details>
<summary>Migration notes</summary>

A model file that called a function ferx does not have now fails to parse instead of silently dropping the call. **Every such error is a true positive** — the file was already computing something other than what it reads as. The fix is to write the function out in terms of the supported set, e.g. `tanh(u)` as `2*inv_logit(2*u) - 1`.

Names are matched case-insensitively (they are lower-cased before dispatch), so the NONMEM `$PK` spellings `EXP(...)` / `LOG(...)` are unaffected; `TANH(...)` is rejected exactly like `tanh(...)`.

Blast radius was checked, not assumed: nothing in `examples/`, `tests/`, `docs/**/*.qmd` or `nonmem_anchor/` uses a name outside the whitelist. The single place that named `tanh` was a comment in `tests/vi_dcm_omega_recovery.rs` documenting this bug as unfixed and writing the term out as `2·inv_logit(2u) − 1` to dodge it — comment updated. (`tanh` also appears in `docs/model-file/covariate-nn.qmd` as a **`[covariate_nn]` activation-function name**, a different namespace parsed as a key, not an expression — unaffected.)

</details>

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit
- [x] Not applicable — no NONMEM anchor exists for either half, and neither needs one:
  - The parse rejection produces **no numbers at all**; it converts a silently-wrong fit into an error. There is nothing to anchor.
  - `floor`/`ceil`/`round` differentiating to 0 is an **exact closed form**, not a tolerance: the function is piecewise constant, so the derivative is 0 everywhere off the steps. It is pinned against central finite differences of the production value path at a point strictly inside a step (`3·θ₀ = 6.9`, FD half-width `3e-5`), which is what makes FD a valid oracle there — evaluated *on* a boundary FD would report `1/(2h)` and measure the discontinuity instead of the arm. The value path is separately asserted to actually round (`floor → 6`, `ceil`/`round → 7`), so "derivative 0" cannot be right for the wrong reason.

## Performance
- [x] No significant impact expected — one `contains` over an 11-element `&[&str]` per function call **at parse time**. The evaluation and compilation paths are unchanged; the `unreachable!()` arms are cold.

## Tests
- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix

New Tier-1 tests in `src/parser/model_parser_tests.rs`:

| test | what it pins |
|---|---|
| `unknown_function_name_is_a_parse_error_in_every_block` | 9 trigger names × 7 expression positions — `[individual_parameters]` plain and inline-`if` arm, `[odes]` statement and `if` condition, `[scaling]`, `[derived]`, `[error_model]` magnitude expression |
| `unknown_fn_probe_sources_parse_when_the_probe_is_known` | the **straddle**: the same fixtures with `sqrt` in the hole must parse, so a rejection above cannot be an unrelated error on the probe line |
| `function_name_matching_is_case_insensitive_on_both_sides` | `EXP(` / `Log(` / `Inv_Logit(` still parse; `TANH(` / `Tanh(` rejected |
| `present_in_value_position_is_rejected_and_points_at_conditions` | plus the positive control that `if (present(WT))` still parses |
| `every_supported_unary_fn_has_an_arm_in_all_three_consumers` | the whitelist ↔ implementation pin |
| `every_supported_unary_fn_parses_in_a_model_file` | closes the loop: whitelisted ⇒ parses ⇒ has a real arm |
| `differentiate_floor_ceil_round_is_zero_away_from_a_step` | the secondary defect, vs FD |

Two of these deserve a note on *why they can fail*, per the repo's rules on assertions that cannot observe the defect:

- **The pin does not rely on the panic.** `unreachable!()` would make a missing arm panic, but a *reintroduced* `_ => v` / `_ => da` fallthrough would not. So each probe is also asserted non-identity on both sides: the argument is `2·θ₀`, so an identity fallthrough gives value `x` and derivative `2`, and every probe is chosen so the true answers are neither (`abs` probed at a negative argument, `log` at 2, `sqrt` at 9, the rounding trio at 6.9, …). The probe table is required to cover `SUPPORTED_UNARY_FNS` exactly, so adding a name to the const without a probe is also red.
- **Fixtures reach the guard.** The `[odes]` probes take `CL` rather than `TVCL` because an ODE RHS may not reference a θ — with `TVCL` the *rejection* test still passed, on a different error, while the straddle fixture was invalid. The straddle test is what caught that; it is the reason it exists.

Mutation-tested, **each side named separately** rather than only toggling the fix as a whole:

| mutation | tests that redden |
|---|---|
| disable the `SUPPORTED_UNARY_FNS` guard in `parse_atom` | 3 (the rejection tests) |
| delete `"floor"` arm in `eval_expr`, **with the identity fallthrough restored** so the panic cannot be doing the work | 4 |
| delete `"floor"` arm in `compile_expr_into` | 4 |
| delete the `"floor" \| "ceil" \| "round"` derivative arm | 3 |

Full runs on this branch: `cargo test --lib` → **4385 passed, 0 failed**; all **183** integration test binaries under `--features ci,survival` green (run serially — the machine was memory-saturated, three parallel `cargo test` runs were OOM-killed); `tools/preflight.sh` → `preflight OK — fmt check clippy rustdoc docs public-api`.

## Example (user-facing features only)
- [x] Not applicable (fix with no new API surface) — the user-visible change is an error message, shown above and in the docs.

## Docs
- [x] `docs/` updated for user-visible changes
- [x] `CHANGELOG.md` `[Unreleased]` entry added (one under `Changed` for the rejection, one under `Fixed` for the derivative)
- [ ] New pages linked in `docs/_quarto.yml` (no new pages)

`docs/model-file/individual-parameters.qmd` — the *Supported Operators and Functions* table was itself incomplete (it omitted `floor`/`ceil`/`round`/`logit`/`inv_logit`/`expit`, all of which have always worked); completed it, then added the closed-list statement, the error message, the case-insensitivity note and the rounding-derivative consequence. `docs/model-file/scaling.qmd` gains a cross-reference so the "available in every block" claim next to `min`/`max`/`clamp` also says the set is closed. `cargo run -p docs-lint -- --check` clean.

## Checklist
- [x] `tools/preflight.sh` green
- [x] Functions on the `Dual2` sensitivity path stay differentiable
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site / ferx-book
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → n/a (this removes an accidental non-feature; no syntax added)
- [ ] New example `.ferx` file → n/a
- [ ] New data file → n/a
- [ ] New estimator, DSL feature, or fit option → n/a

### Example execution
- [x] No example execution step needed — `test_parse_all_example_ferx_files` parses every `examples/*.ferx` on every `--lib` run and is green, which is the check that matters for a parser-hardening change.

## Reviewer hints

Focus on **`SUPPORTED_UNARY_FNS` and its three consumers** (`src/parser/model_parser.rs`): the argument that `unreachable!()` is sound rests entirely on `Expression` being `pub(crate)` with `parse_atom` as its only constructor — worth checking that claim rather than taking it. `git grep 'UnaryFn'` outside `model_parser.rs` returns only the test file. Inside it, `UnaryFn` is built with a literal name in exactly five places, all whitelisted — `sqrt` in the IIV-weighting rewrite, and `exp` / `sqrt` / `inv_logit` / `ln` inside `differentiate_with_chain`'s own output — plus `simplify_expr`, which clones an existing node's name and so cannot introduce a new one.

Second thing worth a look: whether the whitelist should have been *wider*. `tanh` and `softplus` are the two names #1331 wants, and this PR deliberately does not add them — the point is that the export must fail loudly until the builtins exist, rather than emit a model that quietly computes something else. If you would rather land the builtins in the same change, say so and I will add them with their arms and probes (each is a three-line addition plus one row in the probe table).

The docs diff and the `tests/vi_dcm_omega_recovery.rs` comment change can be skimmed.

## Open questions

Should `tanh` / `softplus` land here as real builtins rather than in #1331? The whitelist is designed to make that a small, well-pinned addition either way, but doing it in this PR would mean #1331 has nothing left to block on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MATN4FDqQbmSa8aApKmPaF
