### PR TITLE
feat(estimation): per-parameter priors for penalized ML / MAP estimation (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-parameter priors for penalized maximum-likelihood (MAP) estimation**, declared inline as `prior(value, rse = 25%)` on any `theta`, `omega`, `sigma` or `kappa` — the simple alternative to NONMEM `$PRIOR`, with no separate prior problem and no matrices. The fit reports the data and prior halves of the OFV separately plus a per-parameter shift-toward-prior summary; AIC/BIC stay on the data half. Applies to `foce`, `focei`, `laplace`, `gn` and `gn_hybrid` (#254).
+
 ### Changed
 
 - **SAEM now averages the residual sufficient statistic for eligible single additive and proportional error models, reducing final-draw Monte Carlo noise in the residual SD estimate (#1321).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ section of the SDLC for the versioning policy).
 
 ### Added
 
-- **Per-parameter priors for penalized maximum-likelihood (MAP) estimation**, declared inline as `prior(value, rse = 25%)` on any `theta`, `omega`, `sigma` or `kappa` — the simple alternative to NONMEM `$PRIOR`, with no separate prior problem and no matrices. The fit reports the data and prior halves of the OFV separately plus a per-parameter shift-toward-prior summary; AIC/BIC stay on the data half, and the prior's curvature reaches the reported standard errors and the SIR intervals. Applies to `foce`, `focei`, `laplace`, `gn` and `gn_hybrid`; a chain whose last estimating stage cannot apply priors, and `covariance_method = s` (which cannot represent one), are refused rather than run unpenalized. The θ prior is anchored against NONMEM `$PRIOR NWPRI` (#254).
+- **Per-parameter priors for penalized maximum-likelihood (MAP) estimation**, declared inline as `prior(value, rse = 25%)` on any `theta`, `omega`, `sigma` or `kappa` — the simple alternative to NONMEM `$PRIOR`, with no separate prior problem and no matrices. The fit reports the data and prior halves of the OFV separately plus a per-parameter shift-toward-prior summary; AIC/BIC stay on the data half, and the prior's curvature reaches the reported standard errors and the SIR intervals. Applies to `foce`, `focei`, `laplace`, `gn` and `gn_hybrid`; a chain whose last estimating stage cannot apply priors, and an `S`-based covariance estimator (`covariance_method = s` or `rsr`, neither of which can represent one), are refused rather than run unpenalized. The θ prior is anchored against NONMEM `$PRIOR NWPRI` (#254).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ section of the SDLC for the versioning policy).
 
 ### Added
 
-- **Per-parameter priors for penalized maximum-likelihood (MAP) estimation**, declared inline as `prior(value, rse = 25%)` on any `theta`, `omega`, `sigma` or `kappa` — the simple alternative to NONMEM `$PRIOR`, with no separate prior problem and no matrices. The fit reports the data and prior halves of the OFV separately plus a per-parameter shift-toward-prior summary; AIC/BIC stay on the data half. Applies to `foce`, `focei`, `laplace`, `gn` and `gn_hybrid` (#254).
+- **Per-parameter priors for penalized maximum-likelihood (MAP) estimation**, declared inline as `prior(value, rse = 25%)` on any `theta`, `omega`, `sigma` or `kappa` — the simple alternative to NONMEM `$PRIOR`, with no separate prior problem and no matrices. The fit reports the data and prior halves of the OFV separately plus a per-parameter shift-toward-prior summary; AIC/BIC stay on the data half, and the prior's curvature reaches the reported standard errors and the SIR intervals. Applies to `foce`, `focei`, `laplace`, `gn` and `gn_hybrid`; a chain whose last estimating stage cannot apply priors, and `covariance_method = s` (which cannot represent one), are refused rather than run unpenalized. The θ prior is anchored against NONMEM `$PRIOR NWPRI` (#254).
 
 ### Changed
 

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -2390,6 +2390,9 @@ pub ferx_core::types::Prediction::Continuous
 pub ferx_core::types::Prediction::Continuous::pred: f64
 impl ferx_core::Prediction
 pub fn ferx_core::Prediction::prob(&self, k: usize) -> core::option::Option<f64>
+pub enum ferx_core::types::PriorSpread
+pub ferx_core::types::PriorSpread::Rse(f64)
+pub ferx_core::types::PriorSpread::Sd(f64)
 pub enum ferx_core::types::RateMode
 pub ferx_core::types::RateMode::Fixed
 pub ferx_core::types::RateMode::ModeledDuration
@@ -2570,6 +2573,7 @@ pub ferx_core::types::CompiledModel::pk_idx_f64: alloc::vec::Vec<f64>
 pub ferx_core::types::CompiledModel::pk_indices: alloc::vec::Vec<usize>
 pub ferx_core::types::CompiledModel::pk_model: ferx_core::PkModel
 pub ferx_core::types::CompiledModel::pk_param_fn: ferx_core::PkParamFn
+pub ferx_core::types::CompiledModel::priors: alloc::vec::Vec<ferx_core::ParameterPrior>
 pub ferx_core::types::CompiledModel::referenced_covariates: alloc::vec::Vec<alloc::string::String>
 pub ferx_core::types::CompiledModel::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::types::CompiledModel::residual_error_eta: core::option::Option<usize>
@@ -2973,6 +2977,8 @@ pub ferx_core::types::FitResult::nlopt_missing_algorithms: alloc::vec::Vec<alloc
 pub ferx_core::types::FitResult::npde_seed: core::option::Option<u64>
 pub ferx_core::types::FitResult::obs_time_range: core::option::Option<(f64, f64)>
 pub ferx_core::types::FitResult::ofv: f64
+pub ferx_core::types::FitResult::ofv_data: f64
+pub ferx_core::types::FitResult::ofv_prior: f64
 pub ferx_core::types::FitResult::omega: nalgebra::base::alias::DMatrix<f64>
 pub ferx_core::types::FitResult::omega_fixed: alloc::vec::Vec<bool>
 pub ferx_core::types::FitResult::omega_init: nalgebra::base::alias::DMatrix<f64>
@@ -2985,6 +2991,7 @@ pub ferx_core::types::FitResult::optimizer: alloc::string::String
 pub ferx_core::types::FitResult::outer_gtol: f64
 pub ferx_core::types::FitResult::outer_maxiter: usize
 pub ferx_core::types::FitResult::packed_estimate: core::option::Option<alloc::vec::Vec<f64>>
+pub ferx_core::types::FitResult::prior_summary: alloc::vec::Vec<ferx_core::PriorSummary>
 pub ferx_core::types::FitResult::residual_correlation_fixed: alloc::vec::Vec<bool>
 pub ferx_core::types::FitResult::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::types::FitResult::restored_from_checkpoint: bool
@@ -3132,6 +3139,10 @@ pub fn ferx_core::OmegaMatrix::from_chol_factor(l: nalgebra::base::alias::DMatri
 pub fn ferx_core::OmegaMatrix::from_diagonal(variances: &[f64], names: alloc::vec::Vec<alloc::string::String>) -> Self
 pub fn ferx_core::OmegaMatrix::from_matrix(m: nalgebra::base::alias::DMatrix<f64>, names: alloc::vec::Vec<alloc::string::String>, diagonal: bool) -> Self
 pub fn ferx_core::OmegaMatrix::from_matrix_with_mask(m: nalgebra::base::alias::DMatrix<f64>, names: alloc::vec::Vec<alloc::string::String>, diagonal: bool, free_mask: nalgebra::base::alias::DMatrix<bool>) -> Self
+pub struct ferx_core::types::ParameterPrior
+pub ferx_core::types::ParameterPrior::name: alloc::string::String
+pub ferx_core::types::ParameterPrior::spread: ferx_core::PriorSpread
+pub ferx_core::types::ParameterPrior::value: f64
 pub struct ferx_core::types::ParsedModel
 pub ferx_core::types::ParsedModel::adaptive_dosing: core::option::Option<ferx_core::sim::adaptive::AdaptiveDosingSpec>
 pub ferx_core::types::ParsedModel::bindings: ferx_core::parser::model_parser::ParseBindings
@@ -3183,6 +3194,15 @@ pub ferx_core::types::PosteriorSummary::q025: f64
 pub ferx_core::types::PosteriorSummary::q975: f64
 pub ferx_core::types::PosteriorSummary::rhat: f64
 pub ferx_core::types::PosteriorSummary::sd: f64
+pub struct ferx_core::types::PriorSummary
+pub ferx_core::types::PriorSummary::estimate: f64
+pub ferx_core::types::PriorSummary::family: alloc::string::String
+pub ferx_core::types::PriorSummary::name: alloc::string::String
+pub ferx_core::types::PriorSummary::penalty: f64
+pub ferx_core::types::PriorSummary::prior_lower_95: f64
+pub ferx_core::types::PriorSummary::prior_upper_95: f64
+pub ferx_core::types::PriorSummary::prior_value: f64
+pub ferx_core::types::PriorSummary::shift_in_prior_sds: f64
 pub struct ferx_core::types::ResidualCorrelation
 pub ferx_core::types::ResidualCorrelation::rho: f64
 pub ferx_core::types::ResidualCorrelation::sigma_i: usize
@@ -3650,6 +3670,9 @@ pub ferx_core::Prediction::Continuous
 pub ferx_core::Prediction::Continuous::pred: f64
 impl ferx_core::Prediction
 pub fn ferx_core::Prediction::prob(&self, k: usize) -> core::option::Option<f64>
+pub enum ferx_core::PriorSpread
+pub ferx_core::PriorSpread::Rse(f64)
+pub ferx_core::PriorSpread::Sd(f64)
 pub enum ferx_core::RateMode
 pub ferx_core::RateMode::Fixed
 pub ferx_core::RateMode::ModeledDuration
@@ -3900,6 +3923,7 @@ pub ferx_core::CompiledModel::pk_idx_f64: alloc::vec::Vec<f64>
 pub ferx_core::CompiledModel::pk_indices: alloc::vec::Vec<usize>
 pub ferx_core::CompiledModel::pk_model: ferx_core::PkModel
 pub ferx_core::CompiledModel::pk_param_fn: ferx_core::PkParamFn
+pub ferx_core::CompiledModel::priors: alloc::vec::Vec<ferx_core::ParameterPrior>
 pub ferx_core::CompiledModel::referenced_covariates: alloc::vec::Vec<alloc::string::String>
 pub ferx_core::CompiledModel::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::CompiledModel::residual_error_eta: core::option::Option<usize>
@@ -4356,6 +4380,8 @@ pub ferx_core::FitResult::nlopt_missing_algorithms: alloc::vec::Vec<alloc::strin
 pub ferx_core::FitResult::npde_seed: core::option::Option<u64>
 pub ferx_core::FitResult::obs_time_range: core::option::Option<(f64, f64)>
 pub ferx_core::FitResult::ofv: f64
+pub ferx_core::FitResult::ofv_data: f64
+pub ferx_core::FitResult::ofv_prior: f64
 pub ferx_core::FitResult::omega: nalgebra::base::alias::DMatrix<f64>
 pub ferx_core::FitResult::omega_fixed: alloc::vec::Vec<bool>
 pub ferx_core::FitResult::omega_init: nalgebra::base::alias::DMatrix<f64>
@@ -4368,6 +4394,7 @@ pub ferx_core::FitResult::optimizer: alloc::string::String
 pub ferx_core::FitResult::outer_gtol: f64
 pub ferx_core::FitResult::outer_maxiter: usize
 pub ferx_core::FitResult::packed_estimate: core::option::Option<alloc::vec::Vec<f64>>
+pub ferx_core::FitResult::prior_summary: alloc::vec::Vec<ferx_core::PriorSummary>
 pub ferx_core::FitResult::residual_correlation_fixed: alloc::vec::Vec<bool>
 pub ferx_core::FitResult::residual_correlations: alloc::vec::Vec<ferx_core::ResidualCorrelation>
 pub ferx_core::FitResult::restored_from_checkpoint: bool
@@ -4543,6 +4570,10 @@ pub fn ferx_core::OmegaMatrix::from_chol_factor(l: nalgebra::base::alias::DMatri
 pub fn ferx_core::OmegaMatrix::from_diagonal(variances: &[f64], names: alloc::vec::Vec<alloc::string::String>) -> Self
 pub fn ferx_core::OmegaMatrix::from_matrix(m: nalgebra::base::alias::DMatrix<f64>, names: alloc::vec::Vec<alloc::string::String>, diagonal: bool) -> Self
 pub fn ferx_core::OmegaMatrix::from_matrix_with_mask(m: nalgebra::base::alias::DMatrix<f64>, names: alloc::vec::Vec<alloc::string::String>, diagonal: bool, free_mask: nalgebra::base::alias::DMatrix<bool>) -> Self
+pub struct ferx_core::ParameterPrior
+pub ferx_core::ParameterPrior::name: alloc::string::String
+pub ferx_core::ParameterPrior::spread: ferx_core::PriorSpread
+pub ferx_core::ParameterPrior::value: f64
 pub struct ferx_core::ParsedModel
 pub ferx_core::ParsedModel::adaptive_dosing: core::option::Option<ferx_core::sim::adaptive::AdaptiveDosingSpec>
 pub ferx_core::ParsedModel::bindings: ferx_core::parser::model_parser::ParseBindings
@@ -4619,6 +4650,15 @@ pub ferx_core::PreparedRun::init_params: ferx_core::ModelParameters
 pub ferx_core::PreparedRun::model_hash: core::option::Option<alloc::string::String>
 pub ferx_core::PreparedRun::parsed: ferx_core::ParsedModel
 pub ferx_core::PreparedRun::population: ferx_core::Population
+pub struct ferx_core::PriorSummary
+pub ferx_core::PriorSummary::estimate: f64
+pub ferx_core::PriorSummary::family: alloc::string::String
+pub ferx_core::PriorSummary::name: alloc::string::String
+pub ferx_core::PriorSummary::penalty: f64
+pub ferx_core::PriorSummary::prior_lower_95: f64
+pub ferx_core::PriorSummary::prior_upper_95: f64
+pub ferx_core::PriorSummary::prior_value: f64
+pub ferx_core::PriorSummary::shift_in_prior_sds: f64
 pub struct ferx_core::ResidualCorrelation
 pub ferx_core::ResidualCorrelation::rho: f64
 pub ferx_core::ResidualCorrelation::sigma_i: usize

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -102,6 +102,7 @@ website:
           - estimation/categorical.qmd
           - estimation/ctmm.qmd
           - estimation/mixture.qmd
+          - estimation/priors.qmd
       - text: "Tools"
         href: tools/index.qmd
         contents:

--- a/docs/estimation/priors.qmd
+++ b/docs/estimation/priors.qmd
@@ -1,0 +1,212 @@
+---
+pagetitle: "Parameter priors in ferx"
+description-meta: "Stabilize sparse-data fits with per-parameter priors: penalized maximum likelihood (MAP) estimation in the ferx NLME engine, the simple alternative to NONMEM $PRIOR."
+---
+
+# Parameter Priors (penalized ML / MAP)
+
+> **Maturity: experimental** — see [Feature Maturity](../maturity.qmd) for what this means.
+
+A **prior** pins a parameter near a value you already believe, and lets the data
+move it only as far as the data can pay for. Declare one next to the parameter:
+
+```toml
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)  prior(0.15, rse = 25%)
+  theta TVV(10.0, 0.1, 500.0)   prior(9.8,  rse = 12%)
+  omega ETA_CL ~ 0.09           prior(0.09, rse = 40%)
+```
+
+That is the entire user-facing surface: **a central value and a relative
+uncertainty**, both read off the same row of a published parameter table. There
+is no separate prior problem, no precision or covariance matrix, no
+inverse-Wishart, and no degrees-of-freedom indexing to keep aligned by hand
+(compare [NONMEM `$PRIOR`](#comparison-with-nonmem-prior)).
+
+## When to reach for one
+
+Sparse clinical data — rare disease, pediatrics, TDM-led fits. The likelihood is
+weakly informative, IIV terms collapse onto boundaries, and structural parameters
+drift. A prior taken from a published popPK model stabilizes the fit and lets a
+small local dataset borrow strength from what is already known.
+
+The same mechanism is **model updating**: take a literature model as the prior,
+refit on local sparse data, and get a regularized estimate. That is the
+MAP-Bayesian updating behind much of model-informed precision dosing.
+
+## What a prior does to the objective
+
+The penalty is added to the objective the optimizer minimises:
+
+$$
+\mathrm{OFV}_{\text{total}} \;=\; \mathrm{OFV}_{\text{data}} \;+\; \sum_k \left(\frac{x_k - m_k}{s_k}\right)^2
+$$
+
+where $x_k$ is the parameter on the scale ferx estimates it, $m_k$ is the prior
+centre on that same scale, and $s_k$ comes from the RSE.
+
+Two consequences worth knowing before you read a result:
+
+- **`ofv` is the penalized total.** The fit report splits it into `ofv_data` and
+  `ofv_prior` so you can see how much of the objective the prior is responsible
+  for. Normalisation constants are dropped on both halves (ferx's −2 log L
+  already omits $N\log 2\pi$), so a priored ferx OFV is not absolutely comparable
+  to a priored NONMEM objective — compare a **ΔOFV against a null twin** instead.
+- **AIC and BIC are computed from `ofv_data`.** A penalized objective is not a
+  log-likelihood, and an information criterion built from one would silently
+  reward a tighter prior.
+
+## Which scale the prior lives on
+
+**The prior's central value and its spread are always on the scale the parameter
+was declared on.** If you wrote a variance, the prior is a variance; if you wrote
+`(sd)`, both are standard deviations. Nothing is ever converted by hand.
+
+What the prior *becomes* internally follows from how ferx estimates the
+parameter:
+
+| Declaration | Estimated as | Prior family | From `prior(v, rse = r)` |
+|---|---|---|---|
+| `theta X(init, lower ≥ 0, …)` | $\ln\theta$ | lognormal on $\theta$ | $m=\ln v$, $s=\sqrt{\ln(1+r^2)}$ |
+| `theta X(init, lower < 0, …)` | $\theta$ | normal on $\theta$ | $m=v$, $s=\lvert v\rvert\,r$ |
+| `omega E ~ var` | $\ln(\mathrm{SD})$ | lognormal on the variance | $m=\tfrac12\ln v$, $s=\tfrac12\sqrt{\ln(1+r^2)}$ |
+| `omega E ~ sd (sd)` | $\ln(\mathrm{SD})$ | lognormal on the SD | $m=\ln v$, $s=\sqrt{\ln(1+r^2)}$ |
+| `sigma S ~ var` / `(sd)` | $\ln(\mathrm{SD})$ | as omega | as omega |
+| `kappa K ~ var` / `(sd)` | $\ln(\mathrm{SD})$ | as omega | as omega |
+
+Working on the log-variance scale for $\Omega$ keeps the prior positive and
+symmetric and avoids any matrix algebra.
+
+### The trap: a θ's prior family follows its bounds
+
+A θ declared with a **non-negative** lower bound is estimated as $\ln\theta$, so
+its prior is lognormal. Widen the bound to allow negative values and ferx
+estimates $\theta$ directly, which makes the same `prior(...)` declaration a
+**normal** prior instead. Nothing in the declaration changes; the family does.
+
+This is visible rather than hidden: the fit report prints the realised family and
+the implied 95% prior interval for every priored parameter, so check that column
+rather than inferring the family from the model file.
+
+## Declaring a prior
+
+```
+prior(<value>, rse = <r>%)      # relative uncertainty, as a percent
+prior(<value>, rse = <r>)       # …or as a fraction below 1
+prior(<value>, sd  = <s>)       # absolute SD, on the declared scale
+```
+
+`value =` may be written explicitly (`prior(value = 0.15, rse = 25%)`). Exactly
+one of `rse` / `sd` is required.
+
+**RSE units are validated, not guessed.** `rse = 25%` and `rse = 0.25` both mean
+25%. A bare number greater than 1 is a hard error: `rse = 25` is overwhelmingly a
+percent written without its sign, and reading it as 2500% would produce a prior
+so flat the fit is indistinguishable from an unpriored one — a mistake you would
+never see, because the fit still converges.
+
+Use `sd = ` when a relative uncertainty is meaningless: a θ that can be negative
+(a covariate exponent, a drug-effect slope) whose prior centre sits at or near
+zero. On a log-estimated parameter `sd` is read as the relative spread it implies
+(`sd = 0.03` on a value of `0.15` is `rse = 20%`), so the two spellings never
+disagree.
+
+## Reading the output
+
+```
+--- Objective Function ---
+OFV:  1584.2213
+    data:  1583.9501
+    prior: 0.2712
+AIC:  1595.9501
+BIC:  1612.1530
+
+--- Parameter Priors (penalized ML / MAP) ---
+  PARAMETER               PRIOR     ESTIMATE    SHIFT    PENALTY  PRIOR 95%
+  TVCL                  0.15000      0.13195    -0.52      0.271  [0.0926, 0.2430] (lognormal)
+  SHIFT is (estimate − prior) in prior SDs. Standard errors above are the curvature of
+  the penalized objective — MAP standard errors, not posterior SDs.
+```
+
+`SHIFT` is the column that earns its place. A raw difference only says the
+estimate moved; the standardized one says whether the data and the prior actually
+**disagree** — which is the question a MAP fit is asked. A shift beyond about ±2
+means the data is fighting the prior, and is worth investigating before the
+result is used.
+
+The same values are written to the fit YAML under `objective_function` (as
+`ofv_data` / `ofv_prior`) and `parameter_priors`.
+
+### Standard errors are MAP standard errors
+
+The reported SEs are the curvature of the **penalized** objective, not posterior
+standard deviations. This is deliberate and it is the only defensible choice: a
+sparse fit carries a prior precisely because the data alone does not identify the
+direction, and that is exactly where the unpenalized Hessian goes flat or
+non-positive-definite. Reporting the data-only curvature would give a standard
+error for a quantity the data cannot estimate.
+
+It also means a tighter prior gives a smaller SE, mechanically. Do not read a
+narrow MAP interval as evidence the data was informative — read `SHIFT` and
+`ofv_prior` for that.
+
+## Where it applies
+
+Priors are applied by the **FOCE family**: `foce`, `focei`, `laplace`, `gn`,
+`gn_hybrid`. They enter the objective, the gradient, and the covariance step's
+Hessian.
+
+If the **final** estimation stage of a chain does not apply priors, the fit is
+**refused** rather than run unpenalized. An unapplied prior is invisible in the
+output — the fit converges, the estimates look reasonable, and nothing says the
+prior was dropped — so a silent fallback would be worse than no feature. Chaining
+is fine as long as the last stage qualifies: `method = [saem, focei]` works,
+because the FOCEI stage is the one whose estimates are reported.
+
+## Not supported in v1
+
+Each of these is an **error**, never a silently ignored declaration:
+
+- a prior on a `block_omega` / `block_sigma` / `block_kappa` element — those are
+  estimated as Cholesky entries rather than as variances, and a correlated block
+  needs the inverse-Wishart machinery this feature exists to avoid. Declare the
+  diagonal variances separately to prior them;
+- a prior on a `FIX`ed parameter (it could never move it, so it is a typo);
+- a prior on a θ level block (`theta PLACEBO[STUDY, TIME](…)`) — one declaration
+  standing for many parameters would make one prior mean "the same prior on every
+  level", which is a useful ridge but a different feature;
+- a prior on a per-class `[mixture]` Ω/Σ override.
+
+Also out of scope by design: joint priors across parameters (no precision
+matrices anywhere), and full Bayesian inference — this is MAP / penalized ML, and
+`method = bayes` carries its own priors.
+
+## Comparison with NONMEM `$PRIOR`
+
+NONMEM's `$PRIOR NWPRI` works, and is a known source of friction: a separate
+prior problem, a variance block for the thetas, an inverse-Wishart on $\Omega$
+via a prior matrix plus degrees of freedom, and all the matrix indexing kept
+aligned by hand.
+
+| | NONMEM `$PRIOR NWPRI` | ferx `prior(...)` |
+|---|---|---|
+| Where it is written | a second `$PROBLEM` | inline, next to the parameter |
+| θ prior | `$THETAP` + `$THETAPV` (a variance-covariance matrix) | `prior(value, rse = …)` |
+| Ω prior | inverse-Wishart: `$OMEGAP` + `$OMEGAPD` degrees of freedom | `prior(value, rse = …)` on the declared variance |
+| Correlated priors | supported (full matrices) | not in v1 |
+| Scale conversions | yours | internal |
+
+The θ side is directly equivalent — a normal prior, differing only in whether it
+sits on $\theta$ or $\ln\theta$, which in ferx follows the declared bounds. The
+$\Omega$ side is genuinely a different prior: lognormal on the variance rather
+than inverse-Wishart. For a diagonal $\Omega$ the two are close in practice and
+neither is more "correct"; they differ in tail behaviour and in how a very small
+variance is penalized.
+
+## References
+
+- Gisleskog PO, Karlsson MO, Beal SL. *Use of prior information to stabilize a
+  population data analysis.* J Pharmacokinet Pharmacodyn 29(5):473–505, 2002. The
+  canonical frequentist-prior reference, and exactly the sparse-data clinical use
+  case above.
+- NONMEM 7 guides, `$PRIOR` (`NWPRI`, `TNPRI`).

--- a/docs/estimation/priors.qmd
+++ b/docs/estimation/priors.qmd
@@ -156,12 +156,33 @@ Priors are applied by the **FOCE family**: `foce`, `focei`, `laplace`, `gn`,
 `gn_hybrid`. They enter the objective, the gradient, and the covariance step's
 Hessian.
 
-If the **final** estimation stage of a chain does not apply priors, the fit is
+If the last **estimating** stage of a chain does not apply priors, the fit is
 **refused** rather than run unpenalized. An unapplied prior is invisible in the
 output — the fit converges, the estimates look reasonable, and nothing says the
 prior was dropped — so a silent fallback would be worse than no feature. Chaining
-is fine as long as the last stage qualifies: `method = [saem, focei]` works,
-because the FOCEI stage is the one whose estimates are reported.
+is fine as long as that stage qualifies: `method = [saem, focei]` works, because
+the FOCEI stage is the one whose estimates are reported.
+
+"Last estimating" is deliberate: a trailing **evaluation-only** stage (`imp` with
+`imp_eval_only`, `laplace` with `agq_eval_only`) only scores the preceding
+stage's parameters, so it neither applies a prior nor undoes one. `method =
+[focei, imp]` with `imp_eval_only = true` is accepted — FOCEI applied the prior —
+while `[saem, laplace]` with `agq_eval_only = true` is refused, because Laplace
+there is only evaluating SAEM's unpriored estimates.
+
+### Covariance estimators
+
+`covariance_method = r` (the default) and `rsr` carry the prior's curvature.
+`covariance_method = s` is **refused** under a prior: `S` is a sum of per-subject
+score cross-products, and a prior contributes one score for the whole population
+rather than one per subject, so `S⁻¹` cannot represent it and reporting it as a
+MAP standard error would be a plain misstatement. For the same reason, a
+large-parameter fit that would normally be auto-routed from `r` to `s` stays on
+`r` when a prior is declared, and says so.
+
+Under SIR (`sir = true`), the importance weights score the penalized objective,
+so the resampled intervals reflect the prior rather than drifting back toward the
+unpenalized MLE.
 
 ## Not supported in v1
 
@@ -202,6 +223,28 @@ $\Omega$ side is genuinely a different prior: lognormal on the variance rather
 than inverse-Wishart. For a diagonal $\Omega$ the two are close in practice and
 neither is more "correct"; they differ in tail behaviour and in how a very small
 variance is penalized.
+
+### The θ prior is anchored against NWPRI
+
+Not just equivalent on paper. With both engines writing the model on the log
+scale and evaluating at the same fixed point, ferx's penalty reproduces NONMEM's:
+
+| | NONMEM 7.5.1 | ferx |
+|---|---|---|
+| null (no prior) | 177.82632978040530 | 177.826330 |
+| prior centred on θ | 177.826 (== null) | — |
+| prior offset from θ | 177.94393305151641 | 177.943933 |
+| **prior contribution** | **0.11760327111** | **0.117603** |
+
+The centred run — prior mean placed exactly on the parameter — reproducing the
+null is what establishes that NWPRI drops the prior's normalisation constant just
+as ferx does, so these are comparable absolutely and not only as a difference.
+Control streams and the measured `.lst` files live in `nonmem_anchor/`; the
+comparison runs as a test (`the_prior_penalty_matches_nonmem_nwpri`).
+
+The **Ω** prior has no NWPRI counterpart to difference against, since NONMEM's is
+an inverse-Wishart. It is pinned instead by closed-form unit tests, including a
+differential pair that catches the variance-vs-SD scale.
 
 ## References
 

--- a/docs/estimation/priors.qmd
+++ b/docs/estimation/priors.qmd
@@ -172,13 +172,22 @@ there is only evaluating SAEM's unpriored estimates.
 
 ### Covariance estimators
 
-`covariance_method = r` (the default) and `rsr` carry the prior's curvature.
-`covariance_method = s` is **refused** under a prior: `S` is a sum of per-subject
-score cross-products, and a prior contributes one score for the whole population
-rather than one per subject, so `S⁻¹` cannot represent it and reporting it as a
-MAP standard error would be a plain misstatement. For the same reason, a
-large-parameter fit that would normally be auto-routed from `r` to `s` stays on
-`r` when a prior is declared, and says so.
+`covariance_method = r` (the default) is the only estimator accepted under a
+prior; it is the one whose Hessian carries the prior's curvature, so its `R⁻¹` is
+the penalized (MAP) covariance.
+
+Both estimators built on `S` are **refused**. `S` is a sum of per-subject score
+cross-products, and a prior contributes one score for the whole population rather
+than one per subject, so nothing assembled from `S` can represent it:
+
+- `covariance_method = s` is `S⁻¹`, the unpenalized information outright;
+- `covariance_method = rsr` is the `R⁻¹ S R⁻¹` sandwich, which wraps a prior-free
+  `S` in two prior-shrunk `R⁻¹` factors. The result is neither the penalized
+  estimator nor the unpenalized one — it under-states the standard error on every
+  priored coordinate — so it is rejected rather than reported with a caveat.
+
+For the same reason, a large-parameter fit that would normally be auto-routed
+from `r` to `s` stays on `r` when a prior is declared, and says so.
 
 Under SIR (`sir = true`), the importance weights score the penalized objective,
 so the resampled intervals reflect the prior rather than drifting back toward the

--- a/docs/model-file/parameters.qmd
+++ b/docs/model-file/parameters.qmd
@@ -566,6 +566,24 @@ For a **single-endpoint** `[error_model]` ("first" and "second" above) these rol
 
 > **Migration note** (pre-issue-#56 models): `sigma NAME ~ value` was previously interpreted as a standard deviation. The new default is **variance**, so a pre-#56 value `v` becomes either `v² (variance)` or `v (sd)`. The `examples/` directory uses the `(sd)` form to preserve the prior initial values verbatim.
 
+## Priors
+
+Any `theta`, `omega`, `sigma` or `kappa` declaration may carry a trailing
+`prior(...)`, which adds a penalty to the objective and turns the fit into
+penalized maximum likelihood (MAP) — the simple alternative to NONMEM's
+`$PRIOR`:
+
+```
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)  prior(0.15, rse = 25%)
+  omega ETA_CL ~ 0.09           prior(0.09, rse = 40%)
+```
+
+The central value and the RSE are always on the scale the parameter was declared
+on — a variance for a bare `omega X ~ v`, an SD under `(sd)`. See
+[Parameter priors](../estimation/priors.qmd) for the full rules, what the fit
+report shows, and which estimation methods apply them.
+
 ## Complete Examples
 
 Diagonal omega (no correlations):

--- a/examples/warfarin_prior.ferx
+++ b/examples/warfarin_prior.ferx
@@ -1,0 +1,48 @@
+# Warfarin 1-cpt oral, fitted with priors from a "published" model (#254).
+#
+# The model-updating pattern: a literature popPK model supplies the central
+# values and their RSEs, a small local dataset supplies the data, and the fit
+# returns a regularized (MAP) estimate that borrows strength from both.
+#
+# Every prior is (central value, relative uncertainty). The value and the RSE are
+# on the scale the parameter was declared on — a variance for a bare
+# `omega X ~ v`, an SD under `(sd)` — so both come off the same row of the source
+# paper's parameter table with no conversion.
+#
+#   cargo run --release -p ferx-cli -- examples/warfarin_prior.ferx \
+#       --data data/warfarin.csv
+#
+# The report splits the OFV into its data and prior halves and prints, per
+# priored parameter, how far the estimate landed from the prior in prior SDs.
+# A shift beyond about ±2 means the data is arguing with the prior.
+
+[parameters]
+  theta TVCL(0.2, 0.001, 10.0)  prior(0.134, rse = 15%)
+  theta TVV(10.0, 0.1, 500.0)   prior(8.1,   rse = 10%)
+  theta TVKA(1.5, 0.01, 50.0)   prior(1.0,   rse = 40%)
+
+  # Ω priors are what keep a sparse fit off the variance boundary. Declared (and
+  # so priored) on the variance scale.
+  omega ETA_CL ~ 0.09  prior(0.07, rse = 50%)
+  omega ETA_V  ~ 0.04  prior(0.02, rse = 50%)
+  omega ETA_KA ~ 0.30
+
+  sigma PROP_ERR ~ 0.02 (sd)
+
+[individual_parameters]
+  CL = TVCL * exp(ETA_CL)
+  V  = TVV  * exp(ETA_V)
+  KA = TVKA * exp(ETA_KA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  # Priors are applied by the FOCE family (foce, focei, laplace, gn, gn_hybrid).
+  # A final stage that cannot apply them is refused rather than run unpenalized.
+  method     = focei
+  maxiter    = 300
+  covariance = true

--- a/nonmem_anchor/README.md
+++ b/nonmem_anchor/README.md
@@ -861,3 +861,75 @@ where the train says `0.962` and `1.200` — every record after `t = 48` short b
 Mutation-verified: with `restore_chz` writing `0.0` the arm fails at **99.8% relative
 disagreement** on `H`.
 The shape was right; only the origin was wrong.
+
+---
+
+## Parameter priors vs `$PRIOR NWPRI` (#254)
+
+`prior_theta_null.{ctl,ferx}` · `prior_theta_nwpri.{ctl,ferx}` ·
+`prior_theta_nwpri_centered.ctl` · test `the_prior_penalty_matches_nonmem_nwpri`
+(`tests/parameter_priors.rs`)
+
+Anchors the penalty ferx adds for an inline `prior(...)` against NONMEM's
+`$PRIOR NWPRI`, on the warfarin dataset.
+
+### The construction
+
+The two engines do not agree on a priored objective by construction — they
+disagree about parameterisation, about which normalisation constants the
+objective carries, and about the optimizer path. Three choices remove all three:
+
+- **Same coordinate.** Both sides write the model on the log scale
+  (`CL = EXP(THETA(1) + ETA(1))`), and the ferx θ is declared with a *negative*
+  lower bound so ferx packs it as the identity. Both engines then put a normal
+  prior on the same number with the same mean and SD, and nothing rests on ferx's
+  packing conventions.
+- **Same point.** `MAXEVAL=0` / `maxiter = 0`. The quantity under test is the
+  objective, not a minimizer's path to it.
+- **A null control, run first.** Same model, no prior, both engines. If that
+  disagreed, an agreeing prior term would only mean two compensating errors.
+
+A third NONMEM run puts the prior mean *exactly on* `THETA(1)`. It reproduces the
+null objective, which establishes that NWPRI — like ferx — omits the prior's
+normalisation constant. That is what lets the absolute values be compared rather
+than only their difference.
+
+### Measured
+
+| | NONMEM 7.5.1 | ferx |
+|---|---|---|
+| null (no prior) | 177.82632978040530 | 177.826330 |
+| prior centred on θ | 177.826 (== null) | — |
+| prior offset from θ | 177.94393305151641 | 177.943933 |
+| **prior contribution** | **0.11760327111** | **0.117603** |
+
+Worst realised disagreement **5.2e-8** (priored objective) and 2.2e-7 (null) —
+both at the limit of the six decimals ferx's fit YAML prints, not a real gap. The
+closed form is `((-2.0 + 1.89712) / 0.30)² = 0.117603266`, which both engines
+reproduce, so the arm pins ferx against NONMEM *and* against arithmetic. The test
+bound is 1e-6: two orders above the realised error, and far below the 1e-3 that
+would let a dropped constant or a factor-of-two scale error through.
+
+### Two NWPRI traps worth recording
+
+- `NTHETA` / `NETA` must match the **estimation problem's** counts, not the
+  number of parameters you actually want to prior. `NTHETA=1` on a three-θ model
+  fails with `NOT ENOUGH INITIAL THETAS DEFINED FOR COMPUTATIONS: CHECK PRIORS`.
+  The two θ not under test are given prior means equal to their own values (zero
+  quadratic contribution) and a flat variance, so they cancel between the paired
+  runs.
+- `$THETAPV` must use the `BLOCK(n) FIX` form. Per-element `FIX` is rejected with
+  `INPUTS SPECIFIED TO ROUTINE NWPRI ARE INAPPROPRIATE`, a message that names
+  neither the offending record nor the reason.
+
+### What this arm does *not* cover
+
+The Ω prior. ferx puts a lognormal prior on the **variance** (a normal on
+`½·ln(variance)`, its packed coordinate); NWPRI's Ω prior is an inverse-Wishart.
+They are genuinely different priors, so there is no NONMEM run to difference
+against — the Ω scale is pinned instead by the Tier-1 closed forms in
+`src/estimation/priors_tests.rs`, including the variance-vs-`(sd)` differential
+pair whose penalties must differ by exactly 4×. Anchoring Ω would need the
+`$OMEGA 1 FIX` + `EXP(THETA(k))·ETA(1)` reparameterisation, which rests on FOCE's
+marginal being invariant under a linear rescaling of η; that is a separate null
+control and is not yet run.

--- a/nonmem_anchor/prior_theta_null.ctl
+++ b/nonmem_anchor/prior_theta_null.ctl
@@ -1,0 +1,43 @@
+; #254 parameter-prior anchor — STEP 1, the null control.
+;
+; One-compartment oral warfarin, with the structural parameters written on the
+; LOG scale (CL = EXP(THETA(1))) so that a NONMEM $PRIOR NWPRI normal prior on
+; THETA(1) is a normal prior on exactly the coordinate ferx penalizes. This run
+; carries NO prior: it fixes the common baseline the priored run is compared
+; against, so the anchor is a DELTA and every normalization constant — NONMEM's
+; and ferx's alike — cancels.
+;
+; Estimation is evaluation-only (MAXEVAL=0) at a fixed point, deliberately: the
+; quantity under test is the OBJECTIVE, not an optimizer's path to a minimum, and
+; pinning the point removes any chance that the two engines' minimizers land
+; somewhere different and confound the comparison.
+$PROBLEM warfarin 1-cpt oral, log-parameterised, no prior
+
+$INPUT ID TIME DV EVID AMT DROP RATE MDV
+$DATA ../data/warfarin.csv IGNORE=@
+
+$SUBROUTINE ADVAN2 TRANS2
+
+$PK
+  CL = EXP(THETA(1) + ETA(1))
+  V  = EXP(THETA(2) + ETA(2))
+  KA = EXP(THETA(3))
+  S2 = V
+
+$ERROR
+  IPRED = F
+  Y = IPRED * (1 + EPS(1))
+
+; LOG-scale typical values. exp(-2.0217) = 0.13246, exp(2.0450) = 7.7297,
+; exp(-0.3212) = 0.72526 — the unpriored ferx optimum, so both engines are
+; evaluated at the same point.
+$THETA -2.0000      ; log CL
+$THETA  2.0450      ; log V
+$THETA -0.3212      ; log KA
+
+$OMEGA 0.0455       ; IIV CL
+$OMEGA 0.0145       ; IIV V
+
+$SIGMA 0.01055      ; proportional
+
+$ESTIMATION METHOD=1 INTERACTION MAXEVAL=0 PRINT=1 NOABORT

--- a/nonmem_anchor/prior_theta_null.ferx
+++ b/nonmem_anchor/prior_theta_null.ferx
@@ -1,0 +1,37 @@
+# #254 parameter-prior anchor — ferx side, STEP 1 (the null control).
+#
+# The exact twin of `prior_theta_null.ctl`: the same one-compartment oral model,
+# the same log-scale parameterisation, the same numbers, evaluated at the same
+# fixed point (`maxiter = 0`).
+#
+# `LCL` is declared with a NEGATIVE lower bound on purpose. That makes ferx pack
+# it as the identity, so the prior added in the priored twin is a plain normal on
+# LCL — which is exactly what NONMEM's `$PRIOR NWPRI` puts on `THETA(1)` there.
+# Same coordinate, same family, same mean, same SD: nothing about the comparison
+# depends on ferx's packing conventions.
+
+[parameters]
+  theta LCL(-2.0000, -100.0, 100.0)
+  theta LV(2.0450, -100.0, 100.0)
+  theta LKA(-0.3212, -100.0, 100.0)
+
+  omega ETA_CL ~ 0.0455
+  omega ETA_V  ~ 0.0145
+
+  sigma PROP_ERR ~ 0.01055
+
+[individual_parameters]
+  CL = exp(LCL + ETA_CL)
+  V  = exp(LV + ETA_V)
+  KA = exp(LKA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  maxiter    = 0
+  covariance = false

--- a/nonmem_anchor/prior_theta_nwpri.ctl
+++ b/nonmem_anchor/prior_theta_nwpri.ctl
@@ -1,0 +1,72 @@
+; #254 parameter-prior anchor — the PRIORED run (step 2 of 2).
+;
+; Paired with `prior_theta_nwpri_centered.ctl`, which is identical except for ONE
+; number: `$THETAP`'s first entry. That is deliberate — the anchor is a difference
+; of two NONMEM runs varying a single input, so every additive constant NONMEM
+; carries (its own normalisation of the prior density, the data term, whatever
+; either engine includes or drops) cancels exactly, and what remains is the
+; prior's quadratic contribution alone.
+;
+;   centered run : THETAP(1) = -2.0000    == THETA(1), so its quadratic term is 0
+;   this run     : THETAP(1) = -1.8971200 == log(0.15), so it is not
+;
+;   expected difference = ((-2.0000 + 1.8971200) / 0.30)^2 = 0.1176027...
+;
+; Why NTHETA=3 and not 1: NWPRI's `NTHETA` must cover every THETA in the
+; estimation problem, so thetas 2 and 3 are given prior means exactly equal to
+; their own values (zero quadratic contribution) and a variance of 1e6 (flat).
+; They contribute the same constant to both runs and drop out.
+;
+; `CL = EXP(THETA(1) + ETA(1))` makes THETA(1) log CL — the same coordinate ferx
+; penalizes for an identity-packed theta — so this is a normal prior on the same
+; quantity, with the same mean and the same SD, as the ferx twin.
+;
+; MAXEVAL=0: the quantity under test is the OBJECTIVE, not an optimizer's path to
+; a minimum. Pinning the point removes any chance the two engines' minimizers
+; land somewhere different and confound the comparison.
+$PROBLEM warfarin 1-cpt oral, log-parameterised, NWPRI on log CL (offset)
+
+$INPUT ID TIME DV EVID AMT DROP RATE MDV
+$DATA ../data/warfarin.csv IGNORE=@
+
+$SUBROUTINE ADVAN2 TRANS2
+
+$PRIOR NWPRI NTHETA=3 NETA=2 NTHP=3 NETP=0
+
+$PK
+  CL = EXP(THETA(1) + ETA(1))
+  V  = EXP(THETA(2) + ETA(2))
+  KA = EXP(THETA(3))
+  S2 = V
+
+$ERROR
+  IPRED = F
+  Y = IPRED * (1 + EPS(1))
+
+$THETA -2.0000      ; log CL
+$THETA  2.0450      ; log V
+$THETA -0.3212      ; log KA
+
+$OMEGA 0.0455       ; IIV CL
+$OMEGA 0.0145       ; IIV V
+
+$SIGMA 0.01055      ; proportional
+
+; --- prior block -----------------------------------------------------------
+; THETAP(1) = log(0.15); the other two sit on their own values (inert).
+$THETAP (-1.8971200 FIX) (2.0450 FIX) (-0.3212 FIX)
+
+; Lower triangle of the prior VARIANCE matrix, as a BLOCK — NWPRI requires the
+; `BLOCK(n) FIX` form here and rejects per-element `FIX` with "INPUTS SPECIFIED
+; TO ROUTINE NWPRI ARE INAPPROPRIATE".
+;
+;   0.30^2 = 0.09 on log CL (the prior under test);
+;   100 on the other two — flat for a log-scale parameter of order 1, and they
+;   already sit on their own prior means, so their quadratic term is 0 in BOTH
+;   runs and cancels in the difference.
+$THETAPV BLOCK(3) FIX
+ 0.09
+ 0.0   100.0
+ 0.0   0.0    100.0
+
+$ESTIMATION METHOD=1 INTERACTION MAXEVAL=0 PRINT=1 NOABORT

--- a/nonmem_anchor/prior_theta_nwpri.ferx
+++ b/nonmem_anchor/prior_theta_nwpri.ferx
@@ -1,0 +1,37 @@
+# #254 parameter-prior anchor — ferx side, STEP 2 (the priored run).
+#
+# The exact twin of `prior_theta_null.ctl`: the same one-compartment oral model,
+# the same log-scale parameterisation, the same numbers, evaluated at the same
+# fixed point (`maxiter = 0`).
+#
+# `LCL` is declared with a NEGATIVE lower bound on purpose. That makes ferx pack
+# it as the identity, so the prior added in the priored twin is a plain normal on
+# LCL — which is exactly what NONMEM's `$PRIOR NWPRI` puts on `THETA(1)` there.
+# Same coordinate, same family, same mean, same SD: nothing about the comparison
+# depends on ferx's packing conventions.
+
+[parameters]
+  theta LCL(-2.0000, -100.0, 100.0)  prior(-1.8971200, sd = 0.30)
+  theta LV(2.0450, -100.0, 100.0)
+  theta LKA(-0.3212, -100.0, 100.0)
+
+  omega ETA_CL ~ 0.0455
+  omega ETA_V  ~ 0.0145
+
+  sigma PROP_ERR ~ 0.01055
+
+[individual_parameters]
+  CL = exp(LCL + ETA_CL)
+  V  = exp(LV + ETA_V)
+  KA = exp(LKA)
+
+[structural_model]
+  pk one_cpt_oral(cl=CL, v=V, ka=KA)
+
+[error_model]
+  DV ~ proportional(PROP_ERR)
+
+[fit_options]
+  method     = focei
+  maxiter    = 0
+  covariance = false

--- a/nonmem_anchor/prior_theta_nwpri_centered.ctl
+++ b/nonmem_anchor/prior_theta_nwpri_centered.ctl
@@ -1,0 +1,72 @@
+; #254 parameter-prior anchor — the CENTERED reference run (step 1 of 2).
+;
+; Paired with `prior_theta_nwpri_centered.ctl`, which is identical except for ONE
+; number: `$THETAP`'s first entry. That is deliberate — the anchor is a difference
+; of two NONMEM runs varying a single input, so every additive constant NONMEM
+; carries (its own normalisation of the prior density, the data term, whatever
+; either engine includes or drops) cancels exactly, and what remains is the
+; prior's quadratic contribution alone.
+;
+;   centered run : THETAP(1) = -2.0000    == THETA(1), so its quadratic term is 0
+;   this run     : THETAP(1) = -1.8971200 == log(0.15), so it is not
+;
+;   expected difference = ((-2.0000 + 1.8971200) / 0.30)^2 = 0.1176027...
+;
+; Why NTHETA=3 and not 1: NWPRI's `NTHETA` must cover every THETA in the
+; estimation problem, so thetas 2 and 3 are given prior means exactly equal to
+; their own values (zero quadratic contribution) and a variance of 1e6 (flat).
+; They contribute the same constant to both runs and drop out.
+;
+; `CL = EXP(THETA(1) + ETA(1))` makes THETA(1) log CL — the same coordinate ferx
+; penalizes for an identity-packed theta — so this is a normal prior on the same
+; quantity, with the same mean and the same SD, as the ferx twin.
+;
+; MAXEVAL=0: the quantity under test is the OBJECTIVE, not an optimizer's path to
+; a minimum. Pinning the point removes any chance the two engines' minimizers
+; land somewhere different and confound the comparison.
+$PROBLEM warfarin 1-cpt oral, log-parameterised, NWPRI on log CL (centered)
+
+$INPUT ID TIME DV EVID AMT DROP RATE MDV
+$DATA ../data/warfarin.csv IGNORE=@
+
+$SUBROUTINE ADVAN2 TRANS2
+
+$PRIOR NWPRI NTHETA=3 NETA=2 NTHP=3 NETP=0
+
+$PK
+  CL = EXP(THETA(1) + ETA(1))
+  V  = EXP(THETA(2) + ETA(2))
+  KA = EXP(THETA(3))
+  S2 = V
+
+$ERROR
+  IPRED = F
+  Y = IPRED * (1 + EPS(1))
+
+$THETA -2.0000      ; log CL
+$THETA  2.0450      ; log V
+$THETA -0.3212      ; log KA
+
+$OMEGA 0.0455       ; IIV CL
+$OMEGA 0.0145       ; IIV V
+
+$SIGMA 0.01055      ; proportional
+
+; --- prior block -----------------------------------------------------------
+; THETAP(1) = log(0.15); the other two sit on their own values (inert).
+$THETAP (-2.0000 FIX) (2.0450 FIX) (-0.3212 FIX)
+
+; Lower triangle of the prior VARIANCE matrix, as a BLOCK — NWPRI requires the
+; `BLOCK(n) FIX` form here and rejects per-element `FIX` with "INPUTS SPECIFIED
+; TO ROUTINE NWPRI ARE INAPPROPRIATE".
+;
+;   0.30^2 = 0.09 on log CL (the prior under test);
+;   100 on the other two — flat for a log-scale parameter of order 1, and they
+;   already sit on their own prior means, so their quadratic term is 0 in BOTH
+;   runs and cancels in the difference.
+$THETAPV BLOCK(3) FIX
+ 0.09
+ 0.0   100.0
+ 0.0   0.0    100.0
+
+$ESTIMATION METHOD=1 INTERACTION MAXEVAL=0 PRINT=1 NOABORT

--- a/nonmem_anchor/results/prior_theta_null.lst
+++ b/nonmem_anchor/results/prior_theta_null.lst
@@ -1,0 +1,285 @@
+Fri Sep 11 03:10:12 AM UTC 2026
+; #254 parameter-prior anchor — STEP 1, the null control.
+;
+; One-compartment oral warfarin, with the structural parameters written on the
+; LOG scale (CL = EXP(THETA(1))) so that a NONMEM $PRIOR NWPRI normal prior on
+; THETA(1) is a normal prior on exactly the coordinate ferx penalizes. This run
+; carries NO prior: it fixes the common baseline the priored run is compared
+; against, so the anchor is a DELTA and every normalization constant — NONMEM's
+; and ferx's alike — cancels.
+;
+; Estimation is evaluation-only (MAXEVAL=0) at a fixed point, deliberately: the
+; quantity under test is the OBJECTIVE, not an optimizer's path to a minimum, and
+; pinning the point removes any chance that the two engines' minimizers land
+; somewhere different and confound the comparison.
+$PROBLEM warfarin 1-cpt oral, log-parameterised, no prior
+
+$INPUT ID TIME DV EVID AMT DROP RATE MDV
+$DATA ../data/warfarin.csv IGNORE=@
+
+$SUBROUTINE ADVAN2 TRANS2
+
+$PK
+  CL = EXP(THETA(1) + ETA(1))
+  V  = EXP(THETA(2) + ETA(2))
+  KA = EXP(THETA(3))
+  S2 = V
+
+$ERROR
+  IPRED = F
+  Y = IPRED * (1 + EPS(1))
+
+; LOG-scale typical values. exp(-2.0217) = 0.13246, exp(2.0450) = 7.7297,
+; exp(-0.3212) = 0.72526 — the unpriored ferx optimum, so both engines are
+; evaluated at the same point.
+$THETA -2.0000      ; log CL
+$THETA  2.0450      ; log V
+$THETA -0.3212      ; log KA
+
+$OMEGA 0.0455       ; IIV CL
+$OMEGA 0.0145       ; IIV V
+
+$SIGMA 0.01055      ; proportional
+
+$ESTIMATION METHOD=1 INTERACTION MAXEVAL=0 PRINT=1 NOABORT
+
+NM-TRAN MESSAGES
+  
+ WARNINGS AND ERRORS (IF ANY) FOR PROBLEM    1
+             
+ (WARNING  2) NM-TRAN INFERS THAT THE DATA ARE POPULATION.
+  
+Note: Analytical 2nd Derivatives are constructed in FSUBS but are never used.
+      You may insert $ABBR DERIV2=NO after the first $PROB to save FSUBS construction and compilation time
+  
+
+License Registered to:  InsightRX
+Expiration Date:    14 AUG 2027
+Current Date:       11 SEP 2026
+Days until program expires : 338
+1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.5.1
+ ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN
+ CURRENT DEVELOPERS ARE ROBERT BAUER, ICON DEVELOPMENT SOLUTIONS,
+ AND ALISON BOECKMANN. IMPLEMENTATION, EFFICIENCY, AND STANDARDIZATION
+ PERFORMED BY NOUS INFOSYSTEMS.
+
+ PROBLEM NO.:         1
+ warfarin 1-cpt oral, log-parameterised, no prior
+0DATA CHECKOUT RUN:              NO
+ DATA SET LOCATED ON UNIT NO.:    2
+ THIS UNIT TO BE REWOUND:        NO
+ NO. OF DATA RECS IN DATA SET:      120
+ NO. OF DATA ITEMS IN DATA SET:   7
+ ID DATA ITEM IS DATA ITEM NO.:   1
+ DEP VARIABLE IS DATA ITEM NO.:   3
+ MDV DATA ITEM IS DATA ITEM NO.:  7
+0INDICES PASSED TO SUBROUTINE PRED:
+   4   2   5   6   0   0   0   0   0   0   0
+0LABELS FOR DATA ITEMS:
+ ID TIME DV EVID AMT RATE MDV
+0FORMAT FOR DATA:
+ (7E8.0)
+
+ TOT. NO. OF OBS RECS:      110
+ TOT. NO. OF INDIVIDUALS:       10
+0LENGTH OF THETA:   3
+0DEFAULT THETA BOUNDARY TEST OMITTED:    NO
+0OMEGA HAS SIMPLE DIAGONAL FORM WITH DIMENSION:   2
+0DEFAULT OMEGA BOUNDARY TEST OMITTED:    NO
+0SIGMA HAS SIMPLE DIAGONAL FORM WITH DIMENSION:   1
+0DEFAULT SIGMA BOUNDARY TEST OMITTED:    NO
+0INITIAL ESTIMATE OF THETA:
+  -0.2000E+01  0.2045E+01 -0.3212E+00
+0INITIAL ESTIMATE OF OMEGA:
+ 0.4550E-01
+ 0.0000E+00   0.1450E-01
+0INITIAL ESTIMATE OF SIGMA:
+ 0.1055E-01
+1DOUBLE PRECISION PREDPP VERSION 7.5.1
+
+ ONE COMPARTMENT MODEL WITH FIRST-ORDER ABSORPTION (ADVAN2)
+0MAXIMUM NO. OF BASIC PK PARAMETERS:   3
+0BASIC PK PARAMETERS (AFTER TRANSLATION):
+   ELIMINATION RATE (K) IS BASIC PK PARAMETER NO.:  1
+   ABSORPTION RATE (KA) IS BASIC PK PARAMETER NO.:  3
+
+ TRANSLATOR WILL CONVERT PARAMETERS
+ CLEARANCE (CL) AND VOLUME (V) TO K (TRANS2)
+0COMPARTMENT ATTRIBUTES
+ COMPT. NO.   FUNCTION   INITIAL    ON/OFF      DOSE      DEFAULT    DEFAULT
+                         STATUS     ALLOWED    ALLOWED    FOR DOSE   FOR OBS.
+    1         DEPOT        OFF        YES        YES        YES        NO
+    2         CENTRAL      ON         NO         YES        NO         YES
+    3         OUTPUT       OFF        YES        NO         NO         NO
+1
+ ADDITIONAL PK PARAMETERS - ASSIGNMENT OF ROWS IN GG
+ COMPT. NO.                             INDICES
+              SCALE      BIOAVAIL.   ZERO-ORDER  ZERO-ORDER  ABSORB
+                         FRACTION    RATE        DURATION    LAG
+    1            *           *           *           *           *
+    2            4           *           *           *           *
+    3            *           -           -           -           -
+             - PARAMETER IS NOT ALLOWED FOR THIS MODEL
+             * PARAMETER IS NOT SUPPLIED BY PK SUBROUTINE;
+               WILL DEFAULT TO ONE IF APPLICABLE
+0DATA ITEM INDICES USED BY PRED ARE:
+   EVENT ID DATA ITEM IS DATA ITEM NO.:      4
+   TIME DATA ITEM IS DATA ITEM NO.:          2
+   DOSE AMOUNT DATA ITEM IS DATA ITEM NO.:   5
+   DOSE RATE DATA ITEM IS DATA ITEM NO.:     6
+
+0PK SUBROUTINE CALLED WITH EVERY EVENT RECORD.
+ PK SUBROUTINE NOT CALLED AT NONEVENT (ADDITIONAL OR LAGGED) DOSE TIMES.
+0ERROR SUBROUTINE CALLED WITH EVERY EVENT RECORD.
+1
+
+
+ #TBLN:      1
+ #METH: First Order Conditional Estimation with Interaction (Evaluation)
+
+ ESTIMATION STEP OMITTED:                 YES
+ ANALYSIS TYPE:                           POPULATION
+ CONDITIONAL ESTIMATES USED:              YES
+ CENTERED ETA:                            NO
+ EPS-ETA INTERACTION:                     YES
+ LAPLACIAN OBJ. FUNC.:                    NO
+ NUMERICAL DERIVATIVE
+       FILE REQUEST (NUMDER):               NONE
+ MAP (ETAHAT) ESTIMATION METHOD (OPTMAP):   0
+ ETA HESSIAN EVALUATION METHOD (ETADER):    0
+ INITIAL ETA FOR MAP ESTIMATION (MCETA):    0
+ SIGDIGITS FOR MAP ESTIMATION (SIGLO):      100
+ GRADIENT SIGDIGITS OF
+       FIXED EFFECTS PARAMETERS (SIGL):     100
+ NOPRIOR SETTING (NOPRIOR):                 0
+ NOCOV SETTING (NOCOV):                     OFF
+ DERCONT SETTING (DERCONT):                 OFF
+ FINAL ETA RE-EVALUATION (FNLETA):          1
+ EXCLUDE NON-INFLUENTIAL (NON-INFL.) ETAS
+       IN SHRINKAGE (ETASTYPE):             NO
+ NON-INFL. ETA CORRECTION (NONINFETA):      0
+ RAW OUTPUT FILE (FILE): prior_theta_null.ext
+ EXCLUDE TITLE (NOTITLE):                   NO
+ EXCLUDE COLUMN LABELS (NOLABEL):           NO
+ FORMAT FOR ADDITIONAL FILES (FORMAT):      S1PE12.5
+ PARAMETER ORDER FOR OUTPUTS (ORDER):       TSOL
+ KNUTHSUMOFF:                               0
+ INCLUDE LNTWOPI:                           NO
+ INCLUDE CONSTANT TERM TO PRIOR (PRIORC):   NO
+ INCLUDE CONSTANT TERM TO OMEGA (ETA) (OLNTWOPI):NO
+ ADDITIONAL CONVERGENCE TEST (CTYPE=4)?:    NO
+ EM OR BAYESIAN METHOD USED:                 NONE
+
+
+ THE FOLLOWING LABELS ARE EQUIVALENT
+ PRED=PREDI
+ RES=RESI
+ WRES=WRESI
+ IWRS=IWRESI
+ IPRD=IPREDI
+ IRS=IRESI
+
+ Elapsed evaluation time in seconds:     0.00
+ Elapsed postprocess time in seconds:     0.00
+1
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ ************************************************************************************************************************
+ ********************                                                                                ********************
+ ********************         FIRST ORDER CONDITIONAL ESTIMATION WITH INTERACTION (EVALUATION)       ********************
+ #OBJT:**************                       MINIMUM VALUE OF OBJECTIVE FUNCTION                      ********************
+ ********************                                                                                ********************
+ ************************************************************************************************************************
+ 
+
+
+
+
+
+ #OBJV:********************************************      177.826       **************************************************
+1
+ ************************************************************************************************************************
+ ********************                                                                                ********************
+ ********************         FIRST ORDER CONDITIONAL ESTIMATION WITH INTERACTION (EVALUATION)       ********************
+ ********************                             FINAL PARAMETER ESTIMATE                           ********************
+ ********************                                                                                ********************
+ ************************************************************************************************************************
+ 
+
+
+ THETA - VECTOR OF FIXED EFFECTS PARAMETERS   *********
+
+
+         TH 1      TH 2      TH 3     
+ 
+        -2.00E+00  2.04E+00 -3.21E-01
+ 
+
+
+ OMEGA - COV MATRIX FOR RANDOM EFFECTS - ETAS  ********
+
+
+         ETA1      ETA2     
+ 
+ ETA1
++        4.55E-02
+ 
+ ETA2
++        0.00E+00  1.45E-02
+ 
+
+
+ SIGMA - COV MATRIX FOR RANDOM EFFECTS - EPSILONS  ****
+
+
+         EPS1     
+ 
+ EPS1
++        1.06E-02
+ 
+1
+
+
+ OMEGA - CORR MATRIX FOR RANDOM EFFECTS - ETAS  *******
+
+
+         ETA1      ETA2     
+ 
+ ETA1
++        2.13E-01
+ 
+ ETA2
++        0.00E+00  1.20E-01
+ 
+
+
+ SIGMA - CORR MATRIX FOR RANDOM EFFECTS - EPSILONS  ***
+
+
+         EPS1     
+ 
+ EPS1
++        1.03E-01
+ 
+ Elapsed finaloutput time in seconds:     0.00
+ #CPUT: Total CPU Time in Seconds,        0.015
+Stop Time:
+Fri Sep 11 03:10:12 AM UTC 2026

--- a/nonmem_anchor/results/prior_theta_nwpri.lst
+++ b/nonmem_anchor/results/prior_theta_nwpri.lst
@@ -1,0 +1,334 @@
+Fri Sep 11 03:13:37 AM UTC 2026
+; #254 parameter-prior anchor — the PRIORED run (step 2 of 2).
+;
+; Paired with `prior_theta_nwpri_centered.ctl`, which is identical except for ONE
+; number: `$THETAP`'s first entry. That is deliberate — the anchor is a difference
+; of two NONMEM runs varying a single input, so every additive constant NONMEM
+; carries (its own normalisation of the prior density, the data term, whatever
+; either engine includes or drops) cancels exactly, and what remains is the
+; prior's quadratic contribution alone.
+;
+;   centered run : THETAP(1) = -2.0000    == THETA(1), so its quadratic term is 0
+;   this run     : THETAP(1) = -1.8971200 == log(0.15), so it is not
+;
+;   expected difference = ((-2.0000 + 1.8971200) / 0.30)^2 = 0.1176027...
+;
+; Why NTHETA=3 and not 1: NWPRI's `NTHETA` must cover every THETA in the
+; estimation problem, so thetas 2 and 3 are given prior means exactly equal to
+; their own values (zero quadratic contribution) and a variance of 1e6 (flat).
+; They contribute the same constant to both runs and drop out.
+;
+; `CL = EXP(THETA(1) + ETA(1))` makes THETA(1) log CL — the same coordinate ferx
+; penalizes for an identity-packed theta — so this is a normal prior on the same
+; quantity, with the same mean and the same SD, as the ferx twin.
+;
+; MAXEVAL=0: the quantity under test is the OBJECTIVE, not an optimizer's path to
+; a minimum. Pinning the point removes any chance the two engines' minimizers
+; land somewhere different and confound the comparison.
+$PROBLEM warfarin 1-cpt oral, log-parameterised, NWPRI on log CL (offset)
+
+$INPUT ID TIME DV EVID AMT DROP RATE MDV
+$DATA ../data/warfarin.csv IGNORE=@
+
+$SUBROUTINE ADVAN2 TRANS2
+
+$PRIOR NWPRI NTHETA=3 NETA=2 NTHP=3 NETP=0
+
+$PK
+  CL = EXP(THETA(1) + ETA(1))
+  V  = EXP(THETA(2) + ETA(2))
+  KA = EXP(THETA(3))
+  S2 = V
+
+$ERROR
+  IPRED = F
+  Y = IPRED * (1 + EPS(1))
+
+$THETA -2.0000      ; log CL
+$THETA  2.0450      ; log V
+$THETA -0.3212      ; log KA
+
+$OMEGA 0.0455       ; IIV CL
+$OMEGA 0.0145       ; IIV V
+
+$SIGMA 0.01055      ; proportional
+
+; --- prior block -----------------------------------------------------------
+; THETAP(1) = log(0.15); the other two sit on their own values (inert).
+$THETAP (-1.8971200 FIX) (2.0450 FIX) (-0.3212 FIX)
+
+; Lower triangle of the prior VARIANCE matrix, as a BLOCK — NWPRI requires the
+; `BLOCK(n) FIX` form here and rejects per-element `FIX` with "INPUTS SPECIFIED
+; TO ROUTINE NWPRI ARE INAPPROPRIATE".
+;
+;   0.30^2 = 0.09 on log CL (the prior under test);
+;   100 on the other two — flat for a log-scale parameter of order 1, and they
+;   already sit on their own prior means, so their quadratic term is 0 in BOTH
+;   runs and cancels in the difference.
+$THETAPV BLOCK(3) FIX
+ 0.09
+ 0.0   100.0
+ 0.0   0.0    100.0
+
+$ESTIMATION METHOD=1 INTERACTION MAXEVAL=0 PRINT=1 NOABORT
+
+NM-TRAN MESSAGES
+  
+ WARNINGS AND ERRORS (IF ANY) FOR PROBLEM    1
+             
+ (WARNING  2) NM-TRAN INFERS THAT THE DATA ARE POPULATION.
+  
+Note: Analytical 2nd Derivatives are constructed in FSUBS but are never used.
+      You may insert $ABBR DERIV2=NO after the first $PROB to save FSUBS construction and compilation time
+  
+
+License Registered to:  InsightRX
+Expiration Date:    14 AUG 2027
+Current Date:       11 SEP 2026
+Days until program expires : 338
+1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.5.1
+ ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN
+ CURRENT DEVELOPERS ARE ROBERT BAUER, ICON DEVELOPMENT SOLUTIONS,
+ AND ALISON BOECKMANN. IMPLEMENTATION, EFFICIENCY, AND STANDARDIZATION
+ PERFORMED BY NOUS INFOSYSTEMS.
+
+ PROBLEM NO.:         1
+ warfarin 1-cpt oral, log-parameterised, NWPRI on log CL (offset)
+0DATA CHECKOUT RUN:              NO
+ DATA SET LOCATED ON UNIT NO.:    2
+ THIS UNIT TO BE REWOUND:        NO
+ NO. OF DATA RECS IN DATA SET:      120
+ NO. OF DATA ITEMS IN DATA SET:   7
+ ID DATA ITEM IS DATA ITEM NO.:   1
+ DEP VARIABLE IS DATA ITEM NO.:   3
+ MDV DATA ITEM IS DATA ITEM NO.:  7
+0INDICES PASSED TO SUBROUTINE PRED:
+   4   2   5   6   0   0   0   0   0   0   0
+0LABELS FOR DATA ITEMS:
+ ID TIME DV EVID AMT RATE MDV
+0FORMAT FOR DATA:
+ (7E8.0)
+
+ TOT. NO. OF OBS RECS:      110
+ TOT. NO. OF INDIVIDUALS:       10
+0LENGTH OF THETA:   6
+0DEFAULT THETA BOUNDARY TEST OMITTED:    NO
+0OMEGA HAS BLOCK FORM:
+  1
+  0  2
+  0  0  3
+  0  0  3  3
+  0  0  3  3  3
+0DEFAULT OMEGA BOUNDARY TEST OMITTED:    NO
+0SIGMA HAS SIMPLE DIAGONAL FORM WITH DIMENSION:   1
+0DEFAULT SIGMA BOUNDARY TEST OMITTED:    NO
+0INITIAL ESTIMATE OF THETA:
+ LOWER BOUND    INITIAL EST    UPPER BOUND
+ -0.1000E+07    -0.2000E+01     0.1000E+07
+ -0.1000E+07     0.2045E+01     0.1000E+07
+ -0.1000E+07    -0.3212E+00     0.1000E+07
+ -0.1897E+01    -0.1897E+01    -0.1897E+01
+  0.2045E+01     0.2045E+01     0.2045E+01
+ -0.3212E+00    -0.3212E+00    -0.3212E+00
+0INITIAL ESTIMATE OF OMEGA:
+ BLOCK SET NO.   BLOCK                                                                    FIXED
+        1                                                                                   NO
+                  0.4550E-01
+        2                                                                                   NO
+                  0.1450E-01
+        3                                                                                  YES
+                  0.9000E-01
+                  0.0000E+00   0.1000E+03
+                  0.0000E+00   0.0000E+00   0.1000E+03
+0INITIAL ESTIMATE OF SIGMA:
+ 0.1055E-01
+0
+ PRIOR SUBROUTINE USER-SUPPLIED
+1DOUBLE PRECISION PREDPP VERSION 7.5.1
+
+ ONE COMPARTMENT MODEL WITH FIRST-ORDER ABSORPTION (ADVAN2)
+0MAXIMUM NO. OF BASIC PK PARAMETERS:   3
+0BASIC PK PARAMETERS (AFTER TRANSLATION):
+   ELIMINATION RATE (K) IS BASIC PK PARAMETER NO.:  1
+   ABSORPTION RATE (KA) IS BASIC PK PARAMETER NO.:  3
+
+ TRANSLATOR WILL CONVERT PARAMETERS
+ CLEARANCE (CL) AND VOLUME (V) TO K (TRANS2)
+0COMPARTMENT ATTRIBUTES
+ COMPT. NO.   FUNCTION   INITIAL    ON/OFF      DOSE      DEFAULT    DEFAULT
+                         STATUS     ALLOWED    ALLOWED    FOR DOSE   FOR OBS.
+    1         DEPOT        OFF        YES        YES        YES        NO
+    2         CENTRAL      ON         NO         YES        NO         YES
+    3         OUTPUT       OFF        YES        NO         NO         NO
+1
+ ADDITIONAL PK PARAMETERS - ASSIGNMENT OF ROWS IN GG
+ COMPT. NO.                             INDICES
+              SCALE      BIOAVAIL.   ZERO-ORDER  ZERO-ORDER  ABSORB
+                         FRACTION    RATE        DURATION    LAG
+    1            *           *           *           *           *
+    2            4           *           *           *           *
+    3            *           -           -           -           -
+             - PARAMETER IS NOT ALLOWED FOR THIS MODEL
+             * PARAMETER IS NOT SUPPLIED BY PK SUBROUTINE;
+               WILL DEFAULT TO ONE IF APPLICABLE
+0DATA ITEM INDICES USED BY PRED ARE:
+   EVENT ID DATA ITEM IS DATA ITEM NO.:      4
+   TIME DATA ITEM IS DATA ITEM NO.:          2
+   DOSE AMOUNT DATA ITEM IS DATA ITEM NO.:   5
+   DOSE RATE DATA ITEM IS DATA ITEM NO.:     6
+
+0PK SUBROUTINE CALLED WITH EVERY EVENT RECORD.
+ PK SUBROUTINE NOT CALLED AT NONEVENT (ADDITIONAL OR LAGGED) DOSE TIMES.
+0ERROR SUBROUTINE CALLED WITH EVERY EVENT RECORD.
+1
+
+
+ #TBLN:      1
+ #METH: First Order Conditional Estimation with Interaction (Evaluation)
+
+ ESTIMATION STEP OMITTED:                 YES
+ ANALYSIS TYPE:                           POPULATION
+ CONDITIONAL ESTIMATES USED:              YES
+ CENTERED ETA:                            NO
+ EPS-ETA INTERACTION:                     YES
+ LAPLACIAN OBJ. FUNC.:                    NO
+ NUMERICAL DERIVATIVE
+       FILE REQUEST (NUMDER):               NONE
+ MAP (ETAHAT) ESTIMATION METHOD (OPTMAP):   0
+ ETA HESSIAN EVALUATION METHOD (ETADER):    0
+ INITIAL ETA FOR MAP ESTIMATION (MCETA):    0
+ SIGDIGITS FOR MAP ESTIMATION (SIGLO):      100
+ GRADIENT SIGDIGITS OF
+       FIXED EFFECTS PARAMETERS (SIGL):     100
+ NOPRIOR SETTING (NOPRIOR):                 0
+ NOCOV SETTING (NOCOV):                     OFF
+ DERCONT SETTING (DERCONT):                 OFF
+ FINAL ETA RE-EVALUATION (FNLETA):          1
+ EXCLUDE NON-INFLUENTIAL (NON-INFL.) ETAS
+       IN SHRINKAGE (ETASTYPE):             NO
+ NON-INFL. ETA CORRECTION (NONINFETA):      0
+ RAW OUTPUT FILE (FILE): prior_theta_nwpri.ext
+ EXCLUDE TITLE (NOTITLE):                   NO
+ EXCLUDE COLUMN LABELS (NOLABEL):           NO
+ FORMAT FOR ADDITIONAL FILES (FORMAT):      S1PE12.5
+ PARAMETER ORDER FOR OUTPUTS (ORDER):       TSOL
+ KNUTHSUMOFF:                               0
+ INCLUDE LNTWOPI:                           NO
+ INCLUDE CONSTANT TERM TO PRIOR (PRIORC):   NO
+ INCLUDE CONSTANT TERM TO OMEGA (ETA) (OLNTWOPI):NO
+ ADDITIONAL CONVERGENCE TEST (CTYPE=4)?:    NO
+ EM OR BAYESIAN METHOD USED:                 NONE
+
+
+ THE FOLLOWING LABELS ARE EQUIVALENT
+ PRED=PREDI
+ RES=RESI
+ WRES=WRESI
+ IWRS=IWRESI
+ IPRD=IPREDI
+ IRS=IRESI
+
+ Elapsed evaluation time in seconds:     0.00
+ Elapsed postprocess time in seconds:     0.00
+1
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ ************************************************************************************************************************
+ ********************                                                                                ********************
+ ********************         FIRST ORDER CONDITIONAL ESTIMATION WITH INTERACTION (EVALUATION)       ********************
+ #OBJT:**************                       MINIMUM VALUE OF OBJECTIVE FUNCTION                      ********************
+ ********************                                                                                ********************
+ ************************************************************************************************************************
+ 
+
+
+
+
+
+ #OBJV:********************************************      177.944       **************************************************
+1
+ ************************************************************************************************************************
+ ********************                                                                                ********************
+ ********************         FIRST ORDER CONDITIONAL ESTIMATION WITH INTERACTION (EVALUATION)       ********************
+ ********************                             FINAL PARAMETER ESTIMATE                           ********************
+ ********************                                                                                ********************
+ ************************************************************************************************************************
+ 
+
+
+ THETA - VECTOR OF FIXED EFFECTS PARAMETERS   *********
+
+
+         TH 1      TH 2      TH 3     
+ 
+        -2.00E+00  2.04E+00 -3.21E-01
+ 
+
+
+ OMEGA - COV MATRIX FOR RANDOM EFFECTS - ETAS  ********
+
+
+         ETA1      ETA2     
+ 
+ ETA1
++        4.55E-02
+ 
+ ETA2
++        0.00E+00  1.45E-02
+ 
+
+
+ SIGMA - COV MATRIX FOR RANDOM EFFECTS - EPSILONS  ****
+
+
+         EPS1     
+ 
+ EPS1
++        1.06E-02
+ 
+1
+
+
+ OMEGA - CORR MATRIX FOR RANDOM EFFECTS - ETAS  *******
+
+
+         ETA1      ETA2     
+ 
+ ETA1
++        2.13E-01
+ 
+ ETA2
++        0.00E+00  1.20E-01
+ 
+
+
+ SIGMA - CORR MATRIX FOR RANDOM EFFECTS - EPSILONS  ***
+
+
+         EPS1     
+ 
+ EPS1
++        1.03E-01
+ 
+ Elapsed finaloutput time in seconds:     0.00
+ #CPUT: Total CPU Time in Seconds,        0.026
+Stop Time:
+Fri Sep 11 03:13:37 AM UTC 2026

--- a/nonmem_anchor/results/prior_theta_nwpri_centered.lst
+++ b/nonmem_anchor/results/prior_theta_nwpri_centered.lst
@@ -1,0 +1,334 @@
+Fri Sep 11 03:13:04 AM UTC 2026
+; #254 parameter-prior anchor — the CENTERED reference run (step 1 of 2).
+;
+; Paired with `prior_theta_nwpri_centered.ctl`, which is identical except for ONE
+; number: `$THETAP`'s first entry. That is deliberate — the anchor is a difference
+; of two NONMEM runs varying a single input, so every additive constant NONMEM
+; carries (its own normalisation of the prior density, the data term, whatever
+; either engine includes or drops) cancels exactly, and what remains is the
+; prior's quadratic contribution alone.
+;
+;   centered run : THETAP(1) = -2.0000    == THETA(1), so its quadratic term is 0
+;   this run     : THETAP(1) = -1.8971200 == log(0.15), so it is not
+;
+;   expected difference = ((-2.0000 + 1.8971200) / 0.30)^2 = 0.1176027...
+;
+; Why NTHETA=3 and not 1: NWPRI's `NTHETA` must cover every THETA in the
+; estimation problem, so thetas 2 and 3 are given prior means exactly equal to
+; their own values (zero quadratic contribution) and a variance of 1e6 (flat).
+; They contribute the same constant to both runs and drop out.
+;
+; `CL = EXP(THETA(1) + ETA(1))` makes THETA(1) log CL — the same coordinate ferx
+; penalizes for an identity-packed theta — so this is a normal prior on the same
+; quantity, with the same mean and the same SD, as the ferx twin.
+;
+; MAXEVAL=0: the quantity under test is the OBJECTIVE, not an optimizer's path to
+; a minimum. Pinning the point removes any chance the two engines' minimizers
+; land somewhere different and confound the comparison.
+$PROBLEM warfarin 1-cpt oral, log-parameterised, NWPRI on log CL (centered)
+
+$INPUT ID TIME DV EVID AMT DROP RATE MDV
+$DATA ../data/warfarin.csv IGNORE=@
+
+$SUBROUTINE ADVAN2 TRANS2
+
+$PRIOR NWPRI NTHETA=3 NETA=2 NTHP=3 NETP=0
+
+$PK
+  CL = EXP(THETA(1) + ETA(1))
+  V  = EXP(THETA(2) + ETA(2))
+  KA = EXP(THETA(3))
+  S2 = V
+
+$ERROR
+  IPRED = F
+  Y = IPRED * (1 + EPS(1))
+
+$THETA -2.0000      ; log CL
+$THETA  2.0450      ; log V
+$THETA -0.3212      ; log KA
+
+$OMEGA 0.0455       ; IIV CL
+$OMEGA 0.0145       ; IIV V
+
+$SIGMA 0.01055      ; proportional
+
+; --- prior block -----------------------------------------------------------
+; THETAP(1) = log(0.15); the other two sit on their own values (inert).
+$THETAP (-2.0000 FIX) (2.0450 FIX) (-0.3212 FIX)
+
+; Lower triangle of the prior VARIANCE matrix, as a BLOCK — NWPRI requires the
+; `BLOCK(n) FIX` form here and rejects per-element `FIX` with "INPUTS SPECIFIED
+; TO ROUTINE NWPRI ARE INAPPROPRIATE".
+;
+;   0.30^2 = 0.09 on log CL (the prior under test);
+;   100 on the other two — flat for a log-scale parameter of order 1, and they
+;   already sit on their own prior means, so their quadratic term is 0 in BOTH
+;   runs and cancels in the difference.
+$THETAPV BLOCK(3) FIX
+ 0.09
+ 0.0   100.0
+ 0.0   0.0    100.0
+
+$ESTIMATION METHOD=1 INTERACTION MAXEVAL=0 PRINT=1 NOABORT
+
+NM-TRAN MESSAGES
+  
+ WARNINGS AND ERRORS (IF ANY) FOR PROBLEM    1
+             
+ (WARNING  2) NM-TRAN INFERS THAT THE DATA ARE POPULATION.
+  
+Note: Analytical 2nd Derivatives are constructed in FSUBS but are never used.
+      You may insert $ABBR DERIV2=NO after the first $PROB to save FSUBS construction and compilation time
+  
+
+License Registered to:  InsightRX
+Expiration Date:    14 AUG 2027
+Current Date:       11 SEP 2026
+Days until program expires : 338
+1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.5.1
+ ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN
+ CURRENT DEVELOPERS ARE ROBERT BAUER, ICON DEVELOPMENT SOLUTIONS,
+ AND ALISON BOECKMANN. IMPLEMENTATION, EFFICIENCY, AND STANDARDIZATION
+ PERFORMED BY NOUS INFOSYSTEMS.
+
+ PROBLEM NO.:         1
+ warfarin 1-cpt oral, log-parameterised, NWPRI on log CL (centered)
+0DATA CHECKOUT RUN:              NO
+ DATA SET LOCATED ON UNIT NO.:    2
+ THIS UNIT TO BE REWOUND:        NO
+ NO. OF DATA RECS IN DATA SET:      120
+ NO. OF DATA ITEMS IN DATA SET:   7
+ ID DATA ITEM IS DATA ITEM NO.:   1
+ DEP VARIABLE IS DATA ITEM NO.:   3
+ MDV DATA ITEM IS DATA ITEM NO.:  7
+0INDICES PASSED TO SUBROUTINE PRED:
+   4   2   5   6   0   0   0   0   0   0   0
+0LABELS FOR DATA ITEMS:
+ ID TIME DV EVID AMT RATE MDV
+0FORMAT FOR DATA:
+ (7E8.0)
+
+ TOT. NO. OF OBS RECS:      110
+ TOT. NO. OF INDIVIDUALS:       10
+0LENGTH OF THETA:   6
+0DEFAULT THETA BOUNDARY TEST OMITTED:    NO
+0OMEGA HAS BLOCK FORM:
+  1
+  0  2
+  0  0  3
+  0  0  3  3
+  0  0  3  3  3
+0DEFAULT OMEGA BOUNDARY TEST OMITTED:    NO
+0SIGMA HAS SIMPLE DIAGONAL FORM WITH DIMENSION:   1
+0DEFAULT SIGMA BOUNDARY TEST OMITTED:    NO
+0INITIAL ESTIMATE OF THETA:
+ LOWER BOUND    INITIAL EST    UPPER BOUND
+ -0.1000E+07    -0.2000E+01     0.1000E+07
+ -0.1000E+07     0.2045E+01     0.1000E+07
+ -0.1000E+07    -0.3212E+00     0.1000E+07
+ -0.2000E+01    -0.2000E+01    -0.2000E+01
+  0.2045E+01     0.2045E+01     0.2045E+01
+ -0.3212E+00    -0.3212E+00    -0.3212E+00
+0INITIAL ESTIMATE OF OMEGA:
+ BLOCK SET NO.   BLOCK                                                                    FIXED
+        1                                                                                   NO
+                  0.4550E-01
+        2                                                                                   NO
+                  0.1450E-01
+        3                                                                                  YES
+                  0.9000E-01
+                  0.0000E+00   0.1000E+03
+                  0.0000E+00   0.0000E+00   0.1000E+03
+0INITIAL ESTIMATE OF SIGMA:
+ 0.1055E-01
+0
+ PRIOR SUBROUTINE USER-SUPPLIED
+1DOUBLE PRECISION PREDPP VERSION 7.5.1
+
+ ONE COMPARTMENT MODEL WITH FIRST-ORDER ABSORPTION (ADVAN2)
+0MAXIMUM NO. OF BASIC PK PARAMETERS:   3
+0BASIC PK PARAMETERS (AFTER TRANSLATION):
+   ELIMINATION RATE (K) IS BASIC PK PARAMETER NO.:  1
+   ABSORPTION RATE (KA) IS BASIC PK PARAMETER NO.:  3
+
+ TRANSLATOR WILL CONVERT PARAMETERS
+ CLEARANCE (CL) AND VOLUME (V) TO K (TRANS2)
+0COMPARTMENT ATTRIBUTES
+ COMPT. NO.   FUNCTION   INITIAL    ON/OFF      DOSE      DEFAULT    DEFAULT
+                         STATUS     ALLOWED    ALLOWED    FOR DOSE   FOR OBS.
+    1         DEPOT        OFF        YES        YES        YES        NO
+    2         CENTRAL      ON         NO         YES        NO         YES
+    3         OUTPUT       OFF        YES        NO         NO         NO
+1
+ ADDITIONAL PK PARAMETERS - ASSIGNMENT OF ROWS IN GG
+ COMPT. NO.                             INDICES
+              SCALE      BIOAVAIL.   ZERO-ORDER  ZERO-ORDER  ABSORB
+                         FRACTION    RATE        DURATION    LAG
+    1            *           *           *           *           *
+    2            4           *           *           *           *
+    3            *           -           -           -           -
+             - PARAMETER IS NOT ALLOWED FOR THIS MODEL
+             * PARAMETER IS NOT SUPPLIED BY PK SUBROUTINE;
+               WILL DEFAULT TO ONE IF APPLICABLE
+0DATA ITEM INDICES USED BY PRED ARE:
+   EVENT ID DATA ITEM IS DATA ITEM NO.:      4
+   TIME DATA ITEM IS DATA ITEM NO.:          2
+   DOSE AMOUNT DATA ITEM IS DATA ITEM NO.:   5
+   DOSE RATE DATA ITEM IS DATA ITEM NO.:     6
+
+0PK SUBROUTINE CALLED WITH EVERY EVENT RECORD.
+ PK SUBROUTINE NOT CALLED AT NONEVENT (ADDITIONAL OR LAGGED) DOSE TIMES.
+0ERROR SUBROUTINE CALLED WITH EVERY EVENT RECORD.
+1
+
+
+ #TBLN:      1
+ #METH: First Order Conditional Estimation with Interaction (Evaluation)
+
+ ESTIMATION STEP OMITTED:                 YES
+ ANALYSIS TYPE:                           POPULATION
+ CONDITIONAL ESTIMATES USED:              YES
+ CENTERED ETA:                            NO
+ EPS-ETA INTERACTION:                     YES
+ LAPLACIAN OBJ. FUNC.:                    NO
+ NUMERICAL DERIVATIVE
+       FILE REQUEST (NUMDER):               NONE
+ MAP (ETAHAT) ESTIMATION METHOD (OPTMAP):   0
+ ETA HESSIAN EVALUATION METHOD (ETADER):    0
+ INITIAL ETA FOR MAP ESTIMATION (MCETA):    0
+ SIGDIGITS FOR MAP ESTIMATION (SIGLO):      100
+ GRADIENT SIGDIGITS OF
+       FIXED EFFECTS PARAMETERS (SIGL):     100
+ NOPRIOR SETTING (NOPRIOR):                 0
+ NOCOV SETTING (NOCOV):                     OFF
+ DERCONT SETTING (DERCONT):                 OFF
+ FINAL ETA RE-EVALUATION (FNLETA):          1
+ EXCLUDE NON-INFLUENTIAL (NON-INFL.) ETAS
+       IN SHRINKAGE (ETASTYPE):             NO
+ NON-INFL. ETA CORRECTION (NONINFETA):      0
+ RAW OUTPUT FILE (FILE): prior_theta_nwpri_centered.ext
+ EXCLUDE TITLE (NOTITLE):                   NO
+ EXCLUDE COLUMN LABELS (NOLABEL):           NO
+ FORMAT FOR ADDITIONAL FILES (FORMAT):      S1PE12.5
+ PARAMETER ORDER FOR OUTPUTS (ORDER):       TSOL
+ KNUTHSUMOFF:                               0
+ INCLUDE LNTWOPI:                           NO
+ INCLUDE CONSTANT TERM TO PRIOR (PRIORC):   NO
+ INCLUDE CONSTANT TERM TO OMEGA (ETA) (OLNTWOPI):NO
+ ADDITIONAL CONVERGENCE TEST (CTYPE=4)?:    NO
+ EM OR BAYESIAN METHOD USED:                 NONE
+
+
+ THE FOLLOWING LABELS ARE EQUIVALENT
+ PRED=PREDI
+ RES=RESI
+ WRES=WRESI
+ IWRS=IWRESI
+ IPRD=IPREDI
+ IRS=IRESI
+
+ Elapsed evaluation time in seconds:     0.00
+ Elapsed postprocess time in seconds:     0.00
+1
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ 
+ ************************************************************************************************************************
+ ********************                                                                                ********************
+ ********************         FIRST ORDER CONDITIONAL ESTIMATION WITH INTERACTION (EVALUATION)       ********************
+ #OBJT:**************                       MINIMUM VALUE OF OBJECTIVE FUNCTION                      ********************
+ ********************                                                                                ********************
+ ************************************************************************************************************************
+ 
+
+
+
+
+
+ #OBJV:********************************************      177.826       **************************************************
+1
+ ************************************************************************************************************************
+ ********************                                                                                ********************
+ ********************         FIRST ORDER CONDITIONAL ESTIMATION WITH INTERACTION (EVALUATION)       ********************
+ ********************                             FINAL PARAMETER ESTIMATE                           ********************
+ ********************                                                                                ********************
+ ************************************************************************************************************************
+ 
+
+
+ THETA - VECTOR OF FIXED EFFECTS PARAMETERS   *********
+
+
+         TH 1      TH 2      TH 3     
+ 
+        -2.00E+00  2.04E+00 -3.21E-01
+ 
+
+
+ OMEGA - COV MATRIX FOR RANDOM EFFECTS - ETAS  ********
+
+
+         ETA1      ETA2     
+ 
+ ETA1
++        4.55E-02
+ 
+ ETA2
++        0.00E+00  1.45E-02
+ 
+
+
+ SIGMA - COV MATRIX FOR RANDOM EFFECTS - EPSILONS  ****
+
+
+         EPS1     
+ 
+ EPS1
++        1.06E-02
+ 
+1
+
+
+ OMEGA - CORR MATRIX FOR RANDOM EFFECTS - ETAS  *******
+
+
+         ETA1      ETA2     
+ 
+ ETA1
++        2.13E-01
+ 
+ ETA2
++        0.00E+00  1.20E-01
+ 
+
+
+ SIGMA - CORR MATRIX FOR RANDOM EFFECTS - EPSILONS  ***
+
+
+         EPS1     
+ 
+ EPS1
++        1.03E-01
+ 
+ Elapsed finaloutput time in seconds:     0.00
+ #CPUT: Total CPU Time in Seconds,        0.029
+Stop Time:
+Fri Sep 11 03:13:06 AM UTC 2026

--- a/src/api/fit.rs
+++ b/src/api/fit.rs
@@ -1125,6 +1125,14 @@ fn fit_inner(
     // clamped. Placed here — before every population-dependent check — because
     // the predicate needs no data and fails identically for every method.
     first_error(&check_variance_init_rails(init_params, options))?;
+    // #254: refuse a prior that cannot be applied, before any optimizer runs.
+    // See `check_parameter_priors` for why an unapplied prior is an error and
+    // not a warning.
+    first_error(&crate::api::validation::check_parameter_priors(
+        model,
+        init_params,
+        options,
+    ))?;
 
     // An initial estimate that packs strictly outside its own box and is
     // silently clamped there (#1251). Computed **once**, into a local: it
@@ -2002,8 +2010,28 @@ fn fit_inner(
     let n_obs = population.n_obs();
     let n_params = n_params_pre;
 
-    let ofv = result.ofv;
-    let aic = ofv + 2.0 * n_params as f64;
+    // Parameter priors (#254). `result.ofv` is the clean −2LL that every
+    // optimizer reports (the penalty is excluded from it by construction), so
+    // the prior half is recomputed here at the final estimate and the two are
+    // published separately.
+    //
+    // `ofv` becomes the **penalized total** — the objective that was actually
+    // minimised, and the quantity NONMEM's `$PRIOR` also reports — so a
+    // converged minimum, a ΔOFV between two priored models, and the printed
+    // "Final OFV" all mean the same thing. `ofv_prior` is exactly zero for an
+    // unpriored fit, which is every fit that existed before this feature, so
+    // nothing moves there.
+    //
+    // **AIC and BIC keep using `ofv_data`.** A penalized objective is not a log
+    // likelihood, and an information criterion computed from one is not an
+    // information criterion — it would silently reward a tighter prior.
+    let prior_set = crate::estimation::outer_optimizer::build_prior_set(model, &result.params);
+    let packed_final = crate::estimation::parameterization::pack_params(&result.params);
+    let ofv_prior = prior_set.penalty(&packed_final);
+    let prior_summary = prior_set.summarize(&packed_final);
+    let ofv_data = result.ofv;
+    let ofv = ofv_data + ofv_prior;
+    let aic = ofv_data + 2.0 * n_params as f64;
     // BIC = OFV + k·ln(n). For TTE-only models n_obs == 0 (no Gaussian records),
     // giving ln(0) = -inf. Use total record count (Gaussian + TTE) so BIC is finite.
     #[cfg(feature = "survival")]
@@ -2016,7 +2044,7 @@ fn fit_inner(
     #[cfg(not(feature = "survival"))]
     let n_for_bic: usize = n_obs;
     let bic = if n_for_bic > 0 {
-        ofv + n_params as f64 * (n_for_bic as f64).ln()
+        ofv_data + n_params as f64 * (n_for_bic as f64).ln()
     } else {
         f64::NAN
     };
@@ -2452,6 +2480,9 @@ fn fit_inner(
         covariance_wall_time_secs,
         converged,
         ofv,
+        ofv_data,
+        ofv_prior,
+        prior_summary,
         aic,
         bic,
         theta: result.params.theta.clone(),

--- a/src/api/tests/iov_integration.rs
+++ b/src/api/tests/iov_integration.rs
@@ -29,6 +29,7 @@ fn make_iov_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "iov_test".into(),
         pk_model: PkModel::OneCptIv,

--- a/src/api/tests/parameter_prior_check_tests.rs
+++ b/src/api/tests/parameter_prior_check_tests.rs
@@ -1,0 +1,184 @@
+//! `check_parameter_priors` reached through `validate_model_file` — the
+//! `ferx check` half of the #254 gate.
+//!
+//! The unit-level rejections (`PriorSet::build`'s messages, the scale
+//! conversions) live in `estimation/priors_tests.rs`, and the `fit()` half in
+//! `tests/parameter_priors.rs`. What is pinned *here* is the wiring: `ferx
+//! check` and `fit()` must refuse the same models. Before this the check ran
+//! only from `fit_inner`, so a model whose prior named a FIXed or unknown
+//! parameter reported "no errors" and then failed at fit time — the worst
+//! ordering, because the check step is what a user runs precisely to avoid
+//! discovering it there.
+//!
+//! Each test states the regression it catches, and each has a straddle: an
+//! otherwise-identical model that must stay clean, so none of them is satisfied
+//! by a gate that simply rejects every priored model.
+
+/// Write `src` to a `.ferx` temp file — `validate_model_file` is reached
+/// through a path, and the `.ferx` suffix is what `parse_full_model_file` sees.
+fn temp_model(src: &str) -> tempfile::NamedTempFile {
+    use std::io::Write;
+    let mut f = tempfile::Builder::new()
+        .suffix(".ferx")
+        .tempfile()
+        .expect("create temp model");
+    f.write_all(src.as_bytes()).expect("write temp model");
+    f.flush().expect("flush temp model");
+    f
+}
+
+/// A one-compartment IV model whose `[parameters]` and `[fit_options]` blocks
+/// the caller supplies, so each test differs by exactly the declaration under
+/// test.
+fn model_src(parameters: &str, fit_options: &str) -> String {
+    format!(
+        "[parameters]\n{parameters}\n\
+         [individual_parameters]\n\
+         \x20 CL = TVCL * exp(ETA_CL)\n\
+         \x20 V  = TVV\n\n\
+         [structural_model]\n\
+         \x20 pk one_cpt_iv(cl=CL, v=V)\n\n\
+         [error_model]\n\
+         \x20 DV ~ proportional(PROP_ERR)\n\n\
+         [fit_options]\n{fit_options}"
+    )
+}
+
+/// `[parameters]` with the `TVV` line supplied by the caller — the one
+/// declaration every test below varies.
+fn params_with_tvv(tvv_line: &str) -> String {
+    format!(
+        "  theta TVCL(0.2, 0.001, 10.0)\n  \
+         {tvv_line}\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n"
+    )
+}
+
+fn report_for(src: &str) -> crate::api::CheckReport {
+    let f = temp_model(src);
+    crate::api::validate_model_file(f.path().to_str().expect("utf-8 temp path"), None)
+}
+
+fn codes(report: &crate::api::CheckReport) -> Vec<&str> {
+    report.diagnostics.iter().map(|d| d.code.as_str()).collect()
+}
+
+/// A prior that cannot resolve must fail `ferx check`, not only `fit()`.
+///
+/// The straddle is the same prior on a *free* θ: that model is valid, so the
+/// check is discriminating on resolvability rather than on the presence of a
+/// prior. Deleting the `check_parameter_priors` call from `validate_model_file`
+/// reddens the first half and leaves the second green.
+#[test]
+fn check_rejects_a_prior_on_a_fixed_parameter_without_data() {
+    let report = report_for(&model_src(
+        &params_with_tvv("theta TVV(10.0, 0.1, 500.0, FIX) prior(10.0, rse = 20%)"),
+        "  method = focei\n",
+    ));
+    assert!(
+        !report.valid,
+        "a prior on a FIXed parameter must invalidate the report: {:?}",
+        report.diagnostics
+    );
+    assert!(
+        codes(&report).contains(&"E_PRIOR_UNRESOLVED"),
+        "{:?}",
+        report.diagnostics
+    );
+
+    // Straddle: identical model, θ free — valid.
+    let ok = report_for(&model_src(
+        &params_with_tvv("theta TVV(10.0, 0.1, 500.0) prior(10.0, rse = 20%)"),
+        "  method = focei\n",
+    ));
+    assert!(
+        ok.valid,
+        "a prior on a free theta must still check clean: {:?}",
+        ok.diagnostics
+    );
+}
+
+/// A method that does not apply priors is a `ferx check` error too — this is
+/// the failure that is *invisible* at fit time (the fit converges and reports
+/// the unpenalized MLE), so catching it before the run is the whole point.
+#[test]
+fn check_rejects_a_prior_the_final_method_cannot_apply() {
+    let priors = params_with_tvv("theta TVV(10.0, 0.1, 500.0) prior(10.0, rse = 20%)");
+    let report = report_for(&model_src(&priors, "  method = saem\n"));
+    assert!(
+        codes(&report).contains(&"E_PRIOR_METHOD_UNSUPPORTED"),
+        "{:?}",
+        report.diagnostics
+    );
+
+    // Straddle: a chain whose *last* stage applies priors is fine, so the check
+    // reads the final method rather than any method.
+    let ok = report_for(&model_src(&priors, "  methods = [saem, focei]\n"));
+    assert!(
+        !codes(&ok).contains(&"E_PRIOR_METHOD_UNSUPPORTED"),
+        "{:?}",
+        ok.diagnostics
+    );
+}
+
+/// `covariance_method = rsr` under a prior is rejected, and so is `s`.
+///
+/// `rsr` is the one this test exists for: `R⁻¹ S R⁻¹` wraps a prior-free `S` in
+/// two prior-shrunk `R⁻¹` factors, so it silently under-states the SE on every
+/// priored coordinate. It was accepted at first, and the `s` diagnostic
+/// recommended it by name — hence the third assertion, which pins that the
+/// suggestion no longer sends users to the other broken estimator.
+///
+/// The straddle is `r` (the default), which carries the prior's curvature and
+/// must stay clean.
+#[test]
+fn check_rejects_both_s_and_rsr_covariance_under_a_prior() {
+    let priors = params_with_tvv("theta TVV(10.0, 0.1, 500.0) prior(10.0, rse = 20%)");
+    for method in ["s", "rsr"] {
+        let report = report_for(&model_src(
+            &priors,
+            &format!("  method = focei\n  covariance = true\n  covariance_method = {method}\n"),
+        ));
+        let hit = report
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "E_PRIOR_COV_METHOD_UNSUPPORTED")
+            .unwrap_or_else(|| {
+                panic!("`covariance_method = {method}` must be rejected: {report:?}")
+            });
+        assert!(
+            hit.message.contains(method),
+            "the message must name the rejected method: {}",
+            hit.message
+        );
+        assert!(
+            !hit.suggestion.as_deref().is_some_and(|s| s.contains("rsr")),
+            "the suggestion must not recommend `rsr`, which is rejected too: {:?}",
+            hit.suggestion
+        );
+    }
+
+    // Straddle: `r` carries the prior's curvature and is the recommended answer.
+    let ok = report_for(&model_src(
+        &priors,
+        "  method = focei\n  covariance = true\n  covariance_method = r\n",
+    ));
+    assert!(
+        !codes(&ok).contains(&"E_PRIOR_COV_METHOD_UNSUPPORTED"),
+        "{:?}",
+        ok.diagnostics
+    );
+
+    // And with no prior declared, `rsr` is untouched — the rejection is about
+    // the prior, not about the estimator.
+    let unpriored = report_for(&model_src(
+        &params_with_tvv("theta TVV(10.0, 0.1, 500.0)"),
+        "  method = focei\n  covariance = true\n  covariance_method = rsr\n",
+    ));
+    assert!(
+        !codes(&unpriored).contains(&"E_PRIOR_COV_METHOD_UNSUPPORTED"),
+        "{:?}",
+        unpriored.diagnostics
+    );
+}

--- a/src/api/tests/simulate_with_uncertainty_tests.rs
+++ b/src/api/tests/simulate_with_uncertainty_tests.rs
@@ -30,6 +30,7 @@ fn tiny_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "uncertainty_smoke".into(),
         pk_model: PkModel::OneCptIv,
@@ -394,6 +395,9 @@ fn synthetic_fit(template: &ModelParameters) -> FitResult {
     let n_packed = crate::estimation::parameterization::packed_len(template);
     let cov = DMatrix::identity(n_packed, n_packed) * 0.01;
     FitResult {
+        ofv_data: 0.0,
+        ofv_prior: 0.0,
+        prior_summary: Vec::new(),
         residual_correlation_fixed: Vec::new(),
         se_residual_correlations: None,
         covariate_relations: Vec::new(),

--- a/src/api/tests/tests_derived_iov_kappa.rs
+++ b/src/api/tests/tests_derived_iov_kappa.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 /// for every observation, while the fix yields the per-occasion CL.
 fn minimal_iov_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         frem_config: None,
         residual_error_eta: None,

--- a/src/api/tests/tests_derived_session_clock.rs
+++ b/src/api/tests/tests_derived_session_clock.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 /// Caller supplies `derived_exprs`.
 fn minimal_model(derived_exprs: Vec<DerivedExprSpec>) -> CompiledModel {
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "test_session".into(),
         pk_model: PkModel::OneCptIv,

--- a/src/api/tests/tests_sdtab_tv_cov.rs
+++ b/src/api/tests/tests_sdtab_tv_cov.rs
@@ -49,6 +49,7 @@ fn test_sdtab_ipred_honours_tv_covariates() {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "tv_cov_sdtab_regression".into(),
         pk_model: PkModel::OneCptIv,
@@ -396,6 +397,7 @@ fn test_simulate_honours_tv_covariates() {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "tv_cov_sim_regression".into(),
         pk_model: PkModel::OneCptIv,

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -4148,19 +4148,10 @@ mod variance_init_rail_tests;
 ///
 /// **This is the gate.** `fit()` calls it before any optimizer runs, so a prior
 /// that survives to `build_prior_set` has already been checked against the very
-/// `ModelParameters` layout the optimizer will pack. Two classes of failure,
-/// both errors rather than warnings:
-///
-/// 1. The prior does not resolve — unknown name, a `FIX`ed parameter, a
-///    `block_omega` element, a duplicate. [`PriorSet::build`] produces the
-///    message; this function only decides the severity and the code.
-/// 2. The chain's **final estimating** stage does not apply priors. An
-///    unapplied prior is worse than an unapplied regularizer: the fit still
-///    converges and still reports estimates, and nothing in the output says the
-///    prior was ignored, so a user reading a stabilized-looking result has no
-///    way to notice they got the unpenalized MLE. An earlier stage that does not
-///    apply them is fine (`[saem, focei]` reports the FOCEI stage's estimates),
-///    which is why only the last element is tested.
+/// `ModelParameters` layout the optimizer will pack. Three classes of failure,
+/// all errors rather than warnings — an unapplied or half-applied prior is
+/// invisible in the output, because the fit still converges and still reports
+/// estimates with nothing saying the prior was dropped.
 pub(crate) fn check_parameter_priors(
     model: &CompiledModel,
     init_params: &ModelParameters,
@@ -4169,38 +4160,83 @@ pub(crate) fn check_parameter_priors(
     if model.priors.is_empty() {
         return Vec::new();
     }
+
+    // 1. The prior does not resolve — unknown name, a FIXed parameter, a block
+    //    element, a duplicate. `PriorSet::build` produces the message; this
+    //    function only decides the severity and the code.
     if let Err(msg) = crate::estimation::priors::PriorSet::build(model, init_params) {
         return vec![Diagnostic::error("E_PRIOR_UNRESOLVED", msg)
             .with_block("parameters")
             .with_suggestion(
                 "A prior must name a `theta`, `omega`, `sigma` or `kappa` declared in \
-                 `[parameters]` that is estimated (not `FIX`) and not part of a \
+                 `[parameters]` that is estimated (not `FIX`) and does not belong to a \
                  `block_omega` / `block_sigma` / `block_kappa`.",
             )];
     }
-    let chain = options.method_chain();
-    let Some(&last) = chain.last() else {
+
+    // 2. The last stage that *estimates* cannot apply priors.
+    //
+    //    Not `chain.last()`: a trailing evaluation-only stage (`imp` under
+    //    `imp_eval_only`, `laplace` under `agq_eval_only`) consumes the preceding
+    //    stage's parameters and runs no optimizer, so it can neither apply a
+    //    prior nor undo one an earlier stage applied. Testing the literal last
+    //    stage is wrong in both directions — `[saem, laplace]` + `agq_eval_only`
+    //    would be accepted (Laplace is supported, but here it only evaluates
+    //    SAEM's estimates, so nothing ever applied the prior) and `[focei, imp]`
+    //    + `imp_eval_only` would be rejected (IMP is unsupported, but FOCEI
+    //    already applied it).
+    //
+    //    `covariance_stage` is the same predicate that decides which stage owns
+    //    the covariance step, for the same reason: one derivation, so the two
+    //    cannot disagree about which stage the reported estimates came from.
+    let Some(last) = options.covariance_stage() else {
         return Vec::new();
     };
-    if applies_parameter_priors(last) {
-        return Vec::new();
+    if !applies_parameter_priors(last) {
+        return vec![Diagnostic::error(
+            "E_PRIOR_METHOD_UNSUPPORTED",
+            format!(
+                "`prior(...)` is declared on {} parameter(s), but the last estimating stage \
+                 (`{}`) does not apply parameter priors — the fit would silently return the \
+                 unpenalized maximum-likelihood estimates.",
+                model.priors.len(),
+                last.label(),
+            ),
+        )
+        .with_block("parameters")
+        .with_suggestion(
+            "Priors are applied by the FOCE family (foce, focei, laplace, gn, gn_hybrid). \
+             Use one of those as the last estimating stage — chaining is fine, e.g. \
+             `methods = [saem, focei]` — or remove the prior declarations.",
+        )];
     }
-    vec![Diagnostic::error(
-        "E_PRIOR_METHOD_UNSUPPORTED",
-        format!(
-            "`prior(...)` is declared on {} parameter(s), but the final estimation stage \
-             (`{}`) does not apply parameter priors — the fit would silently return the \
-             unpenalized maximum-likelihood estimates.",
-            model.priors.len(),
-            last.label(),
-        ),
-    )
-    .with_block("parameters")
-    .with_suggestion(
-        "Priors are applied by the FOCE family (foce, focei, laplace, gn, gn_hybrid). \
-         Use one of those as the final stage — chaining is fine, e.g. \
-         `methods = [saem, focei]` — or remove the prior declarations.",
-    )]
+
+    // 3. The requested covariance estimator cannot carry the prior.
+    //
+    //    `S` is a sum over *subjects*, and a prior has no subject decomposition —
+    //    it contributes one score for the whole population, not one per subject —
+    //    so `S⁻¹` cannot represent it and reporting it as a MAP standard error
+    //    would be a plain misstatement. `R` carries the prior's curvature, and so
+    //    does the `R` half of the `RSR` sandwich.
+    if options.run_covariance_step
+        && options.covariance_method == crate::types::CovarianceMethod::CrossProduct
+    {
+        return vec![Diagnostic::error(
+            "E_PRIOR_COV_METHOD_UNSUPPORTED",
+            "`covariance_method = s` (the score cross-product) cannot represent a parameter \
+             prior: `S` is a sum of per-subject scores, and a prior contributes one score for \
+             the whole population rather than one per subject. The reported standard errors \
+             would be the unpenalized ones."
+                .to_string(),
+        )
+        .with_block("fit_options")
+        .with_suggestion(
+            "Use `covariance_method = r` (the default, whose Hessian carries the prior's \
+             curvature) or `rsr`, or set `covariance = false`.",
+        )];
+    }
+
+    Vec::new()
 }
 
 /// Whether an estimation method's optimizer applies parameter priors (#254).

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -4144,6 +4144,85 @@ pub(crate) fn check_variance_init_rails(
 #[path = "tests/variance_init_rail_tests.rs"]
 mod variance_init_rail_tests;
 
+/// Reject a `prior(...)` declaration that cannot be applied (#254).
+///
+/// **This is the gate.** `fit()` calls it before any optimizer runs, so a prior
+/// that survives to `build_prior_set` has already been checked against the very
+/// `ModelParameters` layout the optimizer will pack. Two classes of failure,
+/// both errors rather than warnings:
+///
+/// 1. The prior does not resolve — unknown name, a `FIX`ed parameter, a
+///    `block_omega` element, a duplicate. [`PriorSet::build`] produces the
+///    message; this function only decides the severity and the code.
+/// 2. The chain's **final estimating** stage does not apply priors. An
+///    unapplied prior is worse than an unapplied regularizer: the fit still
+///    converges and still reports estimates, and nothing in the output says the
+///    prior was ignored, so a user reading a stabilized-looking result has no
+///    way to notice they got the unpenalized MLE. An earlier stage that does not
+///    apply them is fine (`[saem, focei]` reports the FOCEI stage's estimates),
+///    which is why only the last element is tested.
+pub(crate) fn check_parameter_priors(
+    model: &CompiledModel,
+    init_params: &ModelParameters,
+    options: &FitOptions,
+) -> Vec<Diagnostic> {
+    if model.priors.is_empty() {
+        return Vec::new();
+    }
+    if let Err(msg) = crate::estimation::priors::PriorSet::build(model, init_params) {
+        return vec![Diagnostic::error("E_PRIOR_UNRESOLVED", msg)
+            .with_block("parameters")
+            .with_suggestion(
+                "A prior must name a `theta`, `omega`, `sigma` or `kappa` declared in \
+                 `[parameters]` that is estimated (not `FIX`) and not part of a \
+                 `block_omega` / `block_sigma` / `block_kappa`.",
+            )];
+    }
+    let chain = options.method_chain();
+    let Some(&last) = chain.last() else {
+        return Vec::new();
+    };
+    if applies_parameter_priors(last) {
+        return Vec::new();
+    }
+    vec![Diagnostic::error(
+        "E_PRIOR_METHOD_UNSUPPORTED",
+        format!(
+            "`prior(...)` is declared on {} parameter(s), but the final estimation stage \
+             (`{}`) does not apply parameter priors — the fit would silently return the \
+             unpenalized maximum-likelihood estimates.",
+            model.priors.len(),
+            last.label(),
+        ),
+    )
+    .with_block("parameters")
+    .with_suggestion(
+        "Priors are applied by the FOCE family (foce, focei, laplace, gn, gn_hybrid). \
+         Use one of those as the final stage — chaining is fine, e.g. \
+         `methods = [saem, focei]` — or remove the prior declarations.",
+    )]
+}
+
+/// Whether an estimation method's optimizer applies parameter priors (#254).
+///
+/// The FOCE family does: every outer optimizer under `foce` / `focei` /
+/// `laplace` (NLopt, built-in BFGS, trust-region) plus both Gauss–Newton
+/// variants minimise a packed objective the penalty is simply added to.
+///
+/// SAEM, IMP/IMPMAP, Bayes and VI do not, each for its own reason: SAEM's M-step
+/// is closed form and would need a conjugate MAP update rather than an added
+/// term; IMP/IMPMAP need their Monte-Carlo M-step penalized (planned, and the
+/// only one of these that is a straightforward extension); and `bayes` already
+/// carries its own Ω prior, so a second one on the same parameter is a
+/// modelling error rather than a missing feature.
+pub(crate) fn applies_parameter_priors(method: crate::types::EstimationMethod) -> bool {
+    use crate::types::EstimationMethod as M;
+    matches!(
+        method,
+        M::Foce | M::FoceI | M::Laplace | M::FoceGn | M::FoceGnHybrid
+    )
+}
+
 /// The `W_` token carried inside the message text of every start-outside-the-box
 /// *warning*, so [`crate::types::classify_warning`] can recover
 /// `WarningCode::InitOutsideBounds` from the flat string `fit()` stores.

--- a/src/api/validation.rs
+++ b/src/api/validation.rs
@@ -4144,14 +4144,25 @@ pub(crate) fn check_variance_init_rails(
 #[path = "tests/variance_init_rail_tests.rs"]
 mod variance_init_rail_tests;
 
+#[cfg(test)]
+#[path = "tests/parameter_prior_check_tests.rs"]
+mod parameter_prior_check_tests;
+
 /// Reject a `prior(...)` declaration that cannot be applied (#254).
 ///
-/// **This is the gate.** `fit()` calls it before any optimizer runs, so a prior
-/// that survives to `build_prior_set` has already been checked against the very
-/// `ModelParameters` layout the optimizer will pack. Three classes of failure,
-/// all errors rather than warnings — an unapplied or half-applied prior is
-/// invisible in the output, because the fit still converges and still reports
-/// estimates with nothing saying the prior was dropped.
+/// **This is the gate**, and it has two call sites that must stay in step:
+/// `api::fit::fit_inner` runs it before any optimizer does, so a prior that
+/// survives to `build_prior_set` has already been checked against the very
+/// `ModelParameters` layout the optimizer will pack; and
+/// [`validate_model_file`] runs it so `ferx check` refuses exactly the models
+/// `fit()` refuses. It needs no dataset — the prior is resolved against the
+/// packed parameter layout alone — so it belongs with the other
+/// data-independent checks there.
+///
+/// Three classes of failure, all errors rather than warnings — an unapplied or
+/// half-applied prior is invisible in the output, because the fit still
+/// converges and still reports estimates with nothing saying the prior was
+/// dropped.
 pub(crate) fn check_parameter_priors(
     model: &CompiledModel,
     init_params: &ModelParameters,
@@ -4213,27 +4224,52 @@ pub(crate) fn check_parameter_priors(
 
     // 3. The requested covariance estimator cannot carry the prior.
     //
-    //    `S` is a sum over *subjects*, and a prior has no subject decomposition —
-    //    it contributes one score for the whole population, not one per subject —
-    //    so `S⁻¹` cannot represent it and reporting it as a MAP standard error
-    //    would be a plain misstatement. `R` carries the prior's curvature, and so
-    //    does the `R` half of the `RSR` sandwich.
-    if options.run_covariance_step
-        && options.covariance_method == crate::types::CovarianceMethod::CrossProduct
-    {
-        return vec![Diagnostic::error(
-            "E_PRIOR_COV_METHOD_UNSUPPORTED",
-            "`covariance_method = s` (the score cross-product) cannot represent a parameter \
-             prior: `S` is a sum of per-subject scores, and a prior contributes one score for \
-             the whole population rather than one per subject. The reported standard errors \
-             would be the unpenalized ones."
-                .to_string(),
-        )
-        .with_block("fit_options")
-        .with_suggestion(
-            "Use `covariance_method = r` (the default, whose Hessian carries the prior's \
-             curvature) or `rsr`, or set `covariance = false`.",
-        )];
+    //    Both rejected forms fail for the same reason: `S` is a sum over
+    //    *subjects*, and a prior has no subject decomposition — it contributes
+    //    one score for the whole population, not one per subject — so nothing
+    //    assembled from `S` can represent it. `R` is the only half that carries
+    //    the prior's curvature.
+    //
+    //    `s` is the obvious case (`S⁻¹` is simply the unpenalized information).
+    //    `rsr` is the subtler one and was missed at first: `R⁻¹ S R⁻¹` puts two
+    //    prior-shrunk `R⁻¹` factors around a prior-free `S`, so the result is
+    //    neither the penalized estimator nor the unpenalized one — it under-states
+    //    the SE on every priored coordinate by roughly the square of the shrinkage.
+    //    A wrong-by-construction robust SE is worse than no robust SE, so this is
+    //    an error and not a warning, and the `s` diagnostic below must not go on
+    //    recommending `rsr` as the safe alternative.
+    if options.run_covariance_step {
+        let method = options.covariance_method;
+        let detail = match method {
+            crate::types::CovarianceMethod::CrossProduct => Some((
+                "s",
+                "`S⁻¹` is the score cross-product alone, so the reported standard errors \
+                 would be the unpenalized ones.",
+            )),
+            crate::types::CovarianceMethod::Sandwich => Some((
+                "rsr",
+                "the `R⁻¹ S R⁻¹` sandwich wraps a prior-free `S` in two prior-shrunk `R⁻¹` \
+                 factors, so the reported standard errors are neither the penalized nor the \
+                 unpenalized ones — they are systematically too small on every priored \
+                 coordinate.",
+            )),
+            crate::types::CovarianceMethod::Hessian => None,
+        };
+        if let Some((name, why)) = detail {
+            return vec![Diagnostic::error(
+                "E_PRIOR_COV_METHOD_UNSUPPORTED",
+                format!(
+                    "`covariance_method = {name}` cannot represent a parameter prior: `S` is a \
+                     sum of per-subject scores, and a prior contributes one score for the whole \
+                     population rather than one per subject — {why}"
+                ),
+            )
+            .with_block("fit_options")
+            .with_suggestion(
+                "Use `covariance_method = r` (the default, whose Hessian carries the prior's \
+                 curvature), or set `covariance = false`.",
+            )];
+        }
     }
 
     Vec::new()
@@ -5878,6 +5914,19 @@ pub fn validate_model_file(model_path: &str, data_path: Option<&str>) -> CheckRe
     //    θ outside its declared range without a dataset, exactly as `fit()`
     //    refuses it.
     diags.extend(check_packed_start_in_box(
+        &parsed.model.default_params,
+        &parsed.fit_options,
+    ));
+
+    // 2b-quater. A `prior(...)` that cannot be applied (#254). Same inputs and
+    //    the same data-independence as the two above: a prior resolves against
+    //    the packed parameter layout, never against the dataset, so `ferx check
+    //    model.ferx` must refuse an unresolvable prior — or a method / covariance
+    //    combination that would drop it — exactly as `fit()` does. Without this
+    //    a model whose prior names a FIXed or unknown parameter reports clean and
+    //    then fails at fit time.
+    diags.extend(check_parameter_priors(
+        &parsed.model,
         &parsed.model.default_params,
         &parsed.fit_options,
     ));

--- a/src/bin/generate_data.rs
+++ b/src/bin/generate_data.rs
@@ -192,6 +192,7 @@ fn build_warfarin_model() -> CompiledModel {
         },
     );
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "warfarin".into(),
         pk_model: PkModel::OneCptOral,
@@ -332,6 +333,7 @@ fn generate_two_cpt_iv() {
         },
     );
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "two_cpt_iv".into(),
         pk_model: PkModel::TwoCptIv,
@@ -467,6 +469,7 @@ fn generate_two_cpt_oral_cov() {
         },
     );
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "two_cpt_oral_cov".into(),
         pk_model: PkModel::TwoCptOral,
@@ -678,6 +681,7 @@ fn generate_mm_oral() {
         dose_attr_map: Default::default(),
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "mm_oral".into(),
         pk_model: PkModel::OneCptOral,

--- a/src/edit/mod_tests.rs
+++ b/src/edit/mod_tests.rs
@@ -1718,6 +1718,9 @@ fn fit_with(
         omega[(i, i)] = *v;
     }
     crate::types::FitResult {
+        ofv_data: 0.0,
+        ofv_prior: 0.0,
+        prior_summary: Vec::new(),
         theta: theta.to_vec(),
         theta_names: theta_names.iter().map(|s| s.to_string()).collect(),
         eta_names: eta_names.iter().map(|s| s.to_string()).collect(),

--- a/src/estimation/covariance.rs
+++ b/src/estimation/covariance.rs
@@ -1508,9 +1508,30 @@ pub(crate) fn scale_routed_covariance_method(
     n: usize,
     requested: CovarianceMethod,
     explicitly_set: bool,
+    has_priors: bool,
 ) -> (CovarianceMethod, Option<String>) {
     if n <= crate::types::COV_HESSIAN_MAX_DIM || requested != CovarianceMethod::Hessian {
         return (requested, None);
+    }
+    // #254: `S` is a sum of per-*subject* score cross-products, and a parameter
+    // prior has no subject decomposition — it contributes one score for the whole
+    // population, not N of them — so `S` cannot carry the prior's information at
+    // all. Auto-routing a priored fit onto it would silently report unpenalized
+    // standard errors for a penalized fit, which is the one thing the covariance
+    // wiring exists to prevent. Stay on `R` (which does carry the prior) and say
+    // why it will be slow, rather than being quietly wrong and fast.
+    if has_priors {
+        let stencil = n * (n + 1) / 2;
+        return (
+            requested,
+            Some(format!(
+                "covariance_method = r with {n} free parameters and parameter priors \
+                 declared: the R matrix is a finite-difference Hessian needing {stencil} \
+                 re-converged objective evaluations. The usual large-problem fallback \
+                 (`covariance_method = s`) cannot represent a prior, so it was not used. \
+                 Set `covariance = false` if this does not finish."
+            )),
+        );
     }
     let stencil = n * (n + 1) / 2;
     if explicitly_set {
@@ -1568,6 +1589,7 @@ pub(crate) fn run_covariance_step_inner(
         model.free_packed_dim(),
         options.covariance_method,
         options.covariance_method_set,
+        !model.priors.is_empty(),
     );
     if let Some(w) = scale_warning {
         warnings.push(w);
@@ -1665,7 +1687,7 @@ mod tests {
         ] {
             for explicit in [false, true] {
                 let (routed, warning) =
-                    scale_routed_covariance_method(COV_HESSIAN_MAX_DIM, method, explicit);
+                    scale_routed_covariance_method(COV_HESSIAN_MAX_DIM, method, explicit, false);
                 assert_eq!(routed, method);
                 assert!(
                     warning.is_none(),
@@ -1678,7 +1700,8 @@ mod tests {
     #[test]
     fn a_defaulted_hessian_routes_to_the_cross_product_at_scale() {
         let n = COV_HESSIAN_MAX_DIM + 1;
-        let (routed, warning) = scale_routed_covariance_method(n, CovarianceMethod::Hessian, false);
+        let (routed, warning) =
+            scale_routed_covariance_method(n, CovarianceMethod::Hessian, false, false);
         assert_eq!(routed, CovarianceMethod::CrossProduct);
         let warning = warning.expect("the substitution must be reported");
         assert!(warning.contains("score cross-product"), "{warning}");
@@ -1693,7 +1716,8 @@ mod tests {
     #[test]
     fn an_explicit_hessian_is_honoured_at_scale_but_warned_about() {
         let n = COV_HESSIAN_MAX_DIM + 1;
-        let (routed, warning) = scale_routed_covariance_method(n, CovarianceMethod::Hessian, true);
+        let (routed, warning) =
+            scale_routed_covariance_method(n, CovarianceMethod::Hessian, true, false);
         assert_eq!(
             routed,
             CovarianceMethod::Hessian,
@@ -1708,7 +1732,7 @@ mod tests {
         // `s` and `rsr` already cost one pass; the guard has nothing to say.
         for method in [CovarianceMethod::CrossProduct, CovarianceMethod::Sandwich] {
             let (routed, warning) =
-                scale_routed_covariance_method(COV_HESSIAN_MAX_DIM * 8, method, false);
+                scale_routed_covariance_method(COV_HESSIAN_MAX_DIM * 8, method, false, false);
             assert_eq!(routed, method);
             assert!(warning.is_none());
         }

--- a/src/estimation/covariance.rs
+++ b/src/estimation/covariance.rs
@@ -1142,6 +1142,28 @@ pub(crate) fn compute_covariance(
         }
     }
 
+    // ── Parameter-prior curvature (#254) ─────────────────────────────────────
+    //
+    // The reported SE is the curvature of the objective that was *minimised*, and
+    // under a prior that objective is `OFV_data + Σ((x−m)/s)²`. Leaving the prior
+    // out here would report the unpenalized curvature — wrong in exactly the
+    // regime the feature exists for, since a sparse fit's whole reason for
+    // carrying a prior is that the data alone does not identify the direction,
+    // and that is also where the unpenalized Hessian goes flat (rejected just
+    // below as "zero diagonal — flat objective") or non-PD.
+    //
+    // Added here rather than inside `cov_ofv` for two reasons: the penalty's
+    // second derivative is the exact constant `2/s²` (no stencil, no extra
+    // objective evaluations, no FD noise), and adding it post-assembly covers the
+    // analytic R-matrix route and the FD stencil route with one line instead of
+    // one each. It lands before the ill-conditioning diagnosis on purpose — a
+    // coordinate the prior identifies must read as curved, not as flat.
+    //
+    // Name it in the SE report, not just here: these are penalized-ML / MAP
+    // standard errors, not posterior SDs.
+    let cov_priors = crate::estimation::outer_optimizer::build_prior_set(model, template);
+    cov_priors.add_hessian(&mut |i, j, v| hess[(i, j)] += v);
+
     // Diagnose fatal Hessian problems. Use the FD-failure trackers for accurate
     // cause labels — post-hoc checks on `hess` would always read 0 (finite) because
     // non-finite FD results are never stored (only the zero initialisation remains).

--- a/src/estimation/covariance.rs
+++ b/src/estimation/covariance.rs
@@ -1727,6 +1727,59 @@ mod tests {
         assert!(warning.contains("covariance_method = r"), "{warning}");
     }
 
+    /// A priored fit at scale stays on `R` instead of being auto-routed to the
+    /// cross-product (#254).
+    ///
+    /// `S` is a sum of per-*subject* scores and a prior has no subject
+    /// decomposition, so the usual large-problem fallback would silently report
+    /// unpenalized standard errors for a penalized fit. The straddle is the
+    /// pair: identical `n` and identical `explicitly_set`, differing only in
+    /// `has_priors`, so the two arms land on *different* methods. Without both
+    /// sides this passes on an implementation that never routes at all.
+    #[test]
+    fn a_priored_fit_stays_on_the_hessian_at_scale() {
+        let n = COV_HESSIAN_MAX_DIM + 1;
+
+        let (routed, warning) =
+            scale_routed_covariance_method(n, CovarianceMethod::Hessian, false, true);
+        assert_eq!(
+            routed,
+            CovarianceMethod::Hessian,
+            "a prior must keep the covariance step on R"
+        );
+        let warning = warning.expect("staying on the slow estimator must be reported");
+        // The message has to say *why* the usual fallback was skipped, or the
+        // user reads it as the plain large-problem warning and switches to `s`
+        // by hand — which is the outcome this branch exists to prevent.
+        assert!(warning.contains("parameter priors"), "{warning}");
+        assert!(warning.contains("cannot represent a prior"), "{warning}");
+        // And the cost, as in the other two arms.
+        assert!(
+            warning.contains(&(n * (n + 1) / 2).to_string()),
+            "message must name the stencil size: {warning}"
+        );
+
+        // The straddle: same n, same `explicitly_set`, no prior — routed away.
+        let (unpriored, _) =
+            scale_routed_covariance_method(n, CovarianceMethod::Hessian, false, false);
+        assert_eq!(
+            unpriored,
+            CovarianceMethod::CrossProduct,
+            "without a prior the same inputs must still route to S"
+        );
+
+        // Below the threshold the prior changes nothing: the guard is about
+        // scale, and a small priored fit is not warned at all.
+        let (small, small_warning) = scale_routed_covariance_method(
+            COV_HESSIAN_MAX_DIM,
+            CovarianceMethod::Hessian,
+            false,
+            true,
+        );
+        assert_eq!(small, CovarianceMethod::Hessian);
+        assert!(small_warning.is_none(), "{small_warning:?}");
+    }
+
     #[test]
     fn a_non_hessian_request_is_never_rerouted() {
         // `s` and `rsr` already cost one pass; the guard has nothing to say.

--- a/src/estimation/fixed_eta_gradient_tests.rs
+++ b/src/estimation/fixed_eta_gradient_tests.rs
@@ -150,6 +150,7 @@ fn obs_nll_subject_grad_iov_matches_fd() {
 
     // Minimal IOV model: CL = TVCL·exp(ETA_CL + KAPPA_CL), V = TVV.
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "iov_grad_test".into(),
         pk_model: PkModel::OneCptIv,

--- a/src/estimation/gauss_newton.rs
+++ b/src/estimation/gauss_newton.rs
@@ -88,6 +88,11 @@ pub fn run_foce_gn(
     // curvature in the BHHH system; `ofv_clean` — the −2LL at the same point —
     // is what the trace, checkpoint, verbose lines and the reported OFV carry.
     let nn_reg = crate::estimation::nn_reg::NnRegularizer::build(model, population, options);
+    // Parameter priors (#254), on the same contract. Their curvature is an exact
+    // constant `2/s²` diagonal, so unlike the NN smoothness term there is no
+    // Gauss–Newton approximation involved — the BHHH system sees the true
+    // Hessian of this part of the objective.
+    let priors = crate::estimation::outer_optimizer::build_prior_set(model, init_params);
 
     // BHHH Information-matrix approximation degrades as the censoring fraction
     // grows — each censored row contributes less Fisher information than its
@@ -139,7 +144,7 @@ pub fn run_foce_gn(
             &kappas,
             options.interaction,
         );
-    let mut ofv = ofv_clean + nn_reg.penalty_value(&params.theta);
+    let mut ofv = ofv_clean + nn_reg.penalty_value(&params.theta) + priors.penalty(&x);
 
     if verbose {
         eprintln!("  GN iter {:>3}: OFV = {:.6}", 0, ofv_clean);
@@ -179,6 +184,13 @@ pub fn run_foce_gn(
             let theta_x = unpack_params(&x, init_params).theta;
             nn_reg.add_packed_gradient(&theta_x, grad.as_mut_slice());
             nn_reg.add_packed_hessian(&theta_x, &mut |i, j, v| h_bhhh[(i, j)] += v);
+        }
+        // Parameter priors (#254): same two contributions, already in packed
+        // space. Guarded on `is_active` for the same reason — an unpriored fit
+        // must take a byte-identical path.
+        if priors.is_active() {
+            priors.add_gradient(&x, grad.as_mut_slice());
+            priors.add_hessian(&mut |i, j, v| h_bhhh[(i, j)] += v);
         }
 
         // Zero gradient rows / BHHH rows & cols for FIX parameters, and set
@@ -294,7 +306,8 @@ pub fn run_foce_gn(
                 &kap_try,
                 options.interaction,
             );
-        let ofv_try = ofv_try_clean + nn_reg.penalty_value(&params_try.theta);
+        let ofv_try =
+            ofv_try_clean + nn_reg.penalty_value(&params_try.theta) + priors.penalty(&x_try);
 
         // TR ratio: actual OFV decrease vs quadratic model decrease.
         // rho < 0 or non-finite OFV → reject.
@@ -453,6 +466,7 @@ pub fn run_foce_gn(
     // penalized under covariate-NN regularization (see `FitResult::final_gradient`).
     let mut grad_final = grad_final.as_slice().to_vec();
     nn_reg.add_packed_gradient(&gn_params.theta, &mut grad_final);
+    priors.add_gradient(&x, &mut grad_final);
     let mut final_gradient: Option<Vec<f64>> = Some(grad_final);
 
     // Penalized: this is what the FOCEI polish below is ranked against.
@@ -556,7 +570,11 @@ pub fn run_foce_gn(
     // is added back before the compare — comparing clean against clean would
     // throw the regularized polish away whenever the penalty bit (a penalized
     // optimum's clean OFV is ≥ the unregularized GN optimum's by construction).
-    let polish_penalized = polish_result.ofv + nn_reg.penalty_value(&polish_result.params.theta);
+    let polish_penalized = polish_result.ofv
+        + nn_reg.penalty_value(&polish_result.params.theta)
+        + priors.penalty(&crate::estimation::parameterization::pack_params(
+            &polish_result.params,
+        ));
     if polish_penalized < gn_ofv {
         if verbose {
             eprintln!(
@@ -2076,6 +2094,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             name: "gn_test".into(),
             pk_model: PkModel::OneCptIv,
@@ -3139,6 +3158,7 @@ mod tests {
             mixture: None,
         };
         let model = CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             name: "gn_block_omega_test".into(),
             pk_model: PkModel::OneCptIv,
@@ -3433,6 +3453,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             name: "iov_gn_test".into(),
             pk_model: PkModel::OneCptIv,

--- a/src/estimation/importance_sampling.rs
+++ b/src/estimation/importance_sampling.rs
@@ -2828,6 +2828,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             has_conditional_eta_params: false,
             name: "frem_rb_iscale_test".into(),

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -669,6 +669,7 @@ fn make_iov_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "iov_test".into(),
         pk_model: PkModel::OneCptIv,
@@ -2989,6 +2990,7 @@ fn no_iov_1cpt_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "no_iov".into(),
         pk_model: PkModel::OneCptIv,
@@ -3143,6 +3145,7 @@ fn find_ebe_noniov_invariant_to_large_mu_shift() {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         frem_config: None,
         residual_error_eta: None,

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1156,6 +1156,7 @@ fn test_frem_jacobian_overrides_fd_with_exact_values() {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         has_conditional_eta_params: false,
         name: "frem_jac_test".into(),

--- a/src/estimation/mod.rs
+++ b/src/estimation/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod nn_reg;
 pub(crate) mod nn_theta_gradient;
 pub mod outer_optimizer;
 pub mod parameterization;
+pub(crate) mod priors;
 pub mod run_covariance;
 pub mod run_sir;
 pub mod saem;

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1113,6 +1113,7 @@ fn run_global_presearch(
     // distribution + NN architecture. A strict no-op when both λ are 0, so the
     // pre-search objective stays byte-identical for unregularized fits.
     let nn_reg = crate::estimation::nn_reg::NnRegularizer::build(model, population, options);
+    let priors = build_prior_set(model, init_params);
 
     // Helper: evaluate the FOCE OFV at a single point in scaled space,
     // independent of any NLopt state. Used to compute the user's initial
@@ -1131,7 +1132,7 @@ fn run_global_presearch(
             Some(&mu_k),
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
-        let raw = 2.0 * nll + nn_reg.penalty_value(&params.theta);
+        let raw = 2.0 * nll + nn_reg.penalty_value(&params.theta) + priors.penalty(&x);
         let guarded = ebe_guard_rejects(&ebe_stats, n_subj, raw, options.max_unconverged_frac);
         if !raw.is_finite() || guarded {
             1e20
@@ -1168,7 +1169,7 @@ fn run_global_presearch(
             Some(&mu_k),
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
-        let raw_ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta);
+        let raw_ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta) + priors.penalty(&x);
 
         let ebe_guard =
             ebe_guard_rejects(&ebe_stats, n_subj, raw_ofv, options.max_unconverged_frac);
@@ -1370,6 +1371,26 @@ pub(crate) const DIVERGENCE_OFV: f64 = 1e14;
 /// inner objective clamped).
 pub(crate) fn ofv_is_valid(ofv: f64) -> bool {
     ofv.is_finite() && ofv < DIVERGENCE_OFV
+}
+
+/// Resolve a model's declared parameter priors (#254) against `template`'s
+/// packed layout, for an optimizer that needs the penalty on its objective.
+///
+/// **The gate for a bad prior is [`crate::api::validation::check_model_data`],
+/// not this function.** `fit()` calls it before any optimizer runs and refuses
+/// the model with the same message `PriorSet::build` would produce here, so a
+/// prior that reaches this point has already been checked against the very
+/// `ModelParameters` layout passed in. An `Err` here therefore means the caller
+/// bypassed `fit()` entirely — `ferx-tools` driving an optimizer directly, or a
+/// unit test — and the safe answer is an empty set rather than a panic in a
+/// library. The gate is pinned by `fit_refuses_an_unresolvable_prior`; it is
+/// *not* a redundant second check of the same inputs, because failing open here
+/// is exactly what the gate exists to prevent.
+pub(crate) fn build_prior_set(
+    model: &CompiledModel,
+    template: &ModelParameters,
+) -> crate::estimation::priors::PriorSet {
+    crate::estimation::priors::PriorSet::build(model, template).unwrap_or_default()
 }
 
 pub(crate) fn resolve_outer_ftol(
@@ -1585,17 +1606,22 @@ fn optimize_nlopt(
 ) -> OuterResult {
     let first = optimize_nlopt_once(model, population, init_params, options, false);
     // The attempts minimised the *penalized* objective (covariate-NN
-    // regularization), so they are ranked on it too: `result.ofv` is the clean
-    // −2LL, and comparing that alone would prefer the less-regularized attempt —
-    // the opposite of what the penalty asks for. A no-op (`+ 0.0`) when
-    // unregularized.
+    // regularization, parameter priors), so they are ranked on it too:
+    // `result.ofv` is the clean −2LL, and comparing that alone would prefer the
+    // less-regularized attempt — the opposite of what the penalty asks for. A
+    // no-op (`+ 0.0`) when neither penalty is on.
     let nn_reg = crate::estimation::nn_reg::NnRegularizer::build(model, population, options);
+    let priors = build_prior_set(model, init_params);
     resolve_stall_retry(
         options.optimizer,
         options.verbose,
         first,
         || optimize_nlopt_once(model, population, init_params, options, true),
-        |result| result.ofv + nn_reg.penalty_value(&result.params.theta),
+        |result| {
+            result.ofv
+                + nn_reg.penalty_value(&result.params.theta)
+                + priors.penalty(&pack_params(&result.params))
+        },
     )
 }
 
@@ -1669,6 +1695,10 @@ fn optimize_nlopt_once(
     // the reported OFV/AIC/BIC) sees the clean −2LL, which is what `final_ofv`
     // recomputes from a fresh `pop_nll_opts` at the end.
     let nn_reg = crate::estimation::nn_reg::NnRegularizer::build(model, population, options);
+    // Parameter priors (#254) ride alongside on exactly the same contract: the
+    // optimizer minimises the penalized objective, everything user-facing keeps
+    // the clean −2LL, and `FitResult` reports the two halves separately.
+    let priors = build_prior_set(model, init_params);
 
     // Per-element scale factors: present O(1) coordinates to NLopt.
     //
@@ -1951,7 +1981,25 @@ fn optimize_nlopt_once(
         } else {
             nn_reg.penalty_and_gradient(&params.theta, &mut nn_grad)
         };
-        let raw_ofv = raw_ofv + nn_penalty;
+        // Parameter priors (#254). Unlike the NN penalty this is already a
+        // function of the packed vector, so there is nothing to map: `x` *is*
+        // the space the penalty is defined in, and `prior_grad` is spliced into
+        // `grad_raw` below without a change of variables.
+        //
+        // Value and gradient come from one call on purpose — see
+        // `PriorSet::penalty_and_gradient`. Taken separately, deleting only the
+        // gradient half left the whole integration suite green.
+        let mut prior_grad: Vec<f64> = if grad.is_some() && priors.is_active() {
+            vec![0.0; n]
+        } else {
+            Vec::new()
+        };
+        let prior_penalty = if prior_grad.is_empty() {
+            priors.penalty(&x)
+        } else {
+            priors.penalty_and_gradient(&x, &mut prior_grad)
+        };
+        let raw_ofv = raw_ofv + nn_penalty + prior_penalty;
 
         // EBE convergence guard: reject step when too many subjects unconverged or any
         // subject was hard-rejected at its inner start.
@@ -2045,6 +2093,13 @@ fn optimize_nlopt_once(
                 // `compute_scale` gives any |w| > 0.1 a non-unit scale.
                 for (gk, nk) in grad_raw.iter_mut().zip(&nn_grad) {
                     *gk += nk;
+                }
+                // Parameter priors (#254): `2(x−m)/s²` at the priored
+                // coordinates, computed above in the same pass as the value and
+                // already in packed-x space, so the `* scale[k]` chain rule
+                // below applies to it unchanged.
+                for (gk, pk) in grad_raw.iter_mut().zip(&prior_grad) {
+                    *gk += pk;
                 }
                 let mut sq = 0.0_f64;
                 for k in 0..g.len() {
@@ -2608,14 +2663,17 @@ fn optimize_bfgs(
     // reported OFV/AIC/BIC stay the unpenalized −2LL. The trace, checkpoint and
     // verbose `Iter` lines report the clean value too (`clean_ofv_at` below).
     let nn_reg = crate::estimation::nn_reg::NnRegularizer::build(model, population, options);
+    let priors = build_prior_set(model, init_params);
     // The −2LL behind a penalized objective value at scaled point `xs`: what the
     // user-facing streams print, so they agree with the reported `Final OFV`.
     let clean_ofv_at = |xs: &[f64], f_penalized: f64, scale: &[f64]| -> f64 {
-        if !nn_reg.is_active() {
+        if !nn_reg.is_active() && !priors.is_active() {
             return f_penalized;
         }
         let x_real: Vec<f64> = xs.iter().zip(scale).map(|(v, s)| v * s).collect();
-        f_penalized - nn_reg.penalty_value(&unpack_params(&x_real, init_params).theta)
+        f_penalized
+            - nn_reg.penalty_value(&unpack_params(&x_real, init_params).theta)
+            - priors.penalty(&x_real)
     };
 
     // Closures operating on unscaled real (log/Cholesky) space.
@@ -2642,7 +2700,7 @@ fn optimize_bfgs(
             Some(&mu_k),
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
-        let ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta);
+        let ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta) + priors.penalty(x);
         if ofv.is_finite() {
             ofv
         } else {
@@ -2683,6 +2741,9 @@ fn optimize_bfgs(
         // fits unchanged), in one pass. `ofv_at_fixed` above stays clean for
         // final reporting.
         let ofv = ofv + nn_reg.penalty_and_gradient(&params.theta, &mut g);
+        // Parameter priors (#254), value and gradient from one call, in the same
+        // packed space `g` is already expressed in.
+        let ofv = ofv + priors.penalty_and_gradient(x, &mut g);
         let f = if ofv.is_finite() { ofv } else { 1e20 };
         (f, g, ehs, hms)
     };

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1376,8 +1376,9 @@ pub(crate) fn ofv_is_valid(ofv: f64) -> bool {
 /// Resolve a model's declared parameter priors (#254) against `template`'s
 /// packed layout, for an optimizer that needs the penalty on its objective.
 ///
-/// **The gate for a bad prior is [`crate::api::validation::check_model_data`],
-/// not this function.** `fit()` calls it before any optimizer runs and refuses
+/// **The gate for a bad prior is
+/// [`crate::api::validation::check_parameter_priors`], not this function.**
+/// `api::fit::fit_inner` calls it before any optimizer runs and refuses
 /// the model with the same message `PriorSet::build` would produce here, so a
 /// prior that reaches this point has already been checked against the very
 /// `ModelParameters` layout passed in. An `Err` here therefore means the caller

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -1000,6 +1000,7 @@ fn make_model() -> CompiledModel {
         mixture: None,
     };
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "outer_test".into(),
         pk_model: PkModel::OneCptIv,
@@ -1303,6 +1304,7 @@ fn test_outer_ad_gradient_block_omega() {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "block_test".into(),
         pk_model: PkModel::OneCptIv,
@@ -1784,6 +1786,7 @@ fn test_compute_covariance_iov_runs_and_is_pd() {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         frem_config: None,
         residual_error_eta: None,

--- a/src/estimation/parameterization.rs
+++ b/src/estimation/parameterization.rs
@@ -2536,6 +2536,7 @@ mod tests {
             mixture: None,
         };
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             name: "test".into(),
             pk_model: PkModel::OneCptIv,

--- a/src/estimation/priors.rs
+++ b/src/estimation/priors.rs
@@ -47,8 +47,7 @@
 //! never meets a second convention.
 
 use crate::estimation::parameterization::{
-    coordinate_kinds, coordinate_names, packed_fixed_mask, packed_segments, theta_packs_log,
-    PackedCoordKind,
+    coordinate_names, lower_tri_iter, packed_fixed_mask, packed_segments, theta_packs_log,
 };
 use crate::types::{CompiledModel, ModelParameters, PriorSpread, PriorSummary};
 
@@ -385,95 +384,136 @@ struct CoordInfo {
 
 /// Describe every packed coordinate, in [`pack_params`] order.
 ///
-/// This is the one place the packed layout is walked for priors. It leans on
-/// [`coordinate_names`] and [`coordinate_kinds`] for the layout itself, so a
-/// future segment appears here automatically (as an unnamed, rejected
-/// coordinate) rather than being silently mis-indexed.
+/// This is the one place the packed layout is walked for priors. The Ω / Ω_IOV
+/// segments are walked with [`lower_tri_iter`] rather than by offset arithmetic,
+/// because for a **non-diagonal** Ω the packed index is a position in the
+/// column-major lower triangle and is *not* the eta index — so
+/// `omega_init_as_sd[i - omega_start]` reads the wrong flag (or runs off the
+/// end) the moment a `block_omega` is present. Walking the triangle gives each
+/// coordinate its real `(row, col)`, which is what both the scale lookup and the
+/// block test need.
 fn coordinate_table(model: &CompiledModel, template: &ModelParameters) -> Vec<CoordInfo> {
     let names = coordinate_names(template);
-    let kinds = coordinate_kinds(template);
     let segs = packed_segments(template);
-    let omega_start = segs.omega_start();
-    let sigma_start = segs.sigma_start();
-    let iov_start = segs.iov_start();
-    let iov_end = segs.mixture_omega_start();
+    let mut out: Vec<CoordInfo> = Vec::with_capacity(names.len());
 
-    let omega_is_block = !template.omega.diagonal;
-    let iov_is_block = template.omega_iov.as_ref().is_some_and(|m| !m.diagonal);
+    let name_at = |i: usize| names.get(i).cloned().unwrap_or_else(|| format!("#{i}"));
 
-    (0..names.len())
-        .map(|i| {
-            let kind = kinds.get(i).copied().unwrap_or(PackedCoordKind::Theta);
-            let (scale, rejection) = match kind {
-                PackedCoordKind::Theta => {
-                    let scale = if theta_packs_log(template.theta_lower[i]) {
-                        PriorScale::Log
-                    } else {
-                        PriorScale::Identity
-                    };
-                    (scale, None)
-                }
-                PackedCoordKind::OmegaOffDiagonal => (
-                    PriorScale::Identity,
-                    Some(
-                        "priors on a `block_omega` / `block_sigma` off-diagonal are not \
-                         supported. A correlated block needs an inverse-Wishart prior, \
-                         which v1 deliberately leaves out; declare the diagonal \
-                         variances separately to prior them."
-                            .to_string(),
-                    ),
+    // θ — the prior family follows the packing, which follows the lower bound.
+    for i in 0..segs.theta {
+        let scale = if theta_packs_log(template.theta_lower[i]) {
+            PriorScale::Log
+        } else {
+            PriorScale::Identity
+        };
+        out.push(CoordInfo {
+            coord: i,
+            name: name_at(i),
+            scale,
+            rejection: None,
+        });
+    }
+
+    // Ω, then (below) Ω_IOV: same shape, different `init_as_sd` table and
+    // different keyword in the diagnostic.
+    push_omega_coords(
+        &mut out,
+        &template.omega,
+        &model.omega_init_as_sd,
+        "block_omega",
+        &name_at,
+    );
+
+    // Σ — always diagonal, packed as `ln(SD)`; declared as a variance unless `(sd)`.
+    for s_i in 0..segs.sigma {
+        let i = out.len();
+        out.push(CoordInfo {
+            coord: i,
+            name: name_at(i),
+            scale: sd_or_var_scale(flag_at(&model.sigma_init_as_sd, s_i)),
+            rejection: None,
+        });
+    }
+
+    if let Some(iov) = template.omega_iov.as_ref() {
+        push_omega_coords(
+            &mut out,
+            iov,
+            &model.kappa_init_as_sd,
+            "block_kappa",
+            &name_at,
+        );
+    }
+
+    // Everything past here — `[mixture]` per-class Ω/Σ overrides and the
+    // `block_sigma` ρ coordinates — is out of scope for v1. Filling the tail
+    // generically means a future segment arrives as a *rejected* coordinate
+    // rather than being silently mis-indexed onto one of the tables above.
+    while out.len() < names.len() {
+        let i = out.len();
+        out.push(CoordInfo {
+            coord: i,
+            name: name_at(i),
+            scale: PriorScale::HalfLog,
+            rejection: Some(
+                "priors on a per-class `[mixture]` Ω/Σ override or a `block_sigma` \
+                 correlation are not supported."
+                    .to_string(),
+            ),
+        });
+    }
+    out
+}
+
+/// Append one Ω-family segment (Ω or Ω_IOV) to the coordinate table.
+///
+/// Block membership is decided **per coordinate**, not per matrix. A mixed model
+/// — `block_omega (A, B)` alongside a standalone `omega C ~ …` — is one
+/// non-diagonal `OmegaMatrix`, so a matrix-level `!diagonal` test rejects a prior
+/// on `C` even though `C` is an ordinary independent variance. That is exactly
+/// the arrangement the block diagnostic tells users to reach for ("declare the
+/// diagonal variances separately to prior them"), so getting it wrong makes the
+/// advice impossible to follow.
+///
+/// `free_mask` is what encodes the real structure: a diagonal `(e, e)` is inside
+/// a block iff some off-diagonal in its row or column is a *free* parameter.
+fn push_omega_coords(
+    out: &mut Vec<CoordInfo>,
+    om: &crate::types::OmegaMatrix,
+    init_as_sd: &[bool],
+    block_keyword: &str,
+    name_at: &dyn Fn(usize) -> String,
+) {
+    let n = om.dim();
+    for (r, c) in lower_tri_iter(n, om.diagonal) {
+        let i = out.len();
+        let (scale, rejection) = if r == c {
+            // `init_as_sd` is parallel to the *eta* list, so it is indexed by the
+            // row, never by the packed position.
+            let in_block = (0..n).any(|j| j != r && (om.free_mask[(r, j)] || om.free_mask[(j, r)]));
+            (
+                sd_or_var_scale(flag_at(init_as_sd, r)),
+                in_block.then(|| block_rejection(block_keyword)),
+            )
+        } else {
+            (
+                PriorScale::Identity,
+                Some(
+                    "priors on a `block_omega` / `block_sigma` off-diagonal are not \
+                     supported. A correlated block needs an inverse-Wishart prior, \
+                     which v1 deliberately leaves out; declare the diagonal \
+                     variances separately to prior them."
+                        .to_string(),
                 ),
-                PackedCoordKind::OmegaDiagonal => {
-                    // Which Ω family this diagonal belongs to decides both the
-                    // declared scale (`(sd)` vs the variance default) and
-                    // whether it sits inside a block.
-                    if i < sigma_start {
-                        let as_sd = flag_at(&model.omega_init_as_sd, i - omega_start);
-                        (
-                            sd_or_var_scale(as_sd),
-                            omega_is_block.then(|| block_rejection("block_omega")),
-                        )
-                    } else if i < iov_end {
-                        let as_sd = flag_at(&model.kappa_init_as_sd, i - iov_start);
-                        (
-                            sd_or_var_scale(as_sd),
-                            iov_is_block.then(|| block_rejection("block_kappa")),
-                        )
-                    } else {
-                        (
-                            PriorScale::HalfLog,
-                            Some(
-                                "priors on a per-class `[mixture]` Ω/Σ override are not \
-                                 supported."
-                                    .to_string(),
-                            ),
-                        )
-                    }
-                }
-                PackedCoordKind::Sigma => {
-                    if i < iov_start {
-                        let s = i - sigma_start;
-                        (sd_or_var_scale(flag_at(&model.sigma_init_as_sd, s)), None)
-                    } else {
-                        (
-                            PriorScale::HalfLog,
-                            Some(
-                                "priors on a per-class `[mixture]` Ω/Σ override are not \
-                                 supported."
-                                    .to_string(),
-                            ),
-                        )
-                    }
-                }
-            };
-            CoordInfo {
-                coord: i,
-                name: names[i].clone(),
-                scale,
-                rejection,
-            }
-        })
-        .collect()
+            )
+        };
+        out.push(CoordInfo {
+            coord: i,
+            name: name_at(i),
+            scale,
+            rejection,
+        });
+    }
 }
 
 fn block_rejection(kind: &str) -> String {

--- a/src/estimation/priors.rs
+++ b/src/estimation/priors.rs
@@ -1,0 +1,507 @@
+//! Per-parameter frequentist priors — penalized ML / MAP point estimation (#254).
+//!
+//! A prior is declared next to the parameter it constrains as a central value
+//! plus a relative uncertainty (`prior(0.15, rse = 25%)`), and contributes a
+//! quadratic penalty to the objective:
+//!
+//! ```text
+//! OFV_total = OFV_data + Σ_k ((x_k − m_k) / s_k)²
+//! ```
+//!
+//! # Why the penalty lives in packed space
+//!
+//! `x` here is the **packed** parameter vector — the optimizer's own
+//! coordinates ([`pack_params`](super::parameterization::pack_params)), not the
+//! natural values. Three things follow, and they are the whole reason this
+//! module is 200 lines rather than a new sensitivity kernel:
+//!
+//! - The gradient `2(x−m)/s²` and the Hessian `2/s²` are exact and closed form,
+//!   and the Hessian is a **constant** diagonal. Nothing here goes through
+//!   `sens/`, so no `Dual2` instantiation and no added monomorphization on a
+//!   compile path that is already 93% LLVM (#971).
+//! - The prior family falls out of the packing rather than being a second
+//!   convention: a θ with a non-negative lower bound packs as `ln θ`, so a
+//!   normal prior there *is* a lognormal prior on θ — which is exactly what the
+//!   issue asks for ("if the parameter is estimated on the log scale, apply the
+//!   prior on that scale"). An Ω diagonal packs as `ln(chol) = ln(SD) =
+//!   ½·ln(variance)`, so a normal prior there is a lognormal prior on the
+//!   variance, positive and symmetric with no matrix algebra.
+//! - Every consumer — the outer objective, the Gauss-Newton and trust-region
+//!   optimizers, and the covariance step — already works in packed space, so
+//!   there is one form of the penalty rather than one per caller.
+//!
+//! The coupling that buys: **a θ's prior family is decided by its declared lower
+//! bound**, so changing `theta HILL(1.0, 0.0, 5.0)` to `theta HILL(1.0, -5.0,
+//! 5.0)` silently moves its prior from lognormal to normal. That is real, and
+//! the mitigation is visibility rather than cleverness — [`PriorSummary`]
+//! reports the realised family and the implied natural-scale 95% interval for
+//! every priored parameter, so the flip shows up in the fit report instead of
+//! having to be inferred from the model file.
+//!
+//! # Scale convention
+//!
+//! **The prior's central value and spread are always on the scale the parameter
+//! was declared on.** `omega ETA_CL ~ 0.09 prior(0.09, rse = 40%)` reads its
+//! RSE off the *variance* row of a paper's parameter table; under `(sd)` both
+//! the declaration and the prior are SDs. The user never converts anything and
+//! never meets a second convention.
+
+use crate::estimation::parameterization::{
+    coordinate_kinds, coordinate_names, packed_fixed_mask, packed_segments, theta_packs_log,
+    PackedCoordKind,
+};
+use crate::types::{CompiledModel, ModelParameters, PriorSpread, PriorSummary};
+
+/// How a coordinate's **declared** value maps onto its packed value.
+///
+/// This is the single derivation of "what scale is this prior on", read by the
+/// mean, the spread, the reporting inverse and the 95% interval alike. Keeping
+/// it in one place is what stops the mean and the spread from disagreeing about
+/// whether a variance-declared Ω is on the log-SD or the log-variance scale —
+/// a disagreement that would be a factor of two and would still look plausible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PriorScale {
+    /// `packed = value`. A θ whose declared lower bound is negative.
+    Identity,
+    /// `packed = ln(value)`. A log-packed θ, or an Ω/Σ/κ declared `(sd)`.
+    Log,
+    /// `packed = ½·ln(value)`. An Ω/Σ/κ declared on the (default) variance
+    /// scale, whose packed coordinate is `ln(SD)`.
+    HalfLog,
+}
+
+impl PriorScale {
+    /// Declared value → packed coordinate.
+    pub(crate) fn to_packed(self, value: f64) -> f64 {
+        match self {
+            PriorScale::Identity => value,
+            PriorScale::Log => value.ln(),
+            PriorScale::HalfLog => 0.5 * value.ln(),
+        }
+    }
+
+    /// Packed coordinate → declared value. Exact inverse of [`Self::to_packed`].
+    pub(crate) fn from_packed(self, packed: f64) -> f64 {
+        match self {
+            PriorScale::Identity => packed,
+            PriorScale::Log => packed.exp(),
+            PriorScale::HalfLog => (2.0 * packed).exp(),
+        }
+    }
+
+    /// `d(packed) / d(ln value)` — the factor that carries a spread expressed
+    /// on the declared log scale onto the packed scale. `Identity` has no log
+    /// scale of its own and never uses this.
+    fn log_spread_factor(self) -> f64 {
+        match self {
+            PriorScale::Identity => 1.0,
+            PriorScale::Log => 1.0,
+            PriorScale::HalfLog => 0.5,
+        }
+    }
+
+    /// `true` when the parameter is strictly positive on its declared scale, so
+    /// a non-positive prior central value is a declaration error rather than a
+    /// legitimate point on the real line.
+    fn requires_positive(self) -> bool {
+        !matches!(self, PriorScale::Identity)
+    }
+
+    /// Human-readable family name for the fit report.
+    fn family(self) -> &'static str {
+        match self {
+            PriorScale::Identity => "normal",
+            PriorScale::Log | PriorScale::HalfLog => "lognormal",
+        }
+    }
+}
+
+/// One resolved prior: a packed coordinate plus the normal `(m, s)` that
+/// governs it there.
+#[derive(Debug, Clone)]
+pub(crate) struct PriorTerm {
+    /// Index into the packed parameter vector.
+    pub(crate) coord: usize,
+    /// Parameter name as declared, for diagnostics and the fit report.
+    pub(crate) name: String,
+    /// Prior mean, on the packed scale.
+    pub(crate) mean: f64,
+    /// Prior SD, on the packed scale. Strictly positive.
+    pub(crate) sd: f64,
+    /// How this coordinate's declared value maps to its packed value.
+    pub(crate) scale: PriorScale,
+    /// Prior central value as the user wrote it (declared scale), carried so
+    /// the report can echo it without inverting `mean`.
+    pub(crate) declared_value: f64,
+}
+
+/// Every prior in force for one fit, resolved against the packed layout.
+///
+/// Built once per estimation stage — never per objective evaluation — so the
+/// name resolution and the `ln`/`sqrt` conversions cost nothing on the hot path.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PriorSet {
+    terms: Vec<PriorTerm>,
+}
+
+impl PriorSet {
+    /// Resolve a model's declared priors against the packed layout of
+    /// `template`.
+    ///
+    /// Every rejection is an `Err` naming the parameter: a prior that cannot be
+    /// applied must stop the fit, because an unapplied prior returns a
+    /// plausible-looking unpenalized fit with nothing to say the prior was
+    /// dropped.
+    pub(crate) fn build(model: &CompiledModel, template: &ModelParameters) -> Result<Self, String> {
+        if model.priors.is_empty() {
+            return Ok(Self::default());
+        }
+        let coords = coordinate_table(model, template);
+        let fixed = packed_fixed_mask(template);
+        let mut terms: Vec<PriorTerm> = Vec::with_capacity(model.priors.len());
+
+        for prior in &model.priors {
+            let matches: Vec<&CoordInfo> = coords
+                .iter()
+                .filter(|c| c.name.eq_ignore_ascii_case(&prior.name))
+                .collect();
+            let info = match matches.as_slice() {
+                [] => {
+                    return Err(format!(
+                        "prior on `{}`: no theta, omega, sigma or kappa by that name. \
+                         A prior must name a parameter declared in `[parameters]`.",
+                        prior.name
+                    ))
+                }
+                [one] => *one,
+                // Two coordinates can share a name only via a `[mixture]`
+                // per-class override, which v1 rejects anyway — but resolving
+                // ambiguously would silently prior the wrong one.
+                _ => {
+                    return Err(format!(
+                        "prior on `{}`: the name resolves to {} packed coordinates; \
+                         priors on per-class `[mixture]` overrides are not supported.",
+                        prior.name,
+                        matches.len()
+                    ))
+                }
+            };
+
+            if let Some(reason) = info.rejection.as_deref() {
+                return Err(format!("prior on `{}`: {reason}", prior.name));
+            }
+            if fixed.get(info.coord).copied().unwrap_or(false) {
+                return Err(format!(
+                    "prior on `{}`: the parameter is FIXed, so the prior can never move it. \
+                     Drop the prior or drop the FIX.",
+                    prior.name
+                ));
+            }
+
+            let scale = info.scale;
+            // Finiteness first: `!(NaN > 0.0)` is `true`, so the positivity check
+            // below would otherwise report a `NaN` as "must be > 0" and point the
+            // user at the wrong problem.
+            if !prior.value.is_finite() {
+                return Err(format!(
+                    "prior on `{}`: central value must be finite, got {}.",
+                    prior.name, prior.value
+                ));
+            }
+            if scale.requires_positive() && !(prior.value > 0.0) {
+                return Err(format!(
+                    "prior on `{}`: central value must be > 0 on the declared scale \
+                     (this parameter is estimated on the log scale), got {}.",
+                    prior.name, prior.value
+                ));
+            }
+
+            let sd = packed_sd(&prior.name, prior.value, prior.spread, scale)?;
+            terms.push(PriorTerm {
+                coord: info.coord,
+                name: info.name.clone(),
+                mean: scale.to_packed(prior.value),
+                sd,
+                scale,
+                declared_value: prior.value,
+            });
+        }
+
+        // A second prior on the same coordinate would silently multiply the two
+        // densities, which is never what a duplicated line means.
+        terms.sort_by_key(|t| t.coord);
+        if let Some(w) = terms.windows(2).find(|w| w[0].coord == w[1].coord) {
+            return Err(format!(
+                "prior on `{}`: declared more than once.",
+                w[0].name
+            ));
+        }
+        Ok(Self { terms })
+    }
+
+    /// `true` when at least one prior is in force. Call sites use this to keep
+    /// an unpriored fit bit-identical to one built before this feature existed.
+    pub(crate) fn is_active(&self) -> bool {
+        !self.terms.is_empty()
+    }
+
+    /// `Σ ((x−m)/s)²` — the prior contribution to the OFV.
+    ///
+    /// Normalisation constants are omitted, matching the data side (ferx's OFV
+    /// already drops `N·log(2π)`). A priored ferx OFV is therefore not
+    /// absolutely comparable to a priored NONMEM OFV; compare ΔOFV against a
+    /// null twin.
+    pub(crate) fn penalty(&self, packed: &[f64]) -> f64 {
+        self.terms
+            .iter()
+            .map(|t| {
+                let z = (packed[t.coord] - t.mean) / t.sd;
+                z * z
+            })
+            .sum()
+    }
+
+    /// Add `∂penalty/∂x = 2(x−m)/s²` into `grad`, which must be in **packed**
+    /// (unscaled) space — the same space the likelihood gradient is assembled
+    /// in before the optimizer's `* scale[k]` chain rule.
+    pub(crate) fn add_gradient(&self, packed: &[f64], grad: &mut [f64]) {
+        for t in &self.terms {
+            grad[t.coord] += 2.0 * (packed[t.coord] - t.mean) / (t.sd * t.sd);
+        }
+    }
+
+    /// [`Self::penalty`] and [`Self::add_gradient`] in one call.
+    ///
+    /// Exists for the same reason `NnRegularizer::penalty_and_gradient` does,
+    /// plus a test-shaped one: at a call site that takes the value and the
+    /// gradient separately, deleting only the gradient half leaves an optimizer
+    /// minimising a penalized objective with an unpenalized gradient — a defect
+    /// no *outcome* assertion reliably catches, because the line search still
+    /// drags the estimate toward the prior, just badly. Measured: dropping the
+    /// splice in `outer_optimizer` left every integration test in
+    /// `tests/parameter_priors.rs` green. Binding the two together means one
+    /// mutation removes both, and `a_prior_moves_the_estimates_and_not_only_the_report`
+    /// then reddens.
+    pub(crate) fn penalty_and_gradient(&self, packed: &[f64], grad: &mut [f64]) -> f64 {
+        self.add_gradient(packed, grad);
+        self.penalty(packed)
+    }
+
+    /// Add `∂²penalty/∂x² = 2/s²` on the diagonal.
+    ///
+    /// Constant, so it takes no `packed` argument and needs no finite
+    /// differences: the covariance step adds it to the FD-of-OFV `R` matrix for
+    /// free. That matters — an SE computed from the *unpenalized* curvature is
+    /// wrong precisely on the sparse fits this feature exists for, and keeps
+    /// going non-PD in exactly the directions the prior was added to identify.
+    pub(crate) fn add_hessian(&self, add: &mut dyn FnMut(usize, usize, f64)) {
+        for t in &self.terms {
+            add(t.coord, t.coord, 2.0 / (t.sd * t.sd));
+        }
+    }
+
+    /// Per-parameter report at the final packed estimate.
+    pub(crate) fn summarize(&self, packed: &[f64]) -> Vec<PriorSummary> {
+        self.terms
+            .iter()
+            .map(|t| {
+                let x = packed[t.coord];
+                let z = (x - t.mean) / t.sd;
+                PriorSummary {
+                    name: t.name.clone(),
+                    prior_value: t.declared_value,
+                    estimate: t.scale.from_packed(x),
+                    shift_in_prior_sds: z,
+                    penalty: z * z,
+                    family: t.scale.family().to_string(),
+                    prior_lower_95: t.scale.from_packed(t.mean - 1.959_963_984_540_054 * t.sd),
+                    prior_upper_95: t.scale.from_packed(t.mean + 1.959_963_984_540_054 * t.sd),
+                }
+            })
+            .collect()
+    }
+}
+
+/// Convert a declared spread to a packed-scale SD.
+fn packed_sd(
+    name: &str,
+    value: f64,
+    spread: PriorSpread,
+    scale: PriorScale,
+) -> Result<f64, String> {
+    // An absolute SD on a log-packed coordinate is read as the relative spread
+    // it implies, so `sd = 0.03` on a value of 0.15 lands in exactly the same
+    // formula as `rse = 20%`. One conversion, not two that could disagree.
+    let rse = match spread {
+        PriorSpread::Rse(r) => r,
+        PriorSpread::Sd(s) => {
+            if !(s > 0.0) || !s.is_finite() {
+                return Err(format!(
+                    "prior on `{name}`: `sd` must be > 0 and finite, got {s}."
+                ));
+            }
+            if matches!(scale, PriorScale::Identity) {
+                // No log scale to relate to — the absolute SD *is* the packed SD.
+                return Ok(s);
+            }
+            s / value.abs()
+        }
+    };
+    if !(rse > 0.0) || !rse.is_finite() {
+        return Err(format!(
+            "prior on `{name}`: `rse` must be > 0 and finite, got {rse}."
+        ));
+    }
+    let sd = match scale {
+        // Normal prior on the natural scale: SD = |m| · RSE.
+        PriorScale::Identity => value.abs() * rse,
+        // Lognormal: the exact CV → log-SD conversion, then onto the packed
+        // scale (a factor ½ when the declaration is a variance and the packed
+        // coordinate is ln(SD)).
+        PriorScale::Log | PriorScale::HalfLog => {
+            (1.0 + rse * rse).ln().sqrt() * scale.log_spread_factor()
+        }
+    };
+    if !(sd > 0.0) || !sd.is_finite() {
+        return Err(format!(
+            "prior on `{name}`: the declared spread gives a non-positive or \
+             non-finite prior SD ({sd})."
+        ));
+    }
+    Ok(sd)
+}
+
+/// What one packed coordinate is, as far as a prior is concerned.
+struct CoordInfo {
+    coord: usize,
+    name: String,
+    scale: PriorScale,
+    /// `Some(reason)` when a prior on this coordinate is rejected in v1.
+    /// Carried per coordinate rather than tested at the use site so the scope
+    /// gate is a single predicate — two gates rejecting the same inputs is a
+    /// test hole, not belt-and-braces.
+    rejection: Option<String>,
+}
+
+/// Describe every packed coordinate, in [`pack_params`] order.
+///
+/// This is the one place the packed layout is walked for priors. It leans on
+/// [`coordinate_names`] and [`coordinate_kinds`] for the layout itself, so a
+/// future segment appears here automatically (as an unnamed, rejected
+/// coordinate) rather than being silently mis-indexed.
+fn coordinate_table(model: &CompiledModel, template: &ModelParameters) -> Vec<CoordInfo> {
+    let names = coordinate_names(template);
+    let kinds = coordinate_kinds(template);
+    let segs = packed_segments(template);
+    let omega_start = segs.omega_start();
+    let sigma_start = segs.sigma_start();
+    let iov_start = segs.iov_start();
+    let iov_end = segs.mixture_omega_start();
+
+    let omega_is_block = !template.omega.diagonal;
+    let iov_is_block = template.omega_iov.as_ref().is_some_and(|m| !m.diagonal);
+
+    (0..names.len())
+        .map(|i| {
+            let kind = kinds.get(i).copied().unwrap_or(PackedCoordKind::Theta);
+            let (scale, rejection) = match kind {
+                PackedCoordKind::Theta => {
+                    let scale = if theta_packs_log(template.theta_lower[i]) {
+                        PriorScale::Log
+                    } else {
+                        PriorScale::Identity
+                    };
+                    (scale, None)
+                }
+                PackedCoordKind::OmegaOffDiagonal => (
+                    PriorScale::Identity,
+                    Some(
+                        "priors on a `block_omega` / `block_sigma` off-diagonal are not \
+                         supported. A correlated block needs an inverse-Wishart prior, \
+                         which v1 deliberately leaves out; declare the diagonal \
+                         variances separately to prior them."
+                            .to_string(),
+                    ),
+                ),
+                PackedCoordKind::OmegaDiagonal => {
+                    // Which Ω family this diagonal belongs to decides both the
+                    // declared scale (`(sd)` vs the variance default) and
+                    // whether it sits inside a block.
+                    if i < sigma_start {
+                        let as_sd = flag_at(&model.omega_init_as_sd, i - omega_start);
+                        (
+                            sd_or_var_scale(as_sd),
+                            omega_is_block.then(|| block_rejection("block_omega")),
+                        )
+                    } else if i < iov_end {
+                        let as_sd = flag_at(&model.kappa_init_as_sd, i - iov_start);
+                        (
+                            sd_or_var_scale(as_sd),
+                            iov_is_block.then(|| block_rejection("block_kappa")),
+                        )
+                    } else {
+                        (
+                            PriorScale::HalfLog,
+                            Some(
+                                "priors on a per-class `[mixture]` Ω/Σ override are not \
+                                 supported."
+                                    .to_string(),
+                            ),
+                        )
+                    }
+                }
+                PackedCoordKind::Sigma => {
+                    if i < iov_start {
+                        let s = i - sigma_start;
+                        (sd_or_var_scale(flag_at(&model.sigma_init_as_sd, s)), None)
+                    } else {
+                        (
+                            PriorScale::HalfLog,
+                            Some(
+                                "priors on a per-class `[mixture]` Ω/Σ override are not \
+                                 supported."
+                                    .to_string(),
+                            ),
+                        )
+                    }
+                }
+            };
+            CoordInfo {
+                coord: i,
+                name: names[i].clone(),
+                scale,
+                rejection,
+            }
+        })
+        .collect()
+}
+
+fn block_rejection(kind: &str) -> String {
+    format!(
+        "the parameter belongs to a `{kind}`, whose elements are estimated as a \
+         Cholesky factor rather than as variances. Priors on block elements are \
+         not supported in v1."
+    )
+}
+
+fn sd_or_var_scale(declared_as_sd: bool) -> PriorScale {
+    if declared_as_sd {
+        PriorScale::Log
+    } else {
+        PriorScale::HalfLog
+    }
+}
+
+/// Read one `*_init_as_sd` flag, defaulting to the variance scale.
+///
+/// The flags live on [`CompiledModel`], parallel to the Ω diagonal / Σ / κ
+/// declarations, so they are indexed by the coordinate's offset **within its
+/// segment**, never by its packed index. Spelled once so the "missing flag means
+/// the variance default" fallback cannot drift between the three families.
+fn flag_at(flags: &[bool], within_segment: usize) -> bool {
+    flags.get(within_segment).copied().unwrap_or(false)
+}
+
+#[cfg(test)]
+#[path = "priors_tests.rs"]
+mod tests;

--- a/src/estimation/priors.rs
+++ b/src/estimation/priors.rs
@@ -490,7 +490,21 @@ fn push_omega_coords(
         let (scale, rejection) = if r == c {
             // `init_as_sd` is parallel to the *eta* list, so it is indexed by the
             // row, never by the packed position.
-            let in_block = (0..n).any(|j| j != r && (om.free_mask[(r, j)] || om.free_mask[(j, r)]));
+            // A *free* off-diagonal is the usual marker, but it is not the only
+            // one: a fixed non-zero covariance is still a covariance, and the
+            // packed coordinate for row `r > 0` of such a block is `ln(L[r,r])`,
+            // which is not `ln(SD_r)` (`SD_r² = Σⱼ L[r,j]²`) — so scaling a prior
+            // as if it were would be wrong with nothing to say so. Today
+            // `packed_fixed_mask` fixes the whole row/col of a FIXed eta, which
+            // makes the case unreachable; testing the matrix as well as the mask
+            // means this stays correct without depending on that.
+            let in_block = (0..n).any(|j| {
+                j != r
+                    && (om.free_mask[(r, j)]
+                        || om.free_mask[(j, r)]
+                        || om.matrix[(r, j)] != 0.0
+                        || om.matrix[(j, r)] != 0.0)
+            });
             (
                 sd_or_var_scale(flag_at(init_as_sd, r)),
                 in_block.then(|| block_rejection(block_keyword)),

--- a/src/estimation/priors_tests.rs
+++ b/src/estimation/priors_tests.rs
@@ -438,6 +438,56 @@ fn a_non_positive_spread_is_an_error() {
     }
 }
 
+/// A non-finite central value is rejected *before* the positivity check, and
+/// says so in those words.
+///
+/// The ordering is the point: `!(NaN > 0.0)` is `true`, so a positivity test
+/// reached first would report a `NaN` as "must be > 0" and send the user looking
+/// at the sign of a value that has no sign. Asserted on the message, not merely
+/// on `is_err`, because both branches return `Err` and only the text
+/// distinguishes them.
+#[test]
+fn a_non_finite_central_value_is_rejected_as_non_finite() {
+    for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+        let f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", value, PriorSpread::Rse(0.2));
+        let msg = err_of(&f);
+        assert!(
+            msg.contains("finite"),
+            "{value}: must be reported as non-finite, not as non-positive: {msg}"
+        );
+    }
+
+    // The straddle: the same coordinate with a finite positive value resolves,
+    // so the check rejects non-finiteness rather than every value.
+    assert!(Fixture::new(0.2, 0.001, 0.1, 0.1)
+        .with_prior("TVCL", 0.15, PriorSpread::Rse(0.2))
+        .build()
+        .is_ok());
+}
+
+/// A non-finite *spread* is rejected in both spellings.
+///
+/// `a_non_positive_spread_is_an_error` covers zero and negative; these are the
+/// values that pass `> 0` and would otherwise produce an `sd` of `NaN` or `inf`
+/// — a penalty that is silently zero (`z = finite/inf`) or `NaN` for the whole
+/// fit, neither of which any outcome assertion would attribute to the prior.
+#[test]
+fn a_non_finite_spread_is_an_error() {
+    for spread in [
+        PriorSpread::Rse(f64::NAN),
+        PriorSpread::Rse(f64::INFINITY),
+        PriorSpread::Sd(f64::NAN),
+        PriorSpread::Sd(f64::INFINITY),
+    ] {
+        let f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, spread);
+        let msg = err_of(&f);
+        assert!(
+            msg.contains("finite") || msg.contains("> 0"),
+            "{spread:?}: {msg}"
+        );
+    }
+}
+
 /// A `block_omega` element has no variance of its own to prior — the packed
 /// coordinates are Cholesky entries — so v1 rejects it by name rather than
 /// priding a Cholesky diagonal as if it were a variance.

--- a/src/estimation/priors_tests.rs
+++ b/src/estimation/priors_tests.rs
@@ -454,6 +454,53 @@ fn a_prior_on_a_block_omega_element_is_an_error() {
     assert!(msg.contains("block_omega"), "{msg}");
 }
 
+/// Block membership is a property of the **matrix**, not only of the free mask.
+///
+/// A fixed non-zero covariance is still a covariance: the packed coordinate for
+/// row `r > 0` of such a block is `ln(L[r,r])`, and `SD_r² = Σⱼ L[r,j]²`, so
+/// scaling a prior there as if `L[r,r]` were the SD is wrong with nothing in the
+/// output to say so. Today `packed_fixed_mask` fixes the whole row and column of
+/// a FIXed eta, which makes the arrangement unreachable through the parser — so
+/// this is built directly, and it is the reason the predicate consults
+/// `om.matrix` rather than resting on that coupling.
+///
+/// Deleting the `om.matrix` clause from `in_block` reddens the first half here
+/// and nothing else in the suite.
+#[test]
+fn a_prior_on_a_block_diagonal_with_a_fixed_covariance_is_an_error() {
+    // ETA_CL ~ ETA_V correlated, but the off-diagonal is *not* a free parameter:
+    // `free_mask` is the identity while the matrix is genuinely non-diagonal.
+    let fixed_cov = |off: f64| -> Fixture {
+        let mut f = Fixture::new(0.2, 0.001, 0.1, 0.1);
+        let m = nalgebra::DMatrix::from_row_slice(2, 2, &[0.09, off, off, 0.20]);
+        let mut free = nalgebra::DMatrix::from_element(2, 2, false);
+        free[(0, 0)] = true;
+        free[(1, 1)] = true;
+        f.model.default_params.omega = OmegaMatrix::from_matrix_with_mask(
+            m,
+            vec!["ETA_CL".into(), "ETA_V".into()],
+            false,
+            free,
+        );
+        f.model.default_params.omega_fixed = vec![false, false];
+        f.model.omega_init_as_sd = vec![false, false];
+        f.with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4))
+    };
+
+    let err = fixed_cov(0.02)
+        .build()
+        .expect_err("a diagonal correlated by a fixed covariance is a block member");
+    assert!(err.contains("block_omega"), "{err}");
+
+    // The straddle: the identical shape with a *zero* off-diagonal is an ordinary
+    // independent variance and resolves. Without this the first half is satisfied
+    // by a predicate that rejects every non-`diagonal` matrix outright, which is
+    // the mixed-Ω regression the test above this one exists to prevent.
+    fixed_cov(0.0)
+        .build()
+        .expect("an uncorrelated diagonal must still resolve");
+}
+
 /// A **mixed** Ω — `block_omega (A, B)` alongside an independent `omega C` — is a
 /// single non-diagonal matrix, so a matrix-level `!diagonal` test rejects a prior
 /// on `C` even though `C` is an ordinary uncorrelated variance.

--- a/src/estimation/priors_tests.rs
+++ b/src/estimation/priors_tests.rs
@@ -1,0 +1,455 @@
+//! Tier-1 tests for the parameter-prior penalty (#254).
+//!
+//! Every assertion here pins a **hand-computed** number rather than a tolerance
+//! picked from a run: the penalty is three lines of closed-form algebra, so an
+//! oracle outside the implementation is a pocket calculator, not a second
+//! engine. Where a bound is used it is a finite-difference comparison, and the
+//! realised worst error is recorded in the comment next to it.
+
+use super::*;
+use crate::estimation::parameterization::pack_params;
+use crate::types::{
+    GradientMethod, ModelParameters, OmegaMatrix, ParameterPrior, PriorSpread, SigmaVector,
+};
+
+/// `sqrt(ln(1 + 0.4²))` — the exact CV → log-SD conversion at RSE = 40%, which
+/// every Ω assertion below is built from. Spelled once so a test that disagrees
+/// with the implementation disagrees about the *formula*, not about a typo.
+const TAU_40: f64 = 0.385_253_170_159_926_7;
+
+/// A one-θ / one-η / one-σ analytical model whose parameter values, bounds and
+/// declared scales the caller chooses. Everything the prior code reads comes
+/// from here; nothing else about the model matters, because `PriorSet::build`
+/// touches only the packed layout and the `*_init_as_sd` flags.
+struct Fixture {
+    model: CompiledModel,
+}
+
+impl Fixture {
+    /// θ = `theta`, lower bound `theta_lower` (this is what decides whether the
+    /// θ prior is lognormal or normal), Ω variance `omega_var`, σ SD `sigma_sd`.
+    fn new(theta: f64, theta_lower: f64, omega_var: f64, sigma_sd: f64) -> Self {
+        let mut model = crate::types::test_helpers::analytical_model(GradientMethod::Auto);
+        model.default_params = ModelParameters {
+            theta: vec![theta],
+            theta_names: vec!["TVCL".into()],
+            theta_lower: vec![theta_lower],
+            theta_upper: vec![1e9],
+            theta_fixed: vec![false],
+            omega: OmegaMatrix::from_diagonal(&[omega_var], vec!["ETA_CL".into()]),
+            omega_fixed: vec![false],
+            sigma: SigmaVector {
+                values: vec![sigma_sd],
+                names: vec!["PROP_ERR".into()],
+            },
+            sigma_fixed: vec![false],
+            residual_correlations: Vec::new(),
+            residual_correlation_fixed: Vec::new(),
+            omega_iov: None,
+            kappa_fixed: Vec::new(),
+            mixture: None,
+        };
+        model.omega_init_as_sd = vec![false];
+        model.sigma_init_as_sd = vec![false];
+        Self { model }
+    }
+
+    fn with_prior(mut self, name: &str, value: f64, spread: PriorSpread) -> Self {
+        self.model.priors.push(ParameterPrior {
+            name: name.into(),
+            value,
+            spread,
+        });
+        self
+    }
+
+    fn omega_declared_as_sd(mut self) -> Self {
+        self.model.omega_init_as_sd = vec![true];
+        self
+    }
+
+    fn sigma_declared_as_sd(mut self) -> Self {
+        self.model.sigma_init_as_sd = vec![true];
+        self
+    }
+
+    fn params(&self) -> &ModelParameters {
+        &self.model.default_params
+    }
+
+    fn build(&self) -> Result<PriorSet, String> {
+        PriorSet::build(&self.model, &self.model.default_params)
+    }
+
+    fn set(&self) -> PriorSet {
+        self.build().expect("prior set should build")
+    }
+
+    fn packed(&self) -> Vec<f64> {
+        pack_params(self.params())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The closed forms
+// ---------------------------------------------------------------------------
+
+/// A θ with a non-negative lower bound packs as `ln θ`, so its prior is
+/// lognormal on θ with `m = ln(value)` and `s = sqrt(ln(1 + rse²))`.
+///
+/// Catches: a prior applied on the natural θ scale while the optimizer moves
+/// `ln θ` — which would still produce a plausible, monotone penalty and a fit
+/// that "looks regularized" while pulling toward the wrong point.
+#[test]
+fn log_packed_theta_prior_is_lognormal_on_theta() {
+    // θ̂ = 0.2, prior centred at 0.15 with RSE 40%.
+    let f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, PriorSpread::Rse(0.4));
+    let set = f.set();
+    let packed = f.packed();
+
+    // z = ln(0.2 / 0.15) / TAU_40 = 0.2876820724 / 0.3852531702 = 0.7467351205
+    let z = (0.2f64 / 0.15).ln() / TAU_40;
+    assert!((set.penalty(&packed) - z * z).abs() < 1e-12);
+    // Hand-computed, so the test disagrees with a wrong implementation rather
+    // than with itself: z² = 0.5576133402
+    assert!((set.penalty(&packed) - 0.557_613_340_2).abs() < 1e-8);
+
+    // At the prior mean the penalty is exactly zero — no floating-point slop,
+    // because `to_packed` is the exact inverse the packer uses.
+    let at_mean =
+        Fixture::new(0.15, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, PriorSpread::Rse(0.4));
+    assert_eq!(at_mean.set().penalty(&at_mean.packed()), 0.0);
+}
+
+/// A θ whose declared lower bound is negative packs as the identity, so its
+/// prior is normal on θ with `s = |value|·rse`.
+///
+/// This is the pair to the test above: the two straddle `theta_packs_log`, so a
+/// change that collapses the two families to one reddens exactly one of them.
+#[test]
+fn identity_packed_theta_prior_is_normal_on_theta() {
+    // Prior mean 0.5, RSE 40% → s = 0.2. θ̂ = 0.7 sits exactly one prior SD out.
+    let f = Fixture::new(0.7, -5.0, 0.1, 0.1).with_prior("TVCL", 0.5, PriorSpread::Rse(0.4));
+    let set = f.set();
+    assert!((set.penalty(&f.packed()) - 1.0).abs() < 1e-12);
+
+    // And the straddle is real rather than assumed: the same numbers on a
+    // non-negative lower bound take the *other* arm and give a different
+    // penalty. Without this the pair could quietly become a tautology.
+    let logged = Fixture::new(0.7, 0.0, 0.1, 0.1).with_prior("TVCL", 0.5, PriorSpread::Rse(0.4));
+    let logged_pen = logged.set().penalty(&logged.packed());
+    assert!(
+        (logged_pen - 1.0).abs() > 0.1,
+        "log-packed θ must not coincide with the identity-packed penalty; got {logged_pen}"
+    );
+    // ln(0.7/0.5)/TAU_40 = 0.3364722366 / 0.3852531702 = 0.8733795402, squared.
+    assert!((logged_pen - 0.762_791_821_3).abs() < 1e-8);
+}
+
+/// An Ω declared on the (default) variance scale gets a lognormal prior on the
+/// **variance**, even though the packed coordinate is `ln(SD)`.
+///
+/// Catches: the ½ that relates `ln(SD)` to `ln(variance)` being dropped from the
+/// mean, from the spread, or from both.
+#[test]
+fn variance_declared_omega_prior_is_lognormal_on_the_variance() {
+    // Ω̂ = 0.16 (SD 0.4), prior centred on a variance of 0.09 at RSE 40%.
+    let f = Fixture::new(0.2, 0.001, 0.16, 0.1).with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4));
+    let set = f.set();
+    // z = ln(0.16 / 0.09) / TAU_40 = 0.5753641449 / 0.3852531702 = 1.4934702410
+    let z = (0.16f64 / 0.09).ln() / TAU_40;
+    assert!((set.penalty(&f.packed()) - z * z).abs() < 1e-12);
+    assert!((set.penalty(&f.packed()) - 2.230_453_360_9).abs() < 1e-8);
+}
+
+/// The same underlying Ω, declared as an SD instead of a variance, with the
+/// same numeric RSE, is a **different** prior — an RSE of 40% on a variance is
+/// roughly an RSE of 20% on the SD.
+///
+/// This is the differential pair for `omega_init_as_sd`. Both fixtures describe
+/// the identical model (variance 0.16, SD 0.4) and the identical prior location
+/// (variance 0.09, SD 0.3), so the only thing that can move the penalty is which
+/// scale the declaration was on. The ratio is exactly 4 because the log-distance
+/// on the variance scale is exactly twice the log-distance on the SD scale.
+///
+/// Catches: `flag_at` ignored, or the Ω scale hard-coded to one of the two arms.
+#[test]
+fn sd_declared_omega_is_a_different_prior_from_the_variance_declaration() {
+    let as_var =
+        Fixture::new(0.2, 0.001, 0.16, 0.1).with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4));
+    let as_sd = Fixture::new(0.2, 0.001, 0.16, 0.1)
+        .omega_declared_as_sd()
+        .with_prior("ETA_CL", 0.3, PriorSpread::Rse(0.4));
+
+    let pen_var = as_var.set().penalty(&as_var.packed());
+    let pen_sd = as_sd.set().penalty(&as_sd.packed());
+
+    // ln(0.4/0.3)/TAU_40 = 0.2876820724 / 0.3852531702 = 0.7467351205, squared.
+    assert!((pen_sd - 0.557_613_340_2).abs() < 1e-8);
+    assert!(
+        (pen_var / pen_sd - 4.0).abs() < 1e-9,
+        "{pen_var} vs {pen_sd}"
+    );
+}
+
+/// σ is stored internally on the SD scale but declared as a variance by
+/// default, so it needs the same two arms Ω does — and gets them from the same
+/// `flag_at` call, which is why this test exists to pin that σ is wired up at
+/// all rather than silently defaulting.
+#[test]
+fn sigma_honours_its_declared_scale() {
+    // Stored σ is an SD of 0.4, i.e. a declared variance of 0.16.
+    let as_var =
+        Fixture::new(0.2, 0.001, 0.1, 0.4).with_prior("PROP_ERR", 0.09, PriorSpread::Rse(0.4));
+    let as_sd = Fixture::new(0.2, 0.001, 0.1, 0.4)
+        .sigma_declared_as_sd()
+        .with_prior("PROP_ERR", 0.3, PriorSpread::Rse(0.4));
+
+    let pen_var = as_var.set().penalty(&as_var.packed());
+    let pen_sd = as_sd.set().penalty(&as_sd.packed());
+    assert!((pen_var - 2.230_453_360_9).abs() < 1e-8);
+    assert!((pen_sd - 0.557_613_340_2).abs() < 1e-8);
+}
+
+/// `sd = <absolute>` on a log-packed coordinate is sugar for the equivalent
+/// RSE, so the two spellings must coincide exactly rather than approximately.
+#[test]
+fn absolute_sd_matches_the_equivalent_rse_on_a_log_packed_coordinate() {
+    let by_rse = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, PriorSpread::Rse(0.2));
+    // 0.03 / 0.15 == 0.2.
+    let by_sd = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, PriorSpread::Sd(0.03));
+    assert_eq!(
+        by_rse.set().penalty(&by_rse.packed()),
+        by_sd.set().penalty(&by_sd.packed())
+    );
+}
+
+/// On an identity-packed θ there is no log scale to relate to, so `sd` is the
+/// packed SD directly — the one place the two spellings are *not* related by a
+/// division.
+#[test]
+fn absolute_sd_on_an_identity_packed_theta_is_the_packed_sd() {
+    // θ̂ = 0.7, prior mean 0.5, sd 0.2 → exactly one prior SD out.
+    let f = Fixture::new(0.7, -5.0, 0.1, 0.1).with_prior("TVCL", 0.5, PriorSpread::Sd(0.2));
+    assert!((f.set().penalty(&f.packed()) - 1.0).abs() < 1e-12);
+}
+
+// ---------------------------------------------------------------------------
+// Derivatives
+// ---------------------------------------------------------------------------
+
+/// The analytic gradient and Hessian must agree with central finite differences
+/// of `penalty` itself.
+///
+/// This is the parity check the repo requires of every derivative path. It is a
+/// genuine oracle here because `penalty` and `add_gradient` share no code — the
+/// former squares a z-score, the latter differentiates it by hand — so a sign
+/// error or a missing factor of two in either shows up.
+///
+/// Realised worst error over the three priored coordinates, measured by running
+/// this test: gradient **2.12e-10**, Hessian **2.48e-5**. Central FD of a
+/// quadratic has no truncation error, so both are pure round-off — and the
+/// Hessian's is five orders larger than the gradient's only because the second
+/// difference divides by `h²`, cancelling ~10 significant digits at `h = 1e-5`.
+/// Bounds below are set ~4x above each realised value.
+#[test]
+fn gradient_and_hessian_match_central_finite_differences() {
+    let f = Fixture::new(0.2, 0.001, 0.16, 0.4)
+        .with_prior("TVCL", 0.15, PriorSpread::Rse(0.4))
+        .with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4))
+        .with_prior("PROP_ERR", 0.09, PriorSpread::Rse(0.25));
+    let set = f.set();
+    let x = f.packed();
+    assert_eq!(set.summarize(&x).len(), 3);
+
+    let mut analytic = vec![0.0; x.len()];
+    set.add_gradient(&x, &mut analytic);
+
+    let mut hess = vec![0.0; x.len()];
+    set.add_hessian(&mut |i, j, v| {
+        assert_eq!(i, j, "the prior Hessian must be diagonal");
+        hess[i] += v;
+    });
+
+    let h = 1e-5;
+    let mut worst_grad = 0.0f64;
+    let mut worst_hess = 0.0f64;
+    for k in 0..x.len() {
+        let mut up = x.clone();
+        let mut dn = x.clone();
+        up[k] += h;
+        dn[k] -= h;
+        let (fu, fd, f0) = (set.penalty(&up), set.penalty(&dn), set.penalty(&x));
+        // `is_finite` before folding: `f64::max` swallows a NaN, so a solver
+        // returning NaN would otherwise leave `worst` at whatever the healthy
+        // coordinates produced and the bound would pass on their strength.
+        let g_fd = (fu - fd) / (2.0 * h);
+        let h_fd = (fu - 2.0 * f0 + fd) / (h * h);
+        assert!(g_fd.is_finite() && h_fd.is_finite(), "FD at coord {k}");
+        worst_grad = worst_grad.max((analytic[k] - g_fd).abs());
+        worst_hess = worst_hess.max((hess[k] - h_fd).abs());
+    }
+    assert!(worst_grad < 1e-8, "worst gradient error {worst_grad}");
+    assert!(worst_hess < 1e-4, "worst Hessian error {worst_hess}");
+
+    // The Hessian is a *constant* `2/s²`, which is what lets the covariance step
+    // add it without extra objective evaluations. Pin that it does not depend on
+    // the point, since an implementation that recomputed it at `x` would also
+    // pass the FD check above.
+    let far: Vec<f64> = x.iter().map(|v| v + 3.0).collect();
+    let mut hess_far = vec![0.0; x.len()];
+    set.add_hessian(&mut |i, _, v| hess_far[i] += v);
+    assert_eq!(hess, hess_far);
+    let _ = far;
+}
+
+/// `penalty_and_gradient` must be exactly `penalty` plus `add_gradient`.
+///
+/// The combined form exists so an optimizer cannot take the value without the
+/// gradient — a defect that leaves the suite green because the line search still
+/// crawls toward the prior. That only helps if the two forms agree, so this pins
+/// it bit-for-bit rather than to a tolerance.
+#[test]
+fn penalty_and_gradient_is_exactly_the_two_separate_calls() {
+    let f = Fixture::new(0.2, 0.001, 0.16, 0.4)
+        .with_prior("TVCL", 0.15, PriorSpread::Rse(0.4))
+        .with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4));
+    let set = f.set();
+    let x = f.packed();
+
+    let mut separate = vec![0.25; x.len()];
+    set.add_gradient(&x, &mut separate);
+    let mut combined = vec![0.25; x.len()];
+    let value = set.penalty_and_gradient(&x, &mut combined);
+
+    assert_eq!(value, set.penalty(&x));
+    assert_eq!(combined, separate);
+    // And it must have written something, or the equality above is two
+    // untouched copies of the same initial vector.
+    assert_ne!(combined, vec![0.25; x.len()]);
+}
+
+/// An unpriored model must leave the objective and the gradient bit-identical
+/// to what they were before this feature existed.
+#[test]
+fn an_unpriored_model_is_a_strict_noop() {
+    let f = Fixture::new(0.2, 0.001, 0.1, 0.1);
+    let set = f.set();
+    assert!(!set.is_active());
+    assert_eq!(set.penalty(&f.packed()), 0.0);
+    let mut grad = vec![0.5; f.packed().len()];
+    set.add_gradient(&f.packed(), &mut grad);
+    assert_eq!(grad, vec![0.5; f.packed().len()]);
+    let mut touched = false;
+    set.add_hessian(&mut |_, _, _| touched = true);
+    assert!(!touched);
+}
+
+// ---------------------------------------------------------------------------
+// Reporting
+// ---------------------------------------------------------------------------
+
+/// The report echoes the prior on the declared scale and the estimate on that
+/// same scale, so a reader never has to know what the packed coordinate was.
+#[test]
+fn summary_reports_declared_scale_values_and_the_standardized_shift() {
+    let f = Fixture::new(0.2, 0.001, 0.16, 0.1)
+        .with_prior("TVCL", 0.15, PriorSpread::Rse(0.4))
+        .with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4));
+    let rows = f.set().summarize(&f.packed());
+    assert_eq!(rows.len(), 2);
+
+    let theta = &rows[0];
+    assert_eq!(theta.name, "TVCL");
+    assert_eq!(theta.prior_value, 0.15);
+    assert!((theta.estimate - 0.2).abs() < 1e-12);
+    assert_eq!(theta.family, "lognormal");
+    assert!((theta.shift_in_prior_sds - 0.746_735_120_5).abs() < 1e-6);
+    assert!((theta.penalty - 0.557_613_340_2).abs() < 1e-8);
+    // 95% interval on the declared scale: 0.15·exp(±1.96·TAU_40).
+    assert!((theta.prior_lower_95 - 0.15 * (-1.959_963_985 * TAU_40).exp()).abs() < 1e-9);
+
+    // The Ω row reports the **variance**, because that is how it was declared —
+    // reporting `ln(SD)` or the SD here would be a silent scale change between
+    // the model file and the report.
+    let omega = &rows[1];
+    assert_eq!(omega.name, "ETA_CL");
+    assert_eq!(omega.prior_value, 0.09);
+    assert!((omega.estimate - 0.16).abs() < 1e-12);
+
+    // The per-parameter penalties must add up to the total, or the split shown
+    // to the user does not reconcile with the reported `ofv_prior`.
+    let total: f64 = rows.iter().map(|r| r.penalty).sum();
+    assert!((total - f.set().penalty(&f.packed())).abs() < 1e-12);
+}
+
+// ---------------------------------------------------------------------------
+// Rejections — each must be an error, never a silently dropped prior
+// ---------------------------------------------------------------------------
+
+fn err_of(f: &Fixture) -> String {
+    f.build().expect_err("expected this prior to be rejected")
+}
+
+#[test]
+fn a_prior_on_an_unknown_parameter_is_an_error() {
+    let f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("NOPE", 1.0, PriorSpread::Rse(0.2));
+    assert!(err_of(&f).contains("NOPE"), "{}", err_of(&f));
+}
+
+#[test]
+fn a_prior_on_a_fixed_parameter_is_an_error() {
+    let mut f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, PriorSpread::Rse(0.2));
+    f.model.default_params.theta_fixed = vec![true];
+    let msg = err_of(&f);
+    assert!(msg.contains("FIX"), "{msg}");
+}
+
+#[test]
+fn a_prior_declared_twice_is_an_error() {
+    let f = Fixture::new(0.2, 0.001, 0.1, 0.1)
+        .with_prior("TVCL", 0.15, PriorSpread::Rse(0.2))
+        .with_prior("TVCL", 0.16, PriorSpread::Rse(0.3));
+    assert!(err_of(&f).contains("more than once"), "{}", err_of(&f));
+}
+
+#[test]
+fn a_non_positive_central_value_on_a_log_packed_coordinate_is_an_error() {
+    let f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.0, PriorSpread::Rse(0.2));
+    assert!(err_of(&f).contains("> 0"), "{}", err_of(&f));
+
+    // …but the same value is fine on an identity-packed θ, where zero is an
+    // ordinary point on the real line. Without this half the check could be
+    // "reject zero everywhere" and still pass.
+    let ok = Fixture::new(0.2, -5.0, 0.1, 0.1).with_prior("TVCL", 0.0, PriorSpread::Sd(0.1));
+    assert!(ok.build().is_ok());
+}
+
+#[test]
+fn a_non_positive_spread_is_an_error() {
+    for spread in [
+        PriorSpread::Rse(0.0),
+        PriorSpread::Rse(-0.2),
+        PriorSpread::Sd(0.0),
+    ] {
+        let f = Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("TVCL", 0.15, spread);
+        let msg = err_of(&f);
+        assert!(msg.contains("> 0"), "{spread:?}: {msg}");
+    }
+}
+
+/// A `block_omega` element has no variance of its own to prior — the packed
+/// coordinates are Cholesky entries — so v1 rejects it by name rather than
+/// priding a Cholesky diagonal as if it were a variance.
+#[test]
+fn a_prior_on_a_block_omega_element_is_an_error() {
+    let mut f =
+        Fixture::new(0.2, 0.001, 0.1, 0.1).with_prior("ETA_CL", 0.09, PriorSpread::Rse(0.4));
+    let block = nalgebra::DMatrix::from_row_slice(2, 2, &[0.1, 0.02, 0.02, 0.2]);
+    f.model.default_params.omega =
+        OmegaMatrix::from_matrix(block, vec!["ETA_CL".into(), "ETA_V".into()], false);
+    f.model.default_params.omega_fixed = vec![false, false];
+    f.model.omega_init_as_sd = vec![false, false];
+    let msg = err_of(&f);
+    assert!(msg.contains("block_omega"), "{msg}");
+}

--- a/src/estimation/priors_tests.rs
+++ b/src/estimation/priors_tests.rs
@@ -453,3 +453,68 @@ fn a_prior_on_a_block_omega_element_is_an_error() {
     let msg = err_of(&f);
     assert!(msg.contains("block_omega"), "{msg}");
 }
+
+/// A **mixed** Ω — `block_omega (A, B)` alongside an independent `omega C` — is a
+/// single non-diagonal matrix, so a matrix-level `!diagonal` test rejects a prior
+/// on `C` even though `C` is an ordinary uncorrelated variance.
+///
+/// That is exactly the arrangement the block diagnostic tells users to reach for
+/// ("declare the diagonal variances separately to prior them"), so getting it
+/// wrong makes the advice impossible to follow. Block membership has to come from
+/// `free_mask`, per coordinate.
+///
+/// The second half is the packed-index trap the first half hides: in a
+/// non-diagonal Ω the packed coordinate is a position in the column-major lower
+/// triangle, **not** an eta index, so an `omega_init_as_sd` lookup keyed on the
+/// packed offset reads the wrong flag — here it would read `ETA_A`'s (`false`)
+/// for `ETA_C` and silently switch `C` to the variance scale.
+#[test]
+fn a_prior_on_an_independent_diagonal_of_a_mixed_omega_is_accepted() {
+    // Ω = [[0.09, 0.02, 0], [0.02, 0.20, 0], [0, 0, 0.16]] — A~B correlated, C free.
+    // Packed (column-major lower triangle): (A,A) (B,A) (C,A) (B,B) (C,B) (C,C),
+    // so C's diagonal is packed index 5 while its eta index is 2.
+    //
+    // `CompiledModel` holds boxed closures and is not `Clone`, so the fixture is
+    // built fresh per probe rather than cloned.
+    let mixed = |prior_on: &str, value: f64| -> Fixture {
+        let mut f = Fixture::new(0.2, 0.001, 0.1, 0.1);
+        let m = nalgebra::DMatrix::from_row_slice(
+            3,
+            3,
+            &[0.09, 0.02, 0.0, 0.02, 0.20, 0.0, 0.0, 0.0, 0.16],
+        );
+        let mut free = nalgebra::DMatrix::from_element(3, 3, false);
+        for i in 0..3 {
+            free[(i, i)] = true;
+        }
+        free[(0, 1)] = true;
+        free[(1, 0)] = true;
+        f.model.default_params.omega = OmegaMatrix::from_matrix_with_mask(
+            m,
+            vec!["ETA_A".into(), "ETA_B".into(), "ETA_C".into()],
+            false,
+            free,
+        );
+        f.model.default_params.omega_fixed = vec![false; 3];
+        // Only C is declared `(sd)`.
+        f.model.omega_init_as_sd = vec![false, false, true];
+        f.with_prior(prior_on, value, PriorSpread::Rse(0.4))
+    };
+
+    // C is independent → its prior resolves, on C's own declared (SD) scale.
+    let on_c = mixed("ETA_C", 0.4);
+    let set = on_c
+        .build()
+        .expect("a prior on an independent diagonal of a mixed Omega must resolve");
+    // Ω_CC = 0.16 → SD 0.4, which is the prior mean, so the penalty is exactly 0
+    // on the SD scale. Under the variance scale the mean would be ½·ln(0.4) while
+    // the packed value stays ln(0.4), giving a large penalty — so this pins the
+    // flag lookup, not merely the acceptance.
+    assert_eq!(set.penalty(&on_c.packed()), 0.0);
+
+    // A belongs to the block → still rejected, naming the block.
+    let err = mixed("ETA_A", 0.09)
+        .build()
+        .expect_err("a prior on a block member must still be rejected");
+    assert!(err.contains("block_omega"), "{err}");
+}

--- a/src/estimation/run_sir.rs
+++ b/src/estimation/run_sir.rs
@@ -36,6 +36,22 @@ fn push_sir_warnings(warnings: &mut Vec<String>, sir_warnings: &[String]) {
     }
 }
 
+/// The **data** −2 log L of a completed fit — what `sir::run_sir_core` takes as
+/// its `ofv_hat` (#254).
+///
+/// `FitResult::ofv` is the *penalized* total once a `prior(...)` is declared, so
+/// handing it to `run_sir_core` — which adds the penalty itself — counts the
+/// penalty twice. Today that cancels, because `dofv` only ever enters normalized
+/// log-weights, but the contract is what the next reader will rely on.
+///
+/// `ofv - ofv_prior` rather than the `ofv_data` field, because both are
+/// `#[serde(default)]`: a `FitResult` deserialized from a pre-#254 YAML carries
+/// `ofv_data = 0.0`, whereas `ofv_prior = 0.0` is the truth there. One spelling
+/// is therefore correct for an old fit and a new one alike.
+fn data_ofv(fit: &FitResult) -> f64 {
+    fit.ofv - fit.ofv_prior
+}
+
 /// Run SIR against an existing fit. Returns a new `FitResult` that is a clone
 /// of `fit` with the `sir_*` fields populated. Proposal-conditioning
 /// diagnostics (rank deficiency / bound-driven shrinkage, #1021) are appended
@@ -243,7 +259,13 @@ fn run_sir_scoped(
 
     // --- Run SIR (identical to the inline path in fit()) ------------------
     let sir = crate::estimation::sir::run_sir_core(
-        model_ref, pop_ref, &params, &eta_hats, cov, fit.ofv, options,
+        model_ref,
+        pop_ref,
+        &params,
+        &eta_hats,
+        cov,
+        data_ofv(fit),
+        options,
     )?;
 
     // --- Build the augmented FitResult ------------------------------------
@@ -724,5 +746,37 @@ mod tests {
             "expected 'no model supplied' error, got: {}",
             err
         );
+    }
+
+    /// `run_sir_core` adds the prior penalty to the `ofv_hat` it is handed
+    /// (#254), so what `run_sir` passes has to be the **data** OFV.
+    ///
+    /// Both spellings that look right are wrong on one of these two inputs, and
+    /// each is a distinct mutation: returning `fit.ofv` (the bug this replaced)
+    /// reddens the priored case only, and returning `fit.ofv_data` reddens the
+    /// legacy case only — `ofv_data` is `#[serde(default)]`, so a `FitResult`
+    /// deserialized from a pre-#254 YAML carries `0.0` there.
+    #[test]
+    fn data_ofv_strips_the_prior_penalty_and_survives_a_legacy_fit() {
+        // A priored fit: ofv is the penalized total, ofv_data the data half.
+        let mut fit = FitResult {
+            ofv: 110.0,
+            ofv_prior: 10.0,
+            ofv_data: 100.0,
+            ..crate::types::test_helpers::empty_fit_result()
+        };
+        assert_eq!(data_ofv(&fit), 100.0);
+        assert_ne!(
+            data_ofv(&fit),
+            fit.ofv,
+            "passing the penalized total would double-count the penalty"
+        );
+
+        // A pre-#254 fit read back from YAML: neither new field was serialized,
+        // so both default to 0.0 and the whole objective is the data half.
+        fit.ofv = 100.0;
+        fit.ofv_prior = 0.0;
+        fit.ofv_data = 0.0;
+        assert_eq!(data_ofv(&fit), 100.0);
     }
 }

--- a/src/estimation/sir.rs
+++ b/src/estimation/sir.rs
@@ -464,7 +464,10 @@ fn all_invalid_weights_message(
 /// * `params` - ML parameter estimates
 /// * `eta_hats` - ML EBE estimates (for warm-starting inner loop)
 /// * `proposal_cov` - Covariance matrix in packed (log-transformed) parameter space
-/// * `ofv_hat` - OFV at ML estimates
+/// * `ofv_hat` - the **data** OFV (−2 log L) at the estimates, i.e. what every
+///   optimizer reports as `OuterResult::ofv`. Under parameter priors (#254) the
+///   penalty is added internally, to this baseline and to every draw alike, so
+///   callers pass the clean value and cannot get the two halves out of step.
 /// * `options` - Fit options containing SIR settings
 pub fn run_sir_core(
     model: &CompiledModel,
@@ -518,6 +521,21 @@ fn run_sir_core_scoped(
         fixed: fixed_mask,
     } = pack_with_bounds(params);
     let n_packed = x_hat.len();
+
+    // Parameter priors (#254). SIR approximates the posterior the fit targeted,
+    // so under a prior the target is `L(data) · p(θ)` and the importance weight
+    // must score both halves. Without this the proposal is centred on the MAP
+    // estimate and shaped by the *penalized* curvature, while the weights score
+    // the *unpenalized* likelihood — so the resampling actively pulls the
+    // intervals back toward the MLE and a tight prior vanishes from the reported
+    // CIs, which is worse than not supporting SIR at all.
+    //
+    // `ofv_hat` arrives as the data −2 log L (what every caller has to hand), so
+    // the penalty is added here on **both** sides rather than being the caller's
+    // job — one derivation, so the baseline and the samples cannot disagree
+    // about whether the prior is in.
+    let priors = crate::estimation::outer_optimizer::build_prior_set(model, params);
+    let ofv_hat = ofv_hat + priors.penalty(&x_hat);
 
     if proposal_cov.nrows() != n_packed || proposal_cov.ncols() != n_packed {
         return Err(format!(
@@ -694,7 +712,10 @@ fn run_sir_core_scoped(
             // Compute OFV — through the method-aware seam, so an AGQ fit's SIR weights come
             // from the AGQ marginal it was actually optimised against, not the FOCE one.
             let nll_k = pop_nll_opts(model, population, &params_k, &ehs, &hms, &_kappas, options);
-            let ofv_k = 2.0 * nll_k;
+            // The prior half, at this draw. `x_k` is already the packed vector
+            // the penalty is defined on. A no-op (`+ 0.0`) for an unpriored fit,
+            // so those weights stay bit-identical.
+            let ofv_k = 2.0 * nll_k + priors.penalty(x_k);
             if !ofv_k.is_finite() {
                 return (f64::NEG_INFINITY, SampleOutcome::NonFiniteOfv);
             }

--- a/src/estimation/trust_region.rs
+++ b/src/estimation/trust_region.rs
@@ -44,6 +44,9 @@ struct FoceiProblem<'a> {
     /// optimizer objective (`cost`/`ofv_fixed`), gradient and Hessian, not to
     /// the final reported OFV, which reuses a clean `pop_nll_opts`.
     nn_reg: crate::estimation::nn_reg::NnRegularizer,
+    /// Parameter priors (#254). Same contract as `nn_reg`: in the optimizer
+    /// objective, gradient and Hessian; out of the reported OFV.
+    priors: crate::estimation::priors::PriorSet,
 }
 
 impl FoceiProblem<'_> {
@@ -83,7 +86,7 @@ impl FoceiProblem<'_> {
             self.options,
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
-        let raw = 2.0 * nll + self.nn_reg.penalty_value(&params.theta);
+        let raw = 2.0 * nll + self.nn_reg.penalty_value(&params.theta) + self.priors.penalty(x);
         if raw.is_finite() {
             raw
         } else {
@@ -230,6 +233,9 @@ impl Gradient for FoceiProblem<'_> {
         // maps 1:1 into `g`. Its curvature goes into `hessian()` below.
         let params = unpack_params(p, self.init_params);
         self.nn_reg.add_packed_gradient(&params.theta, &mut g);
+        // Parameter priors (#254) are defined on the packed vector directly, so
+        // `p` is already the right space.
+        self.priors.add_gradient(p, &mut g);
         Ok(g)
     }
 }
@@ -264,6 +270,12 @@ impl Hessian for FoceiProblem<'_> {
         let params = unpack_params(p, self.init_params);
         self.nn_reg
             .add_packed_hessian(&params.theta, &mut |i, j, v| h[i][j] += v);
+        // Parameter-prior curvature (#254): the exact `2/s²` diagonal, not an
+        // approximation. Same reason it has to be here as the NN term — the
+        // gradient carries the prior's pull, so a quadratic model without its
+        // curvature would read every priored direction as flat and shrink the
+        // radius on steps that were fine. PSD, so the BHHH model stays PSD.
+        self.priors.add_hessian(&mut |i, j, v| h[i][j] += v);
         Ok(h)
     }
 }
@@ -681,6 +693,7 @@ pub fn optimize_trust_region(
         bounds,
         cached_etas: std::sync::Mutex::new(vec![DVector::zeros(n_eta); n_subj]),
         grad_cache: std::sync::Mutex::new(None),
+        priors: crate::estimation::outer_optimizer::build_prior_set(model, init_params),
         nn_reg,
     };
 
@@ -968,6 +981,10 @@ mod tests {
             cached_etas: std::sync::Mutex::new(vec![nalgebra::DVector::zeros(n_eta); n_subj]),
             grad_cache: std::sync::Mutex::new(None),
             nn_reg: crate::estimation::nn_reg::NnRegularizer::build(&model, &population, &options),
+            priors: crate::estimation::outer_optimizer::build_prior_set(
+                &model,
+                &model.default_params,
+            ),
         };
 
         // 1. Before cost(): cache is None.
@@ -1263,6 +1280,7 @@ mod tests {
                     population.subjects.len()
                 ]),
                 grad_cache: std::sync::Mutex::new(None),
+                priors: crate::estimation::outer_optimizer::build_prior_set(&model, init),
                 nn_reg: crate::estimation::nn_reg::NnRegularizer::build(
                     &model,
                     &population,
@@ -1357,6 +1375,7 @@ mod tests {
                 ]),
                 grad_cache: std::sync::Mutex::new(None),
                 nn_reg: crate::estimation::nn_reg::NnRegularizer::build(model, population, options),
+                priors: crate::estimation::outer_optimizer::build_prior_set(model, init),
             }
         }
         assert!(fresh(&model, &population, init, &options)

--- a/src/estimation/uncertainty_samples.rs
+++ b/src/estimation/uncertainty_samples.rs
@@ -368,6 +368,9 @@ mod tests {
     /// are filled with sensible defaults.
     fn fit_with_cov(template: &ModelParameters, cov: DMatrix<f64>) -> FitResult {
         FitResult {
+            ofv_data: 0.0,
+            ofv_prior: 0.0,
+            prior_summary: Vec::new(),
             residual_correlation_fixed: Vec::new(),
             se_residual_correlations: None,
             covariate_relations: Vec::new(),

--- a/src/frem/mod.rs
+++ b/src/frem/mod.rs
@@ -1119,6 +1119,7 @@ mod tests {
 
     fn make_test_model() -> CompiledModel {
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             has_conditional_eta_params: false,
             name: "test".into(),

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -1875,6 +1875,14 @@ fn wire_to_fit_result(
         covariance_wall_time_secs: w.covariance_wall_time_secs,
         converged: w.converged,
         ofv: w.ofv,
+        // A checkpoint predates the prior split (#254) and carries only the
+        // single `ofv`. Restoring it as the data half is correct for every
+        // checkpoint that can exist — priors were not applied when it was
+        // written — and keeps `ofv == ofv_data + ofv_prior` an invariant rather
+        // than something a restored result quietly breaks.
+        ofv_data: w.ofv,
+        ofv_prior: 0.0,
+        prior_summary: Vec::new(),
         aic: w.aic,
         bic: w.bic,
         theta: w.theta.estimates,

--- a/src/io/fitrx.rs
+++ b/src/io/fitrx.rs
@@ -85,6 +85,21 @@ struct FitWire {
     method_chain: Vec<String>,
     converged: bool,
     ofv: f64,
+    /// Parameter-prior split (#254). `Option` so an artifact written before the
+    /// split still loads: `None` means "this file predates priors", and the
+    /// loader reconstructs `ofv_data = ofv`, which is right for every such file
+    /// because no prior could have been applied when it was written.
+    ///
+    /// A *priored* fit must write these. Storing only `ofv` — the penalized
+    /// total — and reconstructing `ofv_data` from it on load would relabel the
+    /// penalized objective as the data likelihood, drop every prior row, and
+    /// break the `aic == ofv_data + 2k` invariant that `aic` was computed under.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ofv_data: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ofv_prior: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    prior_summary: Vec<crate::types::PriorSummary>,
     aic: f64,
     bic: f64,
     n_obs: usize,
@@ -572,6 +587,11 @@ fn build_fit_wire(r: &FitResult) -> FitWire {
             .collect(),
         converged: r.converged,
         ofv: r.ofv,
+        // Written only for a priored fit, so an unpriored artifact stays
+        // byte-identical to a pre-#254 one.
+        ofv_data: (!r.prior_summary.is_empty()).then_some(r.ofv_data),
+        ofv_prior: (!r.prior_summary.is_empty()).then_some(r.ofv_prior),
+        prior_summary: r.prior_summary.clone(),
         aic: r.aic,
         bic: r.bic,
         n_obs: r.n_obs,
@@ -1875,14 +1895,14 @@ fn wire_to_fit_result(
         covariance_wall_time_secs: w.covariance_wall_time_secs,
         converged: w.converged,
         ofv: w.ofv,
-        // A checkpoint predates the prior split (#254) and carries only the
-        // single `ofv`. Restoring it as the data half is correct for every
-        // checkpoint that can exist — priors were not applied when it was
-        // written — and keeps `ofv == ofv_data + ofv_prior` an invariant rather
-        // than something a restored result quietly breaks.
-        ofv_data: w.ofv,
-        ofv_prior: 0.0,
-        prior_summary: Vec::new(),
+        // #254. An artifact written before the split carries no `ofv_data`, and
+        // for those `ofv` *is* the data likelihood — no prior could have been
+        // applied. A priored artifact carries both halves and they are restored
+        // as written, so `ofv == ofv_data + ofv_prior` and `aic == ofv_data + 2k`
+        // survive the round trip.
+        ofv_data: w.ofv_data.unwrap_or(w.ofv),
+        ofv_prior: w.ofv_prior.unwrap_or(0.0),
+        prior_summary: std::mem::take(&mut w.prior_summary),
         aic: w.aic,
         bic: w.bic,
         theta: w.theta.estimates,

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -129,6 +129,50 @@ fn block_summary(values: &[f64]) -> (f64, f64, f64) {
     (sorted[0], sorted[(n - 1) / 2], sorted[n - 1])
 }
 
+/// Render the per-parameter prior report (#254), or nothing when no prior is in
+/// force.
+///
+/// One writer for both the console (`print_results`) and the file summary, so
+/// the two cannot drift — the numbers a user quotes from a terminal and the ones
+/// in a saved report have to be the same numbers.
+///
+/// The column that earns its place is `shift`: `(x̂ − m)/s` in the space the
+/// prior lives in. A raw difference only says the estimate moved; the
+/// standardized one says whether the data and the prior actually disagree, which
+/// is the question a MAP fit is asked. `family` is printed because it is decided
+/// by the parameter's declared *bounds*, not by the prior declaration — see
+/// [`crate::estimation::priors`].
+fn write_prior_summary(out: &mut impl std::fmt::Write, result: &FitResult) {
+    if result.prior_summary.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\n--- Parameter Priors (penalized ML / MAP) ---");
+    let _ = writeln!(
+        out,
+        "  {:<16} {:>12} {:>12} {:>8} {:>10}  {}",
+        "PARAMETER", "PRIOR", "ESTIMATE", "SHIFT", "PENALTY", "PRIOR 95%"
+    );
+    for p in &result.prior_summary {
+        let _ = writeln!(
+            out,
+            "  {:<16} {:>12.5} {:>12.5} {:>8.2} {:>10.3}  [{:.4}, {:.4}] ({})",
+            p.name,
+            p.prior_value,
+            p.estimate,
+            p.shift_in_prior_sds,
+            p.penalty,
+            p.prior_lower_95,
+            p.prior_upper_95,
+            p.family,
+        );
+    }
+    let _ = writeln!(
+        out,
+        "  SHIFT is (estimate − prior) in prior SDs. Standard errors above are the \
+         curvature of\n  the penalized objective — MAP standard errors, not posterior SDs."
+    );
+}
+
 pub fn print_results(result: &FitResult) {
     eprintln!("\n{}", "=".repeat(60));
     eprintln!("NONLINEAR MIXED EFFECTS MODEL ESTIMATION");
@@ -148,8 +192,19 @@ pub fn print_results(result: &FitResult) {
 
     eprintln!("\n--- Objective Function ---");
     eprintln!("OFV:  {:.4}", result.ofv);
+    if !result.prior_summary.is_empty() {
+        eprintln!("  data:  {:.4}", result.ofv_data);
+        eprintln!("  prior: {:.4}", result.ofv_prior);
+    }
     eprintln!("AIC:  {:.4}", result.aic);
     eprintln!("BIC:  {:.4}", result.bic);
+    {
+        let mut buf = String::new();
+        write_prior_summary(&mut buf, result);
+        if !buf.is_empty() {
+            eprint!("{buf}");
+        }
+    }
 
     eprintln!(
         "\nSubjects: {}  Observations: {}  Parameters: {}",
@@ -691,8 +746,17 @@ pub fn format_summary(result: &FitResult) -> String {
     // --- Objective function ---
     let _ = writeln!(out, "\n--- Objective Function ---");
     let _ = writeln!(out, "  OFV:  {:.4}", result.ofv);
+    // Under parameter priors (#254) the OFV above is the penalized objective
+    // that was minimised, so the split is printed right under it — and AIC/BIC
+    // are labelled with the half they are computed from, since an information
+    // criterion from a penalized objective would not be one.
+    if !result.prior_summary.is_empty() {
+        let _ = writeln!(out, "    data:  {:.4}", result.ofv_data);
+        let _ = writeln!(out, "    prior: {:.4}", result.ofv_prior);
+    }
     let _ = writeln!(out, "  AIC:  {:.4}", result.aic);
     let _ = writeln!(out, "  BIC:  {:.4}", result.bic);
+    write_prior_summary(&mut out, result);
 
     // Failed / SIR-fallback covariance make the SE columns meaningless, so we
     // suppress the derived CV% (mirrors `print_results`).
@@ -1878,8 +1942,39 @@ pub fn write_estimates_yaml(result: &FitResult, path: &str) -> Result<(), String
 
     writeln!(f, "\nobjective_function:").map_err(|e| e.to_string())?;
     writeln!(f, "  ofv: {:.6}", result.ofv).map_err(|e| e.to_string())?;
+    // Emitted only under a prior (#254), so an unpriored fit's YAML is
+    // byte-identical to what it was before this feature.
+    if !result.prior_summary.is_empty() {
+        writeln!(f, "  ofv_data: {:.6}", result.ofv_data).map_err(|e| e.to_string())?;
+        writeln!(f, "  ofv_prior: {:.6}", result.ofv_prior).map_err(|e| e.to_string())?;
+        writeln!(
+            f,
+            "  # aic/bic are computed from ofv_data: a penalized objective"
+        )
+        .map_err(|e| e.to_string())?;
+        writeln!(f, "  # is not a log-likelihood.").map_err(|e| e.to_string())?;
+    }
     writeln!(f, "  aic: {:.6}", result.aic).map_err(|e| e.to_string())?;
     writeln!(f, "  bic: {:.6}", result.bic).map_err(|e| e.to_string())?;
+
+    if !result.prior_summary.is_empty() {
+        writeln!(f, "\nparameter_priors:").map_err(|e| e.to_string())?;
+        for p in &result.prior_summary {
+            writeln!(f, "  - name: {}", p.name).map_err(|e| e.to_string())?;
+            writeln!(f, "    prior_value: {:.6}", p.prior_value).map_err(|e| e.to_string())?;
+            writeln!(f, "    estimate: {:.6}", p.estimate).map_err(|e| e.to_string())?;
+            writeln!(f, "    shift_in_prior_sds: {:.6}", p.shift_in_prior_sds)
+                .map_err(|e| e.to_string())?;
+            writeln!(f, "    penalty: {:.6}", p.penalty).map_err(|e| e.to_string())?;
+            writeln!(f, "    family: {}", p.family).map_err(|e| e.to_string())?;
+            writeln!(
+                f,
+                "    prior_95: [{:.6}, {:.6}]",
+                p.prior_lower_95, p.prior_upper_95
+            )
+            .map_err(|e| e.to_string())?;
+        }
+    }
 
     writeln!(f, "\ndata:").map_err(|e| e.to_string())?;
     writeln!(f, "  n_subjects: {}", result.n_subjects).map_err(|e| e.to_string())?;
@@ -2660,6 +2755,9 @@ mod tests {
         let sigma_types = error_model.sigma_types();
         let n = sigma.len();
         FitResult {
+            ofv_data: 0.0,
+            ofv_prior: 0.0,
+            prior_summary: Vec::new(),
             residual_correlation_fixed: Vec::new(),
             se_residual_correlations: None,
             covariate_relations: Vec::new(),
@@ -3367,6 +3465,9 @@ mod tests {
     fn minimal_sdtab_result(subjects: Vec<SubjectResult>) -> FitResult {
         let sigma_types = ErrorModel::Proportional.sigma_types();
         FitResult {
+            ofv_data: 0.0,
+            ofv_prior: 0.0,
+            prior_summary: Vec::new(),
             residual_correlation_fixed: Vec::new(),
             se_residual_correlations: None,
             covariate_relations: Vec::new(),

--- a/src/io/output.rs
+++ b/src/io/output.rs
@@ -4650,6 +4650,99 @@ mod tests {
         print_results(&r);
     }
 
+    /// The three renderers of the per-parameter prior report (#254) — the file
+    /// summary, the YAML, and the stderr printer — must all emit it, and all
+    /// three must stay silent on an unpriored fit.
+    ///
+    /// The report is the only place a MAP fit says how far the data pulled each
+    /// estimate from its prior, so a renderer that silently drops it leaves a
+    /// penalized fit indistinguishable from an unpenalized one in the output the
+    /// user actually reads. Every assertion below is paired with its negative on
+    /// the *same* `FitResult` with `prior_summary` cleared, so none of them can
+    /// pass on a renderer that prints the block unconditionally.
+    #[test]
+    fn the_prior_report_renders_in_the_summary_the_yaml_and_the_printer() {
+        let mut r = make_sigma_only_result(ErrorModel::Proportional, vec![0.1]);
+        r.ofv = 110.0;
+        r.ofv_data = 100.0;
+        r.ofv_prior = 10.0;
+        r.prior_summary = vec![
+            crate::types::PriorSummary {
+                name: "TVCL".to_string(),
+                prior_value: 0.15,
+                estimate: 0.132,
+                shift_in_prior_sds: -0.48,
+                penalty: 0.2304,
+                family: "lognormal".to_string(),
+                prior_lower_95: 0.0919,
+                prior_upper_95: 0.2449,
+            },
+            crate::types::PriorSummary {
+                name: "HILL".to_string(),
+                prior_value: 1.0,
+                estimate: 1.4,
+                shift_in_prior_sds: 0.8,
+                penalty: 0.64,
+                family: "normal".to_string(),
+                prior_lower_95: 0.02,
+                prior_upper_95: 1.98,
+            },
+        ];
+
+        // --- The file summary -------------------------------------------------
+        let summary = format_summary(&r);
+        assert!(summary.contains("Parameter Priors"), "{summary}");
+        // Both rows, and the OFV split labelled under the penalized total.
+        assert!(summary.contains("TVCL"), "{summary}");
+        assert!(summary.contains("HILL"), "{summary}");
+        assert!(summary.contains("lognormal"), "{summary}");
+        assert!(summary.contains("normal"), "{summary}");
+        assert!(summary.contains("data:  100.0000"), "{summary}");
+        assert!(summary.contains("prior: 10.0000"), "{summary}");
+        // The shift is the column the report exists for, so it must be the
+        // standardized one and not a raw difference (−0.48, not −0.018).
+        assert!(summary.contains("-0.48"), "{summary}");
+
+        // --- The YAML ---------------------------------------------------------
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("fit.yaml");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let yaml = std::fs::read_to_string(&path).expect("read yaml");
+        assert!(yaml.contains("\nparameter_priors:"), "{yaml}");
+        assert!(yaml.contains("  - name: TVCL"), "{yaml}");
+        assert!(yaml.contains("    shift_in_prior_sds: -0.480000"), "{yaml}");
+        assert!(yaml.contains("    penalty: 0.230400"), "{yaml}");
+        assert!(yaml.contains("    family: lognormal"), "{yaml}");
+        assert!(
+            yaml.contains("    prior_95: [0.091900, 0.244900]"),
+            "{yaml}"
+        );
+        assert!(yaml.contains("  ofv_data: 100.000000"), "{yaml}");
+        assert!(yaml.contains("  ofv_prior: 10.000000"), "{yaml}");
+
+        // --- The stderr printer ----------------------------------------------
+        // No capture here; this is the smoke half — the formatting it shares
+        // with the summary is asserted above, through the one `write_prior_summary`.
+        print_results(&r);
+
+        // --- The negative, on the same result --------------------------------
+        // Without this every assertion above is satisfied by a renderer that
+        // emits the block unconditionally, which would put an empty prior table
+        // into every unpriored fit's output.
+        r.prior_summary.clear();
+        r.ofv_prior = 0.0;
+        r.ofv_data = r.ofv;
+        let plain = format_summary(&r);
+        assert!(!plain.contains("Parameter Priors"), "{plain}");
+        assert!(!plain.contains("prior:"), "{plain}");
+        write_estimates_yaml(&r, path.to_str().unwrap()).expect("yaml write");
+        let plain_yaml = std::fs::read_to_string(&path).expect("read yaml");
+        assert!(!plain_yaml.contains("parameter_priors:"), "{plain_yaml}");
+        assert!(!plain_yaml.contains("ofv_prior:"), "{plain_yaml}");
+        assert!(!plain_yaml.contains("ofv_data:"), "{plain_yaml}");
+        print_results(&r);
+    }
+
     #[test]
     fn print_results_smoke_comprehensive() {
         // Exercises the maximal-section path of the stderr printer.

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -14691,6 +14691,38 @@ fn split_weight_modifier(
     Ok((stmt.to_string(), Some(expr.to_string())))
 }
 
+/// Whether the word immediately before byte `i` is a `[parameters]`
+/// declaration keyword — i.e. `i` sits in the declaration's *name* slot rather
+/// than in a trailing modifier (#254).
+///
+/// `prior` is a legal parameter name (the declaration regexes all take `\w+`),
+/// so `omega PRIOR ~ 0.1` and `theta prior(0.1, 0, 10)` are valid models that
+/// predate the modifier and must keep their old meaning. A `prior(...)`
+/// modifier only ever follows a *complete* declaration, so the word before it
+/// is a `)`, a number or a `weight =` expression — never one of these
+/// keywords. The `block_*` forms are deliberately absent: their names live
+/// inside the parenthesised list, which the caller already skips on depth.
+fn preceded_by_declaration_keyword(body: &str, i: usize) -> bool {
+    let bytes = body.as_bytes();
+    let mut end = i;
+    while end > 0 && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    // No whitespace before `i` means no separate preceding word; the caller's
+    // left-boundary test has already ruled out an identifier char abutting it.
+    if end == i {
+        return false;
+    }
+    let mut start = end;
+    while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
+        start -= 1;
+    }
+    matches!(
+        body[start..end].to_ascii_lowercase().as_str(),
+        "theta" | "omega" | "sigma" | "kappa"
+    )
+}
+
 /// Peel a trailing `prior(...)` modifier off a `[parameters]` declaration
 /// (#254), returning the declaration without it plus the parsed prior.
 ///
@@ -14733,6 +14765,16 @@ fn split_prior_modifier(
         // Whole-word on the left, so `MY_prior` is a name and not the modifier.
         let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
         if i > 0 && is_ident(bytes[i - 1]) {
+            continue;
+        }
+        // A declaration's *name* slot is not the modifier. `prior` is a legal
+        // parameter name, so `omega PRIOR ~ 0.1` and `theta prior(0.1, 0, 10)`
+        // are ordinary declarations that predate this feature; the modifier is
+        // always a tail *after* a complete declaration and so never sits in the
+        // token right after `theta` / `omega` / `sigma` / `kappa`. Tested
+        // before the call-shape check below, so the `~` form is skipped rather
+        // than reported as a malformed call.
+        if preceded_by_declaration_keyword(body, i) {
             continue;
         }
         // The modifier is a call, so what follows the keyword must be `(`.

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -1550,6 +1550,7 @@ pub fn parse_full_model_with(
         vector_theta_decls,
         mut level_block_decls,
         unbound_level_blocks,
+        declared_priors,
     ) = parse_parameters(param_lines, level_bindings)?;
     // Install the θ level table for the remainder of this parse so a
     // gather (`PLACEBO[IDX]`) resolves identically in every block that parses
@@ -2945,6 +2946,7 @@ pub fn parse_full_model_with(
         .collect();
 
     let model = CompiledModel {
+        priors: declared_priors,
         name,
         covariate_model,
         pk_model,
@@ -5152,7 +5154,7 @@ fn apply_covariate_model_block(
         .get("parameters")
         .ok_or("Missing [parameters] block")?
         .clone();
-    let (thetas, _, _, _, _, eta_names, kappa_info, _, _, _) =
+    let (thetas, _, _, _, _, eta_names, kappa_info, _, _, _, _) =
         parse_parameters(&param_lines, &bindings.levels)?;
     let mut eta_kappa_names: std::collections::HashSet<String> = eta_names.into_iter().collect();
     eta_kappa_names.extend(kappa_info.names_ordered.iter().cloned());
@@ -13159,11 +13161,12 @@ fn parse_parameters(
         Vec<BlockOmegaSpec>,
         Vec<SigmaSpec>,
         Vec<BlockSigmaSpec>,
-        Vec<String>,          // BSV eta names in declaration order
-        ParsedKappas,         // IOV kappa specs (diagonal and/or block)
-        Vec<VectorThetaDecl>, // #1064 θ level blocks
-        Vec<LevelBlockDecl>,  // #1064 a level block declarations
-        Vec<String>,          // #1064 level blocks still awaiting data
+        Vec<String>,                       // BSV eta names in declaration order
+        ParsedKappas,                      // IOV kappa specs (diagonal and/or block)
+        Vec<VectorThetaDecl>,              // #1064 θ level blocks
+        Vec<LevelBlockDecl>,               // #1064 a level block declarations
+        Vec<String>,                       // #1064 level blocks still awaiting data
+        Vec<crate::types::ParameterPrior>, // #254 inline `prior(...)` declarations
     ),
     String,
 > {
@@ -13180,6 +13183,9 @@ fn parse_parameters(
     let mut block_kappas: Vec<BlockKappaSpec> = Vec::new();
     let mut kappa_names_ordered: Vec<String> = Vec::new();
     let mut kappa_weights_ordered: Vec<Option<String>> = Vec::new();
+    // Per-parameter priors declared with an inline `prior(...)` tail (#254), in
+    // declaration order.
+    let mut priors: Vec<crate::types::ParameterPrior> = Vec::new();
 
     // theta NAME(init)  |  theta NAME(init, FIX)
     // theta NAME(init, lower, upper)  |  theta NAME(init, lower, upper, FIX)
@@ -13289,10 +13295,20 @@ fn parse_parameters(
         // silently dropped, which is the specific failure mode this feature
         // exists to remove. A weight left on any other declaration is rejected
         // below rather than ignored, for the same reason.
+        //
+        // #254: a `prior(...)` tail is peeled first, for the same reason and
+        // one more — `weight =` takes everything to its right as an expression,
+        // so on `kappa K ~ 0.1 weight = NARM prior(0.1, rse = 30%)` the weight
+        // would otherwise swallow the prior and the model would fit unpenalized.
+        let (line, prior_decl) = split_prior_modifier(line, "parameters")?;
         let (line, weight_expr) =
-            split_weight_modifier(line, "parameters", "a `kappa NAME ~ VALUE` declaration")?;
+            split_weight_modifier(&line, "parameters", "a `kappa NAME ~ VALUE` declaration")?;
         let line = &line;
         let mut weight_consumed = false;
+        // Name the prior attaches to, filled in by whichever declaration arm
+        // matched. `None` at the bottom of the loop with a `prior_decl` present
+        // means the prior had no home — an error, never a silent drop.
+        let mut prior_target: Option<String> = None;
         if let Some(caps) = theta_re.captures(line) {
             let name = caps[1].to_string();
             let block = match caps.get(2) {
@@ -13312,14 +13328,29 @@ fn parse_parameters(
                 .unwrap_or(1e9);
             let fixed = caps.get(6).is_some() || caps.get(7).is_some();
             match block {
-                None => thetas.push(ThetaSpec {
-                    name,
-                    init,
-                    lower,
-                    upper,
-                    fixed,
-                }),
+                None => {
+                    prior_target = Some(name.clone());
+                    thetas.push(ThetaSpec {
+                        name,
+                        init,
+                        lower,
+                        upper,
+                        fixed,
+                    })
+                }
                 Some(spec) => {
+                    // #254: a level block is many θ sharing one declaration, so
+                    // one `prior(...)` would have to mean "the same prior on
+                    // every level" — a useful ridge, but a different feature
+                    // from a per-parameter prior and untested here. Reject
+                    // rather than silently priding only the first level.
+                    if prior_decl.is_some() {
+                        return Err(format!(
+                            "[parameters] prior on `{name}`: priors on a θ level block \
+                             (`theta {name}[...]`) are not supported. Declare the levels \
+                             individually to prior them."
+                        ));
+                    }
                     if vector_thetas.iter().any(|d| d.name == name) {
                         return Err(format!("theta {name}: declared twice"));
                     }
@@ -13516,6 +13547,7 @@ fn parse_parameters(
             let variance = if init_as_sd { raw * raw } else { raw };
             let fixed = caps.get(3).is_some() || caps.get(5).is_some();
             eta_names_ordered.push(name.clone());
+            prior_target = Some(name.clone());
             omegas.push(OmegaSpec {
                 name,
                 variance,
@@ -13545,6 +13577,7 @@ fn parse_parameters(
             }
             let value = if init_as_sd { raw } else { raw.sqrt() };
             let fixed = caps.get(3).is_some() || caps.get(5).is_some();
+            prior_target = Some(name.clone());
             sigmas.push(SigmaSpec {
                 name,
                 value,
@@ -13572,12 +13605,34 @@ fn parse_parameters(
             kappa_names_ordered.push(name.clone());
             kappa_weights_ordered.push(weight_expr.clone());
             weight_consumed = true;
+            prior_target = Some(name.clone());
             kappas.push(KappaSpec {
                 name,
                 variance,
                 fixed,
                 init_as_sd,
             });
+        }
+        // #254: attach the peeled prior to whichever declaration matched. A
+        // prior with no target is an error — the alternative is a model file
+        // that reads as regularized and fits as if it were not.
+        if let Some((value, spread)) = prior_decl {
+            match prior_target {
+                Some(name) => priors.push(crate::types::ParameterPrior {
+                    name,
+                    value,
+                    spread,
+                }),
+                None => {
+                    return Err(format!(
+                        "[parameters] `prior(...)` is only supported on a `theta`, `omega`, \
+                         `sigma` or `kappa` declaration. It has no meaning on `{}`. A \
+                         `block_omega` / `block_sigma` / `block_kappa` element cannot carry \
+                         one: its packed coordinates are Cholesky entries, not variances.",
+                        line.trim()
+                    ))
+                }
+            }
         }
         if let Some(w) = &weight_expr {
             if !weight_consumed {
@@ -13631,6 +13686,7 @@ fn parse_parameters(
         vector_thetas,
         level_block_decls,
         unbound_level_blocks,
+        priors,
     ))
 }
 
@@ -14633,6 +14689,205 @@ fn split_weight_modifier(
         ));
     }
     Ok((stmt.to_string(), Some(expr.to_string())))
+}
+
+/// Peel a trailing `prior(...)` modifier off a `[parameters]` declaration
+/// (#254), returning the declaration without it plus the parsed prior.
+///
+/// Like [`split_weight_modifier`], this runs **before** the four declaration
+/// regexes because every one of them is unanchored: a modifier left on the line
+/// would sit past the end of a successful match and be silently dropped, which
+/// for a prior means returning an unpenalized fit that looks regularized. It
+/// runs before `split_weight_modifier` too, so that on a weighted kappa
+/// (`kappa K ~ 0.1 weight = NARM prior(0.1, rse = 30%)`) the weight's
+/// right-hand-side expression does not swallow the prior.
+///
+/// The keyword is matched only at bracket depth zero, so a `prior` appearing
+/// inside a bracketed list is left alone.
+fn split_prior_modifier(
+    body: &str,
+    block: &str,
+) -> Result<(String, Option<(f64, crate::types::PriorSpread)>), String> {
+    const KW: &[u8] = b"prior";
+    let bytes = body.as_bytes();
+    let mut depth: i32 = 0;
+    let mut found: Option<usize> = None;
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' => {
+                depth += 1;
+                continue;
+            }
+            b')' | b']' => {
+                depth -= 1;
+                continue;
+            }
+            _ => {}
+        }
+        if depth != 0 || i + KW.len() > bytes.len() {
+            continue;
+        }
+        if !bytes[i..i + KW.len()].eq_ignore_ascii_case(KW) {
+            continue;
+        }
+        // Whole-word on the left, so `MY_prior` is a name and not the modifier.
+        let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_';
+        if i > 0 && is_ident(bytes[i - 1]) {
+            continue;
+        }
+        // The modifier is a call, so what follows the keyword must be `(`.
+        // `priors` / `prior_x` fail here on the identifier char, and a bare
+        // `prior` with no argument list is reported below rather than ignored.
+        let open = skip_ascii_ws(body, i + KW.len());
+        if bytes.get(open) != Some(&b'(') {
+            if bytes.get(i + KW.len()).copied().is_some_and(is_ident) {
+                continue;
+            }
+            return Err(format!(
+                "[{block}] `prior` must be written as a call, e.g. \
+                 `prior(0.15, rse = 25%)`: `{}`",
+                body.trim()
+            ));
+        }
+        found = Some(i);
+        break;
+    }
+    let Some(i) = found else {
+        return Ok((body.to_string(), None));
+    };
+    let open = skip_ascii_ws(body, i + KW.len());
+    let close = matching_paren(body, open).ok_or_else(|| {
+        format!(
+            "[{block}] unbalanced parentheses in `prior(...)`: `{}`",
+            body.trim()
+        )
+    })?;
+    let trailing = body[close + 1..].trim();
+    if !trailing.is_empty() {
+        return Err(format!(
+            "[{block}] `prior(...)` must be the last thing on the declaration; \
+             found `{trailing}` after it in `{}`",
+            body.trim()
+        ));
+    }
+    let stmt = body[..i].trim();
+    if stmt.is_empty() {
+        return Err(format!(
+            "[{block}] `prior(...)` must follow a parameter declaration on the same line: `{}`",
+            body.trim()
+        ));
+    }
+    let spec = parse_prior_call(&body[open + 1..close], block, stmt)?;
+    Ok((stmt.to_string(), Some(spec)))
+}
+
+/// Index of the `)` matching the `(` at `open`, or `None` if unbalanced.
+fn matching_paren(s: &str, open: usize) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut depth = 0i32;
+    for (i, &b) in bytes.iter().enumerate().skip(open) {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Parse the inside of a `prior(...)` call: a central value followed by exactly
+/// one of `rse = …` or `sd = …`.
+///
+/// # RSE units
+///
+/// `rse = 25%` and `rse = 0.25` both mean 25%. A bare number **greater than 1**
+/// is rejected rather than guessed at: `rse = 25` is overwhelmingly a percent
+/// written without its sign, and silently reading it as 2500% would produce a
+/// prior so flat it is indistinguishable from none — a failure the user would
+/// never see, because the fit still converges.
+fn parse_prior_call(
+    inner: &str,
+    block: &str,
+    stmt: &str,
+) -> Result<(f64, crate::types::PriorSpread), String> {
+    let ctx = || format!("[{block}] prior on `{}`", stmt.trim());
+    let parts: Vec<&str> = inner.split(',').map(|s| s.trim()).collect();
+    if parts.len() != 2 {
+        return Err(format!(
+            "{}: expected `prior(<value>, rse = <r>%)` or `prior(<value>, sd = <s>)`, \
+             got `prior({})`",
+            ctx(),
+            inner.trim()
+        ));
+    }
+
+    // The central value, with `value =` optional so both spellings read the same.
+    let value_txt = match parts[0].split_once('=') {
+        Some((k, v)) if k.trim().eq_ignore_ascii_case("value") => v.trim(),
+        Some(_) => {
+            return Err(format!(
+                "{}: the first argument is the prior's central value; \
+                 write it bare (`prior(0.15, …)`) or as `value = 0.15`",
+                ctx()
+            ))
+        }
+        None => parts[0],
+    };
+    let value: f64 = value_txt
+        .parse()
+        .map_err(|_| format!("{}: `{value_txt}` is not a number", ctx()))?;
+    if !value.is_finite() {
+        return Err(format!("{}: central value must be finite", ctx()));
+    }
+
+    let (key, raw) = parts[1].split_once('=').ok_or_else(|| {
+        format!(
+            "{}: the second argument must be `rse = <r>%` or `sd = <s>`, got `{}`",
+            ctx(),
+            parts[1]
+        )
+    })?;
+    let (key, raw) = (key.trim(), raw.trim());
+    let spread = if key.eq_ignore_ascii_case("rse") {
+        let (num_txt, is_percent) = match raw.strip_suffix('%') {
+            Some(n) => (n.trim(), true),
+            None => (raw, false),
+        };
+        let num: f64 = num_txt
+            .parse()
+            .map_err(|_| format!("{}: `{raw}` is not a number", ctx()))?;
+        if !is_percent && num > 1.0 {
+            return Err(format!(
+                "{}: `rse = {num}` is ambiguous — write `{num}%` for a percent \
+                 or a fraction below 1 (e.g. `{}`) instead.",
+                ctx(),
+                num / 100.0
+            ));
+        }
+        if !(num > 0.0) || !num.is_finite() {
+            return Err(format!("{}: `rse` must be > 0, got {num}", ctx()));
+        }
+        crate::types::PriorSpread::Rse(if is_percent { num / 100.0 } else { num })
+    } else if key.eq_ignore_ascii_case("sd") {
+        let num: f64 = raw
+            .parse()
+            .map_err(|_| format!("{}: `{raw}` is not a number", ctx()))?;
+        if !(num > 0.0) || !num.is_finite() {
+            return Err(format!("{}: `sd` must be > 0, got {num}", ctx()));
+        }
+        crate::types::PriorSpread::Sd(num)
+    } else {
+        return Err(format!(
+            "{}: unknown prior argument `{key}`; expected `rse` or `sd`",
+            ctx()
+        ));
+    };
+    Ok((value, spread))
 }
 
 /// Does `s[i..]` begin with the keyword `kw`, terminated by a non-identifier

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -22455,12 +22455,27 @@ fn a_bare_rse_above_one_is_rejected_as_ambiguous() {
 /// its place.
 #[test]
 fn a_malformed_prior_call_is_rejected() {
-    let cases: [(&str, &str); 5] = [
+    let cases: [(&str, &str); 13] = [
         ("prior(0.15)", "expected"),
         ("prior(0.15, 0.25)", "rse"),
         ("prior(0.15, cv = 25%)", "unknown prior argument"),
         ("prior(0.15, rse = 25%, sd = 0.1)", "expected"),
         ("prior(abc, rse = 25%)", "not a number"),
+        // The first argument is the central value; any other key there is a
+        // mistake rather than a second spread.
+        ("prior(mean = 0.15, rse = 25%)", "central value"),
+        // Non-finite central value — caught before it can reach the packed
+        // `ln` and become a silent NaN prior mean.
+        ("prior(inf, rse = 25%)", "must be finite"),
+        ("prior(nan, rse = 25%)", "must be finite"),
+        // Unparseable and out-of-range spreads, both spellings. A spread of 0
+        // is a point mass, not a prior, and a negative one is nonsense; either
+        // would otherwise divide the penalty by zero or flip its sign.
+        ("prior(0.15, rse = abc%)", "not a number"),
+        ("prior(0.15, rse = 0%)", "must be > 0"),
+        ("prior(0.15, rse = -5%)", "must be > 0"),
+        ("prior(0.15, sd = abc)", "not a number"),
+        ("prior(0.15, sd = 0)", "must be > 0"),
     ];
     for (call, needle) in cases {
         let err = parse_err(&priored_model(&format!(
@@ -22474,6 +22489,48 @@ fn a_malformed_prior_call_is_rejected() {
             "`{call}` should mention `{needle}`: {err}"
         );
     }
+}
+
+/// `value = 0.15` is the long spelling of the bare first argument, and means
+/// exactly the same thing.
+///
+/// Asserted as an *equality* against the bare form rather than merely parsing,
+/// because the failure mode worth catching is the two spellings resolving to
+/// different priors — which no "it parses" check can see.
+#[test]
+fn the_central_value_may_be_written_with_its_keyword() {
+    let parse_one = |call: &str| {
+        parse_full_model(&priored_model(&format!(
+            "  theta TVCL(0.2, 0.001, 10.0) {call}\n  \
+             theta TVV(10.0, 0.1, 500.0)\n  \
+             omega ETA_CL ~ 0.09\n  \
+             sigma PROP_ERR ~ 0.04\n\n"
+        )))
+        .unwrap_or_else(|e| panic!("`{call}` must parse: {e}"))
+        .model
+        .priors
+        .remove(0)
+    };
+
+    let keyed = parse_one("prior(value = 0.15, rse = 25%)");
+    let bare = parse_one("prior(0.15, rse = 25%)");
+    assert_eq!(keyed.name, bare.name);
+    assert_eq!(keyed.value, bare.value);
+    assert_eq!(keyed.spread, bare.spread);
+    assert_eq!(keyed.value, 0.15);
+}
+
+/// An unterminated `prior(` is an error naming the line, not a panic and not a
+/// silently dropped tail.
+#[test]
+fn an_unbalanced_prior_call_is_rejected() {
+    let err = parse_err(&priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0) prior(0.15, rse = 25%\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    ));
+    assert!(err.contains("prior"), "got: {err}");
 }
 
 /// A `prior(...)` on a declaration that cannot carry one must be an error, not

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -5513,7 +5513,7 @@ fn test_parse_diagonal_omega() {
         "omega ETA_CL ~ 0.07".to_string(),
         "omega ETA_V  ~ 0.02".to_string(),
     ];
-    let (_, omegas, block_omegas, _, _, _, _, _, _, _) =
+    let (_, omegas, block_omegas, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(omegas.len(), 2);
     assert_eq!(block_omegas.len(), 0);
@@ -5524,7 +5524,7 @@ fn test_parse_diagonal_omega() {
 #[test]
 fn test_parse_block_omega() {
     let lines = vec!["block_omega (ETA_CL, ETA_V) = [0.09, 0.02, 0.04]".to_string()];
-    let (_, omegas, block_omegas, _, _, _, _, _, _, _) =
+    let (_, omegas, block_omegas, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(omegas.len(), 0);
     assert_eq!(block_omegas.len(), 1);
@@ -5542,7 +5542,7 @@ fn test_parse_block_omega_multiline() {
         "0.02, 0.04".to_string(),
         "]".to_string(),
     ];
-    let (_, omegas, block_omegas, _, _, eta_names, _, _, _, _) =
+    let (_, omegas, block_omegas, _, _, eta_names, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(omegas.len(), 0);
     assert_eq!(block_omegas.len(), 1);
@@ -5559,7 +5559,7 @@ fn test_parse_block_omega_multiline_fix() {
         "block_omega (ETA_CL, ETA_V) = [0.09,".to_string(),
         "0.02, 0.04] FIX".to_string(),
     ];
-    let (_, _, block_omegas, _, _, _, _, _, _, _) =
+    let (_, _, block_omegas, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(block_omegas.len(), 1);
     assert!(block_omegas[0].fixed);
@@ -5575,7 +5575,7 @@ fn test_parse_block_omega_multiline_fix_own_line() {
         "]".to_string(),
         "FIX".to_string(),
     ];
-    let (_, _, block_omegas, _, _, _, _, _, _, _) =
+    let (_, _, block_omegas, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(block_omegas.len(), 1);
     assert!(block_omegas[0].fixed);
@@ -5588,7 +5588,7 @@ fn test_parse_block_kappa_multiline() {
         "0.05, 0.01, 0.03".to_string(),
         "]".to_string(),
     ];
-    let (_, _, _, _, _, _, kappas, _, _, _) =
+    let (_, _, _, _, _, _, kappas, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(kappas.block.len(), 1);
     assert_eq!(kappas.block[0].names, vec!["KAPPA_CL", "KAPPA_V"]);
@@ -5605,7 +5605,7 @@ fn test_parse_block_kappa_multiline_fix_own_line() {
         "]".to_string(),
         "FIX".to_string(),
     ];
-    let (_, _, _, _, _, _, kappas, _, _, _) =
+    let (_, _, _, _, _, _, kappas, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(kappas.block.len(), 1);
     assert!(kappas.block[0].fixed);
@@ -5616,7 +5616,7 @@ fn test_parse_block_omega_3x3() {
     let lines = vec![
         "block_omega (ETA_CL, ETA_V, ETA_KA) = [0.09, 0.01, 0.04, 0.005, 0.002, 0.16]".to_string(),
     ];
-    let (_, _, block_omegas, _, _, _, _, _, _, _) =
+    let (_, _, block_omegas, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(block_omegas[0].names.len(), 3);
     assert_eq!(block_omegas[0].lower_triangle.len(), 6); // 3*(3+1)/2
@@ -5637,7 +5637,7 @@ fn test_parse_mixed_diagonal_and_block() {
         "omega ETA_KA ~ 0.40".to_string(),
         "block_omega (ETA_CL, ETA_V) = [0.09, 0.02, 0.04]".to_string(),
     ];
-    let (_, omegas, block_omegas, _, _, eta_names, _, _, _, _) =
+    let (_, omegas, block_omegas, _, _, eta_names, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(omegas.len(), 1);
     assert_eq!(block_omegas.len(), 1);
@@ -5651,7 +5651,7 @@ fn test_declaration_order_block_before_diagonal() {
         "block_omega (ETA_CL, ETA_V) = [0.09, 0.02, 0.04]".to_string(),
         "omega ETA_KA ~ 0.40".to_string(),
     ];
-    let (_, _, _, _, _, eta_names, _, _, _, _) =
+    let (_, _, _, _, _, eta_names, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     // block_omega declared first, so ETA_CL, ETA_V come before ETA_KA
     assert_eq!(eta_names, vec!["ETA_CL", "ETA_V", "ETA_KA"]);
@@ -5748,7 +5748,7 @@ fn test_build_omega_matrix_mixed() {
 #[test]
 fn test_parse_theta_fix_without_bounds() {
     let lines = vec!["theta TVCL(0.1, FIX)".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(thetas[0].fixed);
@@ -5758,7 +5758,7 @@ fn test_parse_theta_fix_without_bounds() {
 #[test]
 fn test_parse_theta_fix_with_bounds() {
     let lines = vec!["theta TVCL(0.1, 0.01, 1.0, FIX)".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(thetas[0].fixed);
     assert!((thetas[0].lower - 0.01).abs() < 1e-12);
@@ -5769,7 +5769,7 @@ fn test_parse_theta_fix_with_bounds() {
 fn test_parse_theta_fix_no_comma_inside_parens() {
     // theta NAME(init FIX) — no comma before FIX
     let lines = vec!["theta TVCL(0.75 FIX)".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(thetas[0].fixed);
@@ -5780,7 +5780,7 @@ fn test_parse_theta_fix_no_comma_inside_parens() {
 fn test_parse_theta_fix_after_paren() {
     // theta NAME(init) FIX — FIX outside closing paren
     let lines = vec!["theta TVCL(0.75) FIX".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(thetas[0].fixed);
@@ -5791,7 +5791,7 @@ fn test_parse_theta_fix_after_paren() {
 fn test_parse_theta_fix_after_paren_with_bounds() {
     // theta NAME(init, lower, upper) FIX — bounds + FIX outside paren
     let lines = vec!["theta TVKA(1.0, 0.01, 10.0) FIX".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(thetas[0].fixed);
@@ -5804,7 +5804,7 @@ fn test_parse_theta_fix_after_paren_with_bounds() {
 fn test_parse_theta_lower_bound_only() {
     // theta NAME(init, lower) — upper defaults to 1e9
     let lines = vec!["theta TVCL(1.0, 0.01)".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(!thetas[0].fixed);
@@ -5817,7 +5817,7 @@ fn test_parse_theta_lower_bound_only() {
 fn test_parse_theta_lower_bound_fix_inside() {
     // theta NAME(init, lower, FIX) — lower only + FIX inside parens
     let lines = vec!["theta TVCL(1.0, 0.01, FIX)".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(thetas[0].fixed);
@@ -5829,7 +5829,7 @@ fn test_parse_theta_lower_bound_fix_inside() {
 fn test_parse_theta_lower_bound_fix_outside() {
     // theta NAME(init, lower) FIX — lower only + FIX after paren
     let lines = vec!["theta TVCL(1.0, 0.01) FIX".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 1);
     assert!(thetas[0].fixed);
@@ -5840,7 +5840,7 @@ fn test_parse_theta_lower_bound_fix_outside() {
 #[test]
 fn test_parse_theta_unfixed_by_default() {
     let lines = vec!["theta TVCL(0.1, 0.01, 1.0)".to_string()];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(!thetas[0].fixed);
 }
@@ -5855,7 +5855,7 @@ fn test_parse_theta_allows_space_before_paren() {
         "theta TVV  ( 10 )".to_string(),
         "theta TVKA\t(0.5, FIX)".to_string(),
     ];
-    let (thetas, _, _, _, _, _, _, _, _, _) =
+    let (thetas, _, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(thetas.len(), 3);
     assert_eq!(thetas[0].name, "TVCL");
@@ -5872,7 +5872,7 @@ fn test_parse_theta_allows_space_before_paren() {
 #[test]
 fn test_parse_omega_fix() {
     let lines = vec!["omega ETA_CL ~ 0.09 FIX".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(omegas[0].fixed);
 }
@@ -5883,7 +5883,7 @@ fn test_omega_unfixed_no_annotation() {
     // group-numbering shift (annotation moved 3→4) didn't regress the
     // common case.
     let lines = vec!["omega ETA_CL ~ 0.09".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(!omegas[0].fixed);
     assert!(!omegas[0].init_as_sd);
@@ -5895,7 +5895,7 @@ fn test_omega_double_fix_is_harmless() {
     // `FIX (sd) FIX` — both FIX groups fire; result must still be fixed
     // with SD squaring applied.
     let lines = vec!["omega ETA_CL ~ 0.30 FIX (sd) FIX".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     let expected = 0.30 * 0.30;
     assert!((omegas[0].variance - expected).abs() < 1e-12);
@@ -5906,7 +5906,7 @@ fn test_omega_double_fix_is_harmless() {
 #[test]
 fn test_parse_sigma_fix() {
     let lines = vec!["sigma PROP ~ 0.05 FIX".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(sigmas[0].fixed);
 }
@@ -5914,7 +5914,7 @@ fn test_parse_sigma_fix() {
 #[test]
 fn test_parse_block_sigma_builds_sigmas_and_correlation() {
     let lines = vec!["block_sigma (PROP, ADD) = [0.04, 0.10, 1.0]".to_string()];
-    let (_, _, _, sigmas, block_sigmas, _, _, _, _, _) =
+    let (_, _, _, sigmas, block_sigmas, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(sigmas.len(), 2);
     assert_eq!(sigmas[0].name, "PROP");
@@ -5935,7 +5935,7 @@ fn test_parse_block_sigma_builds_sigmas_and_correlation() {
 #[test]
 fn test_parse_block_sigma_fix_marks_sigmas_fixed() {
     let lines = vec!["block_sigma (PROP, ADD) = [0.04, 0.10, 1.0] FIX".to_string()];
-    let (_, _, _, sigmas, block_sigmas, _, _, _, _, _) =
+    let (_, _, _, sigmas, block_sigmas, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(sigmas.iter().all(|s| s.fixed));
 
@@ -6067,7 +6067,7 @@ fn test_build_residual_correlations_zero_covariance_omitted_when_fixed() {
 #[test]
 fn test_parse_block_omega_fix() {
     let lines = vec!["block_omega (ETA_CL, ETA_V) = [0.09, 0.02, 0.04] FIX".to_string()];
-    let (_, _, blocks, _, _, _, _, _, _, _) =
+    let (_, _, blocks, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(blocks[0].fixed);
 }
@@ -6079,7 +6079,7 @@ fn test_fix_keyword_case_insensitive() {
         "omega ETA ~ 0.05 Fix".to_string(),
         "sigma S ~ 0.02 FIX".to_string(),
     ];
-    let (thetas, omegas, _, sigmas, _, _, _, _, _, _) =
+    let (thetas, omegas, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(thetas[0].fixed);
     assert!(omegas[0].fixed);
@@ -6092,7 +6092,7 @@ fn test_fix_keyword_case_insensitive() {
 fn test_omega_default_is_variance() {
     // No annotation: value is stored verbatim as variance.
     let lines = vec!["omega ETA_CL ~ 0.07".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!((omegas[0].variance - 0.07).abs() < 1e-12);
     assert!(!omegas[0].init_as_sd);
@@ -6102,7 +6102,7 @@ fn test_omega_default_is_variance() {
 fn test_omega_sd_annotation_squares_value() {
     // `(sd)` → variance is the square of the raw value.
     let lines = vec!["omega ETA_CL ~ 0.265 (sd)".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     let expected = 0.265 * 0.265;
     assert!((omegas[0].variance - expected).abs() < 1e-12);
@@ -6116,7 +6116,7 @@ fn test_omega_variance_annotation_is_noop() {
         "omega ETA_CL ~ 0.07 (variance)".to_string(),
         "omega ETA_V  ~ 0.04 (var)".to_string(),
     ];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!((omegas[0].variance - 0.07).abs() < 1e-12);
     assert!(!omegas[0].init_as_sd);
@@ -6128,7 +6128,7 @@ fn test_omega_variance_annotation_is_noop() {
 fn test_omega_sd_annotation_with_fix() {
     // `(sd) FIX` — both annotations must be honored together.
     let lines = vec!["omega ETA_CL ~ 0.30 (sd) FIX".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     let expected = 0.30 * 0.30;
     assert!((omegas[0].variance - expected).abs() < 1e-12);
@@ -6140,7 +6140,7 @@ fn test_omega_sd_annotation_with_fix() {
 fn test_omega_fix_before_sd_annotation() {
     // `FIX (sd)` — FIX before the scale annotation.
     let lines = vec!["omega ETA_CL ~ 0.30 FIX (sd)".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     let expected = 0.30 * 0.30;
     assert!((omegas[0].variance - expected).abs() < 1e-12);
@@ -6152,7 +6152,7 @@ fn test_omega_fix_before_sd_annotation() {
 fn test_omega_fix_before_annotation_no_sd() {
     // `FIX` before a no-op annotation — fixed and variance-scale.
     let lines = vec!["omega ETA_CL ~ 0.09 FIX (variance)".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!((omegas[0].variance - 0.09).abs() < 1e-12);
     assert!(omegas[0].fixed);
@@ -6163,7 +6163,7 @@ fn test_omega_fix_before_annotation_no_sd() {
 fn test_sigma_fix_before_sd_annotation() {
     // `FIX (sd)` — FIX before the scale annotation for sigma.
     let lines = vec!["sigma PROP ~ 0.30 FIX (sd)".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(sigmas[0].fixed);
     assert!(sigmas[0].init_as_sd);
@@ -6174,7 +6174,7 @@ fn test_sigma_fix_before_sd_annotation() {
 fn test_sigma_fix_after_sd_annotation() {
     // `(sd) FIX` — existing form still works.
     let lines = vec!["sigma PROP ~ 0.30 (sd) FIX".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(sigmas[0].fixed);
     assert!(sigmas[0].init_as_sd);
@@ -6185,7 +6185,7 @@ fn test_sigma_unfixed_no_annotation() {
     // Baseline: plain sigma with no FIX and no annotation — confirms the
     // group-numbering shift didn't regress the common case.
     let lines = vec!["sigma PROP ~ 0.04".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(!sigmas[0].fixed);
     assert!(!sigmas[0].init_as_sd);
@@ -6198,7 +6198,7 @@ fn test_sigma_default_is_variance() {
     // Since #56, the default sigma input is variance — the parser sqrt's
     // it into the internal SD representation that the likelihood uses.
     let lines = vec!["sigma PROP ~ 0.04".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     // Stored value is SD = sqrt(variance) = sqrt(0.04) = 0.2.
     assert!((sigmas[0].value - 0.2).abs() < 1e-12);
@@ -6209,7 +6209,7 @@ fn test_sigma_default_is_variance() {
 fn test_sigma_sd_annotation_stores_value_as_is() {
     // `(sd)` → the value is already on the SD scale, no transform.
     let lines = vec!["sigma PROP ~ 0.2 (sd)".to_string()];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!((sigmas[0].value - 0.2).abs() < 1e-12);
     assert!(sigmas[0].init_as_sd);
@@ -6223,7 +6223,7 @@ fn test_sigma_default_and_sd_equivalent_initial_value() {
         "sigma A ~ 0.0004".to_string(),    // variance 0.0004
         "sigma B ~ 0.02 (sd)".to_string(), // SD 0.02
     ];
-    let (_, _, _, sigmas, _, _, _, _, _, _) =
+    let (_, _, _, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!((sigmas[0].value - sigmas[1].value).abs() < 1e-12);
 }
@@ -6272,7 +6272,7 @@ fn test_omega_negative_value_rejected() {
 #[test]
 fn test_kappa_sd_annotation_squares_value() {
     let lines = vec!["kappa KAPPA_CL ~ 0.25 (sd)".to_string()];
-    let (_, _, _, _, _, _, kappas, _, _, _) =
+    let (_, _, _, _, _, _, kappas, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     let k = &kappas.diagonal[0];
     let expected = 0.25 * 0.25;
@@ -6288,7 +6288,7 @@ fn test_sd_annotation_case_insensitive() {
         "omega ETA_B ~ 0.2 (Sd)".to_string(),
         "omega ETA_C ~ 0.3 (sd)".to_string(),
     ];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert!(omegas.iter().all(|o| o.init_as_sd));
 }
@@ -6304,7 +6304,7 @@ fn test_unknown_scale_tag_is_ignored_as_trailing_garbage() {
     // behavior; anything else is silently ignored, consistent with the
     // parser's existing FIXED-vs-FIX handling.)
     let lines = vec!["omega ETA_CL ~ 0.07 (foo)".to_string()];
-    let (_, omegas, _, _, _, _, _, _, _, _) =
+    let (_, omegas, _, _, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(omegas.len(), 1);
     assert!((omegas[0].variance - 0.07).abs() < 1e-12);
@@ -6360,7 +6360,7 @@ fn test_fix_keyword_rejects_prefix_match() {
         "sigma PROP ~ 0.02 FIXED".to_string(),
         "block_omega (A, B) = [1.0, 0.0, 1.0] FIXED".to_string(),
     ];
-    let (_, omegas, blocks, sigmas, _, _, _, _, _, _) =
+    let (_, omegas, blocks, sigmas, _, _, _, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     // omega/sigma still parse (trailing `FIXED` is ignored) but must NOT
     // be marked fixed.
@@ -7778,7 +7778,7 @@ fn test_apply_fit_option_fd_hessian_step_negative_rejected() {
 #[test]
 fn test_parse_kappa_keyword() {
     let lines = vec!["kappa KAPPA_CL ~ 0.01".to_string()];
-    let (_, _, _, _, _, _, ki, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
+    let (_, _, _, _, _, _, ki, _, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(ki.diagonal.len(), 1);
     assert_eq!(ki.diagonal[0].name, "KAPPA_CL");
     assert!((ki.diagonal[0].variance - 0.01).abs() < 1e-12);
@@ -7788,7 +7788,7 @@ fn test_parse_kappa_keyword() {
 #[test]
 fn test_parse_kappa_fix() {
     let lines = vec!["kappa KAPPA_V ~ 0.05 FIX".to_string()];
-    let (_, _, _, _, _, _, ki, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
+    let (_, _, _, _, _, _, ki, _, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
     assert!(ki.diagonal[0].fixed);
 }
 
@@ -7797,7 +7797,7 @@ fn test_kappa_unfixed_no_annotation() {
     // Baseline: plain kappa with no FIX and no annotation — confirms the
     // group-numbering shift didn't regress the common case.
     let lines = vec!["kappa KAPPA_V ~ 0.05".to_string()];
-    let (_, _, _, _, _, _, ki, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
+    let (_, _, _, _, _, _, ki, _, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
     assert!(!ki.diagonal[0].fixed);
     assert!(!ki.diagonal[0].init_as_sd);
     assert!((ki.diagonal[0].variance - 0.05).abs() < 1e-12);
@@ -7807,7 +7807,7 @@ fn test_kappa_unfixed_no_annotation() {
 fn test_kappa_fix_before_sd_annotation() {
     // `FIX (sd)` — FIX before the scale annotation for kappa.
     let lines = vec!["kappa KAPPA_V ~ 0.30 FIX (sd)".to_string()];
-    let (_, _, _, _, _, _, ki, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
+    let (_, _, _, _, _, _, ki, _, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
     let expected = 0.30 * 0.30;
     assert!((ki.diagonal[0].variance - expected).abs() < 1e-12);
     assert!(ki.diagonal[0].fixed);
@@ -7822,7 +7822,7 @@ fn test_kappa_appended_after_bsv_etas() {
         "omega ETA_CL ~ 0.09".to_string(),
         "kappa KAPPA_CL ~ 0.01".to_string(),
     ];
-    let (_, _, _, _, _, bsv_etas, ki, _, _, _) =
+    let (_, _, _, _, _, bsv_etas, ki, _, _, _, _) =
         parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(bsv_etas, vec!["ETA_CL"]);
     assert_eq!(ki.diagonal.len(), 1);
@@ -7953,7 +7953,7 @@ fn test_iov_occasion_parsed_from_fit_options_block() {
 #[test]
 fn test_parse_block_kappa_syntax() {
     let lines = vec!["block_kappa (KAPPA_CL, KAPPA_V) = [0.01, 0.002, 0.005]".to_string()];
-    let (_, _, _, _, _, _, ki, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
+    let (_, _, _, _, _, _, ki, _, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
     assert_eq!(ki.diagonal.len(), 0);
     assert_eq!(ki.block.len(), 1);
     assert_eq!(ki.block[0].names, vec!["KAPPA_CL", "KAPPA_V"]);
@@ -7965,7 +7965,7 @@ fn test_parse_block_kappa_syntax() {
 #[test]
 fn test_parse_block_kappa_fix() {
     let lines = vec!["block_kappa (KAPPA_CL, KAPPA_V) = [0.01, 0.002, 0.005] FIX".to_string()];
-    let (_, _, _, _, _, _, ki, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
+    let (_, _, _, _, _, _, ki, _, _, _, _) = parse_parameters(&lines, &Default::default()).unwrap();
     assert!(ki.block[0].fixed);
 }
 
@@ -22340,4 +22340,213 @@ mod unreachable_unary_fn_arms {
     fn the_differentiator_panics_rather_than_passing_the_derivative_through() {
         differentiate(&out_of_whitelist(), DiffAxis::Theta(0));
     }
+}
+
+// ── Inline `prior(...)` declarations (#254) ──────────────────────────────────
+
+/// A one-compartment IV model whose `[parameters]` block the caller supplies,
+/// so each prior test differs from the next by exactly the declaration under
+/// test.
+fn priored_model(parameters: &str) -> String {
+    format!(
+        "[parameters]\n{parameters}\n\
+         [individual_parameters]\n\
+         \x20 CL = TVCL * exp(ETA_CL)\n\
+         \x20 V  = TVV\n\n\
+         [structural_model]\n\
+         \x20 pk one_cpt_iv(cl=CL, v=V)\n\n\
+         [error_model]\n\
+         \x20 DV ~ proportional(PROP_ERR)\n"
+    )
+}
+
+const PRIOR_BASE_PARAMS: &str = "  theta TVCL(0.2, 0.001, 10.0)\n  \
+                                 theta TVV(10.0, 0.1, 500.0)\n  \
+                                 omega ETA_CL ~ 0.09\n  \
+                                 sigma PROP_ERR ~ 0.04\n\n";
+
+/// The tail parses on every declaration kind and lands on the right parameter,
+/// with `25%` and `0.25` meaning the same thing.
+#[test]
+fn prior_tail_parses_on_theta_omega_and_sigma() {
+    let src = priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0) prior(0.15, rse = 25%)\n  \
+         theta TVV(10.0, 0.1, 500.0) prior(9.8, rse = 0.25)\n  \
+         omega ETA_CL ~ 0.09 prior(0.09, rse = 40%)\n  \
+         sigma PROP_ERR ~ 0.04 prior(0.04, sd = 0.01)\n\n",
+    );
+    let model = parse_full_model(&src)
+        .unwrap_or_else(|e| panic!("priored model should parse: {e}"))
+        .model;
+
+    let names: Vec<&str> = model.priors.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, ["TVCL", "TVV", "ETA_CL", "PROP_ERR"]);
+    assert_eq!(model.priors[0].value, 0.15);
+    // Both spellings normalize to the same fraction, so nothing downstream has
+    // to know which was written.
+    assert_eq!(model.priors[0].spread, crate::types::PriorSpread::Rse(0.25));
+    assert_eq!(model.priors[1].spread, crate::types::PriorSpread::Rse(0.25));
+    assert_eq!(model.priors[2].spread, crate::types::PriorSpread::Rse(0.4));
+    assert_eq!(model.priors[3].spread, crate::types::PriorSpread::Sd(0.01));
+}
+
+/// A model with no `prior(...)` anywhere carries no priors — the control for
+/// every test above, without which they could all pass on a parser that
+/// attached a prior to everything.
+#[test]
+fn a_model_without_priors_declares_none() {
+    let model = parse_full_model(&priored_model(PRIOR_BASE_PARAMS))
+        .expect("base model should parse")
+        .model;
+    assert!(model.priors.is_empty());
+}
+
+/// The tail must survive next to every other modifier the declaration can
+/// carry, since it is peeled before the declaration regexes run and they are
+/// all unanchored.
+#[test]
+fn prior_tail_coexists_with_fix_and_scale_annotations() {
+    let src = priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0) prior(0.15, rse = 25%)\n  \
+         theta TVV(10.0, 0.1, 500.0) FIX\n  \
+         omega ETA_CL ~ 0.3 (sd) prior(0.3, rse = 20%)\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    );
+    let model = parse_full_model(&src)
+        .unwrap_or_else(|e| panic!("should parse: {e}"))
+        .model;
+    assert_eq!(model.priors.len(), 2);
+    // The `(sd)` annotation still reached the omega parser: without the peel,
+    // `omega_re` would have matched a line ending in `prior(...)` and the
+    // annotation group would have captured nothing.
+    assert_eq!(model.omega_init_as_sd, vec![true]);
+}
+
+/// `rse = 25` is neither 25% nor 0.25, and reading it as 2500% would give a
+/// prior so flat the fit is indistinguishable from an unpriored one — a
+/// mistake the user could never see. Reject it and name both spellings.
+#[test]
+fn a_bare_rse_above_one_is_rejected_as_ambiguous() {
+    let err = parse_err(&priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0) prior(0.15, rse = 25)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    ));
+    assert!(err.contains("ambiguous"), "got: {err}");
+    assert!(err.contains("25%"), "must name the percent spelling: {err}");
+    assert!(
+        err.contains("0.25"),
+        "must name the fraction spelling: {err}"
+    );
+
+    // The straddle: a fraction at or below 1 is accepted, so the check rejects
+    // the ambiguous case rather than every bare number.
+    let ok = priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0) prior(0.15, rse = 0.25)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    );
+    assert!(parse_full_model(&ok).is_ok());
+}
+
+/// Exactly one of `rse` / `sd` is required, and nothing else is accepted in
+/// its place.
+#[test]
+fn a_malformed_prior_call_is_rejected() {
+    let cases: [(&str, &str); 5] = [
+        ("prior(0.15)", "expected"),
+        ("prior(0.15, 0.25)", "rse"),
+        ("prior(0.15, cv = 25%)", "unknown prior argument"),
+        ("prior(0.15, rse = 25%, sd = 0.1)", "expected"),
+        ("prior(abc, rse = 25%)", "not a number"),
+    ];
+    for (call, needle) in cases {
+        let err = parse_err(&priored_model(&format!(
+            "  theta TVCL(0.2, 0.001, 10.0) {call}\n  \
+             theta TVV(10.0, 0.1, 500.0)\n  \
+             omega ETA_CL ~ 0.09\n  \
+             sigma PROP_ERR ~ 0.04\n\n"
+        )));
+        assert!(
+            err.contains(needle),
+            "`{call}` should mention `{needle}`: {err}"
+        );
+    }
+}
+
+/// A `prior(...)` on a declaration that cannot carry one must be an error, not
+/// a silently ignored tail — the failure mode the peel exists to remove.
+#[test]
+fn a_prior_on_a_block_declaration_is_rejected() {
+    let src = priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         block_omega (ETA_CL, ETA_V) = [0.09, 0.01, 0.09] prior(0.09, rse = 40%)\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    )
+    .replace("V  = TVV", "V  = TVV * exp(ETA_V)");
+    let err = parse_err(&src);
+    assert!(err.contains("only supported on"), "got: {err}");
+    assert!(err.contains("block_omega"), "got: {err}");
+}
+
+/// A θ level block is many parameters sharing one declaration, so one prior
+/// would have to mean "the same prior on every level" — a different feature.
+#[test]
+fn a_prior_on_a_theta_level_block_is_rejected() {
+    let err = parse_err(&priored_model(
+        "  theta TVCL[3](0.2, 0.001, 10.0) prior(0.15, rse = 25%)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    ));
+    assert!(err.contains("level block"), "got: {err}");
+}
+
+/// `weight = <expr>` swallows everything to its right, so a prior written after
+/// one on a kappa declaration must still be peeled first. Without the ordering
+/// the model parses cleanly and fits unpenalized.
+#[test]
+fn a_prior_after_a_kappa_weight_modifier_is_still_seen() {
+    let src = "[parameters]\n  \
+         theta TVCL(0.2, 0.001, 10.0)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         kappa K_CL ~ 0.04 weight = NARM prior(0.04, rse = 30%)\n  \
+         sigma PROP_ERR ~ 0.04\n\n\
+         [individual_parameters]\n  \
+         CL = TVCL * exp(ETA_CL + K_CL)\n  \
+         V  = TVV\n\n\
+         [structural_model]\n  \
+         pk one_cpt_iv(cl=CL, v=V)\n\n\
+         [error_model]\n  \
+         DV ~ proportional(PROP_ERR)\n";
+    let model = parse_full_model(src)
+        .unwrap_or_else(|e| panic!("should parse: {e}"))
+        .model;
+    assert_eq!(model.priors.len(), 1);
+    assert_eq!(model.priors[0].name, "K_CL");
+    // Both modifiers survived: the weight went to the kappa, the prior to the
+    // prior list. Either one alone passing would hide the ordering bug.
+    assert_eq!(model.kappa_weights.len(), 1);
+    assert!(model.kappa_weights[0].is_some());
+}
+
+/// A name containing `prior` is not the modifier.
+#[test]
+fn an_identifier_containing_prior_is_not_the_modifier() {
+    let src = priored_model(
+        "  theta MY_prior(0.2, 0.001, 10.0)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    )
+    .replace("CL = TVCL", "CL = MY_prior");
+    let model = parse_full_model(&src)
+        .unwrap_or_else(|e| panic!("should parse: {e}"))
+        .model;
+    assert!(model.priors.is_empty());
+    assert!(model.theta_names.iter().any(|n| n == "MY_prior"));
 }

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -22534,6 +22534,74 @@ fn a_prior_after_a_kappa_weight_modifier_is_still_seen() {
     assert!(model.kappa_weights[0].is_some());
 }
 
+/// A parameter *named* `prior` is not the modifier either.
+///
+/// `prior` is a legal name (every declaration regex takes `\w+`), so these are
+/// valid models that predate #254 and must keep parsing. Both spellings are
+/// here because they fail differently: `omega PRIOR ~ 0.1` reaches the
+/// call-shape test and was reported as "`prior` must be written as a call",
+/// while `theta prior(0.1, 0, 10)` *is* a call and was peeled off as a
+/// three-argument modifier, erroring on the argument list instead. Neither is
+/// caught by the `MY_prior` test below, whose left-boundary guard fires first.
+#[test]
+fn a_parameter_named_prior_is_not_the_modifier() {
+    // `~` form: the keyword sits in the name slot with no `(` after it.
+    let omega_named_prior = priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega PRIOR ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    )
+    .replace("exp(ETA_CL)", "exp(PRIOR)");
+    let model = parse_full_model(&omega_named_prior)
+        .unwrap_or_else(|e| panic!("`omega PRIOR ~ 0.09` must parse: {e}"))
+        .model;
+    assert!(model.priors.is_empty());
+    assert!(model.eta_names.iter().any(|n| n == "PRIOR"));
+
+    // Call form: the keyword sits in the name slot *and* is followed by `(`, so
+    // only the preceding `theta` separates it from a real modifier.
+    let theta_named_prior = priored_model(
+        "  theta prior(0.2, 0.001, 10.0)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    )
+    .replace("CL = TVCL", "CL = prior");
+    let model = parse_full_model(&theta_named_prior)
+        .unwrap_or_else(|e| panic!("`theta prior(...)` must parse: {e}"))
+        .model;
+    assert!(model.priors.is_empty());
+    assert!(model.theta_names.iter().any(|n| n == "prior"));
+
+    // The straddle, on the *same* declarations: one token further right and the
+    // identical keyword is the modifier again. Without this a fix that simply
+    // stopped recognising `prior` anywhere would pass the two halves above.
+    let both = priored_model(
+        "  theta prior(0.2, 0.001, 10.0) prior(0.2, rse = 25%)\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega PRIOR ~ 0.09 prior(0.09, rse = 40%)\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    )
+    .replace("CL = TVCL", "CL = prior")
+    .replace("exp(ETA_CL)", "exp(PRIOR)");
+    let model = parse_full_model(&both)
+        .unwrap_or_else(|e| panic!("a modifier after a same-named declaration must parse: {e}"))
+        .model;
+    let names: Vec<&str> = model.priors.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["prior", "PRIOR"]);
+
+    // And the bare-tail safety net still fires: a `prior` that is neither a name
+    // slot nor a call is an error, not a silently dropped tail.
+    let err = parse_err(&priored_model(
+        "  theta TVCL(0.2, 0.001, 10.0) prior\n  \
+         theta TVV(10.0, 0.1, 500.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         sigma PROP_ERR ~ 0.04\n\n",
+    ));
+    assert!(err.contains("must be written as a call"), "got: {err}");
+}
+
 /// A name containing `prior` is not the modifier.
 #[test]
 fn an_identifier_containing_prior_is_not_the_modifier() {

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -3413,6 +3413,7 @@ mod tests {
             PkModel, ScalingSpec, SigmaVector,
         };
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             name: "cl_from_cr".into(),
             pk_model: PkModel::OneCptIv,

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -2653,6 +2653,7 @@ mod tests {
 
     fn make_model() -> CompiledModel {
         CompiledModel {
+            priors: Vec::new(),
             covariate_model: None,
             name: "test".into(),
             pk_model: PkModel::OneCptIv,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2037,6 +2037,83 @@ pub struct ResidualCorrelation {
     pub rho: f64,
 }
 
+/// Spread of a user-declared parameter prior (#254).
+///
+/// Exactly one form is given per prior. `Rse` is the ergonomic one the feature
+/// exists for — a number read straight off a published parameter table — and
+/// `Sd` is the escape hatch for a θ that can be negative, where a *relative*
+/// standard error is meaningless.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq)]
+pub enum PriorSpread {
+    /// Relative standard error as a **fraction**. `rse = 25%` in the model file
+    /// arrives here as `0.25`; the parser is what normalizes the two spellings,
+    /// so nothing downstream has to know which one was written.
+    Rse(f64),
+    /// Absolute standard deviation, on the same scale the parameter was
+    /// declared on.
+    Sd(f64),
+}
+
+/// A prior declared on one parameter, for penalized-ML / MAP estimation (#254).
+///
+/// Written inline next to the parameter it constrains:
+///
+/// ```text
+/// [parameters]
+///   theta TVCL(0.2, 0.001, 10.0)  prior(0.15, rse = 25%)
+///   omega ETA_CL ~ 0.09           prior(0.09, rse = 40%)
+/// ```
+///
+/// **`value` is on the scale the parameter was declared on** — a variance for a
+/// bare `omega X ~ v`, an SD under `(sd)` — and so is a [`PriorSpread::Sd`].
+/// That single rule is the whole user-facing convention: the RSE comes off the
+/// same row of the same table as the value, and no conversion is ever asked for.
+///
+/// What the prior *becomes* — a normal on θ, a lognormal on θ, a lognormal on a
+/// variance — is decided by how the parameter packs, not by this struct.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct ParameterPrior {
+    /// Name of the theta, omega/eta, sigma or kappa this prior applies to, as
+    /// declared in `[parameters]`.
+    pub name: String,
+    /// Prior central value, on the declared scale.
+    pub value: f64,
+    /// Prior spread.
+    pub spread: PriorSpread,
+}
+
+/// One priored parameter's line in the fit report (#254).
+///
+/// Named `shift_in_prior_sds` rather than `shift` because the informative
+/// number is the standardized one: "CL landed 1.8 prior SDs above the prior"
+/// says whether the data and the prior disagree, where a raw difference only
+/// says the parameter moved.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
+pub struct PriorSummary {
+    /// Parameter name as declared.
+    pub name: String,
+    /// Prior central value, on the scale the parameter was declared on.
+    pub prior_value: f64,
+    /// Final estimate, on that same declared scale.
+    pub estimate: f64,
+    /// `(x̂ − m) / s` in packed space — how far the estimate sits from the prior
+    /// mean in prior standard deviations. Signed.
+    pub shift_in_prior_sds: f64,
+    /// This parameter's contribution to [`FitResult::ofv_prior`] (the square of
+    /// `shift_in_prior_sds`).
+    pub penalty: f64,
+    /// Realised prior family: `"lognormal"` for a log-packed coordinate,
+    /// `"normal"` for an identity-packed one. Reported because it is decided by
+    /// the parameter's declared lower bound, not by the prior declaration — so
+    /// widening a θ's bounds to allow negative values moves its prior from
+    /// lognormal to normal, and this field is where that becomes visible.
+    pub family: String,
+    /// Lower end of the implied 95% prior interval, on the declared scale.
+    pub prior_lower_95: f64,
+    /// Upper end of the implied 95% prior interval, on the declared scale.
+    pub prior_upper_95: f64,
+}
+
 /// Full set of model parameters
 #[derive(Debug, Clone)]
 pub struct ModelParameters {
@@ -3734,6 +3811,20 @@ pub struct CompiledModel {
     /// the source text plus an evaluator for the effective SD at a typical arm
     /// size (`γ/√W`), which is the number a reader actually needs.
     pub kappa_weights: Vec<Option<KappaWeight>>,
+    /// Per-parameter priors declared with an inline `prior(value, rse = …)`
+    /// (#254). Empty for an ordinary maximum-likelihood fit, in which case every
+    /// objective is bit-identical to one computed before this field existed.
+    ///
+    /// This rides the **model**, not [`FitOptions`], because a prior changes the
+    /// estimates: a caller who parses a `.ferx` file and then hands `fit()` a
+    /// `FitOptions::default()` must not silently get an unpenalized fit back.
+    /// (The covariate-NN regularizer makes the opposite choice — `nn_l2` is a
+    /// `[fit_options]` key — because there the penalty is a *tuning* knob a
+    /// caller legitimately sweeps.)
+    ///
+    /// Resolved against the packed layout by the internal `PriorSet` once per
+    /// estimation stage.
+    pub priors: Vec<ParameterPrior>,
     /// Detected mu-referencing relationships: eta_name → (theta_name, log_transformed).
     /// Populated by the parser; empty map means no mu-referencing detected.
     pub mu_refs: HashMap<String, MuRef>,
@@ -5863,7 +5954,33 @@ pub struct FitResult {
     /// Full sequence of methods executed, in order. Always has at least one entry.
     pub method_chain: Vec<EstimationMethod>,
     pub converged: bool,
+    /// The objective that was minimised. Equal to `ofv_data + ofv_prior`, so for
+    /// a model with no `prior(...)` declarations (#254) it is the plain −2 log L
+    /// it has always been.
     pub ofv: f64,
+    /// The data half of [`Self::ofv`] — the −2 log L with no prior penalty.
+    ///
+    /// This is what [`Self::aic`] and [`Self::bic`] are computed from, and what
+    /// should be compared against an unpriored fit of the same model.
+    #[serde(default)]
+    pub ofv_data: f64,
+    /// The prior half of [`Self::ofv`]: `Σ ((x̂ − m)/s)²` over the priored
+    /// coordinates (#254). Exactly `0.0` when no prior is declared.
+    ///
+    /// Normalisation constants are omitted here just as they are on the data
+    /// side (ferx's −2 log L drops `N·log(2π)`), so this is not absolutely
+    /// comparable to a NONMEM `$PRIOR` objective — compare ΔOFV against a null
+    /// twin instead.
+    #[serde(default)]
+    pub ofv_prior: f64,
+    /// Per-parameter prior report (#254): where the prior sat, where the
+    /// estimate landed, and how far apart they are in prior SDs. Empty when no
+    /// prior is declared.
+    ///
+    /// When this is non-empty the standard errors in `se_*` are the curvature of
+    /// the **penalized** objective — MAP / penalized-ML SEs, not posterior SDs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prior_summary: Vec<PriorSummary>,
     pub aic: f64,
     pub bic: f64,
     pub theta: Vec<f64>,

--- a/src/types_test_helpers.rs
+++ b/src/types_test_helpers.rs
@@ -13,6 +13,7 @@ pub(crate) fn ode_model(gradient_method: GradientMethod) -> CompiledModel {
 
 fn make_compiled_model(with_ode: bool, gradient_method: GradientMethod) -> CompiledModel {
     CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "test".into(),
         pk_model: PkModel::OneCptOral,
@@ -142,6 +143,7 @@ pub(crate) fn tv_cov_iv_model_and_subject() -> (CompiledModel, Subject) {
         mixture: None,
     };
     let model = CompiledModel {
+        priors: Vec::new(),
         covariate_model: None,
         name: "tv_cov_iv".into(),
         pk_model: PkModel::OneCptIv,
@@ -251,6 +253,9 @@ pub(crate) fn tv_cov_iv_model_and_subject() -> (CompiledModel, Subject) {
 /// ```
 pub(crate) fn empty_fit_result() -> FitResult {
     FitResult {
+        ofv_data: 0.0,
+        ofv_prior: 0.0,
+        prior_summary: Vec::new(),
         covariate_relations: Vec::new(),
         restored_from_checkpoint: false,
         method: EstimationMethod::FoceI,
@@ -380,6 +385,9 @@ pub(crate) fn empty_fit_result() -> FitResult {
 pub(crate) fn minimal_fit_result() -> FitResult {
     let n_eta = 2;
     FitResult {
+        ofv_data: 0.0,
+        ofv_prior: 0.0,
+        prior_summary: Vec::new(),
         residual_correlation_fixed: Vec::new(),
         se_residual_correlations: None,
         covariate_relations: Vec::new(),

--- a/tests/parameter_priors.rs
+++ b/tests/parameter_priors.rs
@@ -422,3 +422,340 @@ fn a_tight_prior_tightens_the_reported_standard_error() {
         "tightening the prior must tighten the SE: {se_loose} -> {se_tight}"
     );
 }
+
+// ── Review findings on 762f6aa (#1341) ──────────────────────────────────────
+
+/// **Finding 1.** A trailing *evaluation-only* stage is not an estimator, so it
+/// decides nothing about whether the prior was applied.
+///
+/// Both directions, because each alone passes under a different wrong predicate:
+/// `chain.last()` accepts the first and rejects the second, while "any stage
+/// applies priors" accepts both.
+#[test]
+fn the_prior_method_gate_looks_past_evaluation_only_stages() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let pop = warfarin_population();
+
+    // [saem, laplace] with agq_eval_only: Laplace is a supported method, but here
+    // it only evaluates SAEM's estimates. Nothing applied the prior → reject, and
+    // the message must name SAEM rather than the evaluator.
+    let mut eval_tail = short_focei();
+    eval_tail.methods = vec![EstimationMethod::Saem, EstimationMethod::Laplace];
+    eval_tail.agq_eval_only = true;
+    eval_tail.saem_n_exploration = 1;
+    eval_tail.saem_n_convergence = 1;
+    let err = fit_model(&model, &pop, &eval_tail)
+        .expect_err("an eval-only tail must not launder an unsupported estimator");
+    assert!(err.to_lowercase().contains("saem"), "{err}");
+
+    // [focei, imp] with imp_eval_only: IMP is unsupported as an *estimator*, but
+    // here it only scores FOCEI's estimates, which did apply the prior → accept.
+    let mut eval_imp = short_focei();
+    eval_imp.methods = vec![EstimationMethod::FoceI, EstimationMethod::Imp];
+    eval_imp.imp_eval_only = true;
+    eval_imp.imp_samples = 20;
+    let r = fit_model(&model, &pop, &eval_imp);
+    assert!(
+        r.is_ok(),
+        "an eval-only IMP tail must not reject a prior FOCEI applied: {:?}",
+        r.err()
+    );
+    let r = r.unwrap();
+    assert!(
+        r.ofv_prior > 0.0,
+        "the prior must still be in the objective"
+    );
+}
+
+/// **Finding 2.** A priored fit must survive a `.fitrx` round trip.
+///
+/// Storing only the penalized `ofv` and reconstructing `ofv_data` from it on load
+/// relabels the penalized objective as the data likelihood, drops every prior
+/// row, and breaks the `aic == ofv_data + 2k` invariant `aic` was computed under.
+#[test]
+fn a_priored_fit_round_trips_through_fitrx() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let saved =
+        fit_model(&model, &warfarin_population(), &short_focei()).expect("priored fit should run");
+    assert!(saved.ofv_prior > 0.0, "fixture must actually carry a prior");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("priored.fitrx");
+    ferx_core::io::fitrx::save_fit(
+        &saved,
+        &warfarin_population(),
+        "",
+        &path,
+        ferx_core::io::fitrx::SaveFitOptions { include_data: None },
+    )
+    .expect("write");
+    let loaded = ferx_core::io::fitrx::load_fit(&path).expect("read").fit;
+
+    // The halves come back as written, not reconstructed from the total.
+    assert_eq!(loaded.ofv, saved.ofv);
+    assert_eq!(loaded.ofv_data, saved.ofv_data);
+    assert_eq!(loaded.ofv_prior, saved.ofv_prior);
+    assert_ne!(
+        loaded.ofv_data, loaded.ofv,
+        "ofv_data must not be the penalized total"
+    );
+    // The invariant `aic` was computed under survives the trip.
+    assert!((loaded.aic - (loaded.ofv_data + 2.0 * loaded.n_parameters as f64)).abs() < 1e-9);
+    // And the per-parameter rows survive.
+    assert_eq!(loaded.prior_summary.len(), saved.prior_summary.len());
+    assert_eq!(loaded.prior_summary[0].name, "TVCL");
+    assert_eq!(
+        loaded.prior_summary[0].shift_in_prior_sds,
+        saved.prior_summary[0].shift_in_prior_sds
+    );
+}
+
+/// The control for the round trip: an **unpriored** fit still loads, and its
+/// `ofv_data` falls back to `ofv` (which for it is the data likelihood).
+#[test]
+fn an_unpriored_fit_still_round_trips_through_fitrx() {
+    let model = warfarin_with(BASE_PARAMS);
+    let saved = fit_model(&model, &warfarin_population(), &short_focei()).expect("unpriored fit");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("plain.fitrx");
+    ferx_core::io::fitrx::save_fit(
+        &saved,
+        &warfarin_population(),
+        "",
+        &path,
+        ferx_core::io::fitrx::SaveFitOptions { include_data: None },
+    )
+    .expect("write");
+    let loaded = ferx_core::io::fitrx::load_fit(&path).expect("read").fit;
+
+    assert_eq!(loaded.ofv, saved.ofv);
+    assert_eq!(loaded.ofv_data, saved.ofv);
+    assert_eq!(loaded.ofv_prior, 0.0);
+    assert!(loaded.prior_summary.is_empty());
+}
+
+/// **Finding 5.** `covariance_method = s` cannot carry a prior, so the
+/// combination is refused rather than reported as a MAP standard error.
+#[test]
+fn a_prior_with_the_cross_product_covariance_is_refused() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let pop = warfarin_population();
+
+    let mut s_method = short_focei();
+    s_method.run_covariance_step = true;
+    s_method.covariance_method = ferx_core::types::CovarianceMethod::CrossProduct;
+    let err = fit_model(&model, &pop, &s_method)
+        .expect_err("covariance_method = s cannot represent a prior");
+    assert!(err.contains("covariance_method = s"), "{err}");
+
+    // The straddle: the same model with the default `r` is accepted, so the gate
+    // rejects the estimator rather than every priored covariance step.
+    let mut r_method = short_focei();
+    r_method.run_covariance_step = true;
+    r_method.covariance_method = ferx_core::types::CovarianceMethod::Hessian;
+    assert!(fit_model(&model, &pop, &r_method).is_ok());
+
+    // And an unpriored fit may still use `s`, so the rejection is about the
+    // prior and not about the method.
+    let plain = warfarin_with(BASE_PARAMS);
+    assert!(fit_model(&plain, &pop, &s_method).is_ok());
+}
+
+/// **Finding 3.** SIR must resample against the *penalized* objective.
+///
+/// SIR approximates the posterior the fit targeted. Under a prior that target is
+/// `L(data)·p(θ)`, so the importance weights have to score both halves. If they
+/// score the data alone while the proposal is centred on the MAP estimate and
+/// shaped by the penalized curvature, the resampling actively pulls the interval
+/// back toward the MLE — a prior then shows up in the point estimate but not in
+/// the reported CI, which is worse than not supporting SIR at all.
+///
+/// # Why RSE = 10%, specifically
+///
+/// This test is only meaningful in the regime where the *weights* decide
+/// something, and that regime had to be measured rather than assumed — the first
+/// version of it used RSE = 2% and was **vacuous**: the penalized proposal is
+/// then so tight that every draw lands within a hair of the MAP, both weightings
+/// agree, and the assertion passed with the prior deleted from the sampler.
+/// Measured on this fixture (MLE 0.135276, prior 0.202914, seed 20254):
+///
+/// | RSE | CI with the prior in the weights | CI without |
+/// |-----|----------------------------------|------------|
+/// | 2%  | (0.1931, 0.2096) | (0.1863, 0.2191) — both at the prior, no signal |
+/// | **10%** | **(0.1384, 0.1927)** | **(0.1251, 0.1572)** — separated |
+/// | 20% | (0.1245, 0.1595) | (0.1215, 0.1595) — prior too weak to matter |
+/// | 40% | (0.1210, 0.1555) | (0.1197, 0.1555) — likewise |
+///
+/// At 10% the point estimate is identical either way (0.156190 — the *fit* is
+/// unaffected, only the resampling is), so anything that moves is the weights.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn sir_intervals_respect_the_prior() {
+    let pop = warfarin_population();
+    let mut opts = FitOptions::default();
+    opts.run_covariance_step = true;
+    opts.sir = true;
+    opts.sir_samples = 600;
+    opts.sir_resamples = 300;
+    opts.sir_seed = Some(20254);
+
+    // The unpriored MLE, so the prior can be placed somewhere the data disagrees
+    // with it and "pulled back toward the MLE" has a direction.
+    let mut mle_opts = opts.clone();
+    mle_opts.sir = false;
+    let mle = fit_model(&warfarin_with(BASE_PARAMS), &pop, &mle_opts).expect("mle fit");
+    let i = mle.theta_names.iter().position(|n| n == "TVCL").unwrap();
+    let cl_mle = mle.theta[i];
+    let prior_at = cl_mle * 1.5;
+
+    let r = fit_model(
+        &warfarin_with(&params_with_cl_prior(prior_at, 10.0)),
+        &pop,
+        &opts,
+    )
+    .expect("priored SIR fit");
+    assert!(r.ofv_prior > 0.0, "the fixture must actually carry a prior");
+
+    let ci = r.sir_ci_theta.as_ref().expect("SIR theta CIs")[i];
+    let est = r.theta[i];
+    let mid = 0.5 * (ci.0 + ci.1);
+
+    // Upper bound: 0.1927 correct vs 0.1572 with the prior dropped. Bound placed
+    // between them, nearer the wrong value so noise in the right arm cannot
+    // reach it.
+    assert!(
+        ci.1 > 0.175,
+        "SIR upper bound collapsed toward the MLE — the weights are scoring the \
+         data alone: CI {ci:?}, est {est}, MLE {cl_mle}, prior {prior_at}"
+    );
+    // Direction: correct puts the resampled mass *above* the MAP point estimate
+    // (toward the prior), the bug puts it below (toward the MLE). Measured
+    // `mid - est` is +0.0093 vs -0.0150, so the sign alone separates them.
+    assert!(
+        mid > est,
+        "the SIR distribution must sit toward the prior, not the MLE: \
+         mid {mid}, est {est}, CI {ci:?}"
+    );
+}
+
+// ── NONMEM anchor for the prior penalty ─────────────────────────────────────
+
+/// The prior's contribution to the objective, anchored against **NONMEM
+/// `$PRIOR NWPRI`**.
+///
+/// # Why this is an anchor and not a story
+///
+/// ferx and NONMEM do not agree on a prior objective by construction — they
+/// disagree about the parameterisation (`CL` vs `log CL`), about which
+/// normalisation constants the objective carries, and about the optimizer path.
+/// The design removes all three:
+///
+/// 1. **Same coordinate.** The model is written on the log scale on both sides
+///    (`CL = EXP(THETA(1) + ETA(1))`), and the ferx θ is declared with a
+///    *negative* lower bound so ferx packs it as the identity. Both engines
+///    therefore put a normal prior on the same number, with the same mean and
+///    the same SD — nothing depends on ferx's packing conventions.
+/// 2. **Same point.** Both run `MAXEVAL=0` / `maxiter = 0`. The quantity under
+///    test is the objective, not a minimizer's path to it, so pinning the point
+///    removes any chance the two engines' optimizers land somewhere different
+///    and confound the comparison.
+/// 3. **A measured null control first.** `prior_theta_null.ctl` and
+///    `prior_theta_null.ferx` are the same model with **no** prior. They agree
+///    (NONMEM 177.82632978040530, ferx 177.826330), which is what makes the
+///    priored comparison meaningful: without it, an agreeing prior term could be
+///    hiding two compensating disagreements.
+///
+/// A third NONMEM run, `prior_theta_nwpri_centered.ctl`, puts the prior mean
+/// *exactly on* `THETA(1)` and reproduces the null objective to printed
+/// precision — so NWPRI, like ferx, drops the prior's normalisation constant.
+/// That is why the absolute values below can be compared directly, rather than
+/// only as a difference.
+///
+/// # Measured
+///
+/// | | NONMEM 7.5.1 | ferx |
+/// |---|---|---|
+/// | null (no prior) | 177.82632978040530 | 177.826330 |
+/// | prior centred on θ | 177.826 (== null) | — |
+/// | prior offset from θ | 177.94393305151641 | 177.943933 |
+/// | **prior contribution** | **0.11760327111** | **0.117603** |
+///
+/// Worst realised disagreement **5.2e-8** on the priored objective and 2.2e-7 on
+/// the null — both at the limit of the six decimals ferx's fit YAML prints, not
+/// a real gap. The closed form is `((-2.0 + 1.89712) / 0.30)² = 0.117603266`,
+/// which both engines reproduce, so this pins ferx against NONMEM *and* against
+/// arithmetic. Bound set at 1e-6: two orders above the realised error, and far
+/// below the 1e-3 that would let the ½-scale or a dropped constant through.
+#[test]
+fn the_prior_penalty_matches_nonmem_nwpri() {
+    let pop = warfarin_population();
+    let mut opts = FitOptions {
+        method: EstimationMethod::FoceI,
+        ..FitOptions::default()
+    };
+    opts.outer_maxiter = 0;
+    opts.run_covariance_step = false;
+
+    // NONMEM 7.5.1, `nonmem_anchor/prior_theta_null.ctl` (MAXEVAL=0).
+    const NM_NULL: f64 = 177.826_329_780_405_3;
+    // NONMEM 7.5.1, `nonmem_anchor/prior_theta_nwpri.ctl` (MAXEVAL=0).
+    const NM_PRIORED: f64 = 177.943_933_051_516_41;
+
+    let null = parse_model_string(
+        &std::fs::read_to_string("nonmem_anchor/prior_theta_null.ferx").expect("null model"),
+    )
+    .expect("null model parses");
+    let priored = parse_model_string(
+        &std::fs::read_to_string("nonmem_anchor/prior_theta_nwpri.ferx").expect("priored model"),
+    )
+    .expect("priored model parses");
+
+    let r_null = fit_model(&null, &pop, &opts).expect("null run");
+    let r_prior = fit_model(&priored, &pop, &opts).expect("priored run");
+
+    // The null control. If this fails the priored comparison below means nothing,
+    // so it is asserted first and separately.
+    assert!(
+        (r_null.ofv - NM_NULL).abs() < 1e-6,
+        "null control disagrees with NONMEM: ferx {} vs NONMEM {NM_NULL}",
+        r_null.ofv
+    );
+    assert_eq!(r_null.ofv_prior, 0.0, "the null run must carry no prior");
+
+    // The priored objective, absolutely — valid because the centered NONMEM run
+    // showed NWPRI drops the same constant ferx does.
+    assert!(
+        (r_prior.ofv - NM_PRIORED).abs() < 1e-6,
+        "priored objective disagrees with NONMEM: ferx {} vs NONMEM {NM_PRIORED}",
+        r_prior.ofv
+    );
+
+    // And the prior's own contribution, as a difference — the form that would
+    // still hold if either engine changed its constants.
+    let nm_delta = NM_PRIORED - NM_NULL;
+    assert!(
+        (r_prior.ofv_prior - nm_delta).abs() < 1e-6,
+        "prior contribution disagrees with NONMEM: ferx {} vs NONMEM {nm_delta}",
+        r_prior.ofv_prior
+    );
+
+    // The data half must be untouched by the prior: same model, same point.
+    assert!(
+        (r_prior.ofv_data - r_null.ofv).abs() < 1e-9,
+        "the prior moved the data likelihood: {} vs {}",
+        r_prior.ofv_data,
+        r_null.ofv
+    );
+
+    // Non-degeneracy: the prior term has to be doing something, or every
+    // assertion above is satisfied by an engine that ignores priors entirely.
+    assert!(
+        r_prior.ofv_prior > 0.1,
+        "the anchor fixture must exercise a non-zero penalty, got {}",
+        r_prior.ofv_prior
+    );
+}

--- a/tests/parameter_priors.rs
+++ b/tests/parameter_priors.rs
@@ -535,31 +535,62 @@ fn an_unpriored_fit_still_round_trips_through_fitrx() {
     assert!(loaded.prior_summary.is_empty());
 }
 
-/// **Finding 5.** `covariance_method = s` cannot carry a prior, so the
-/// combination is refused rather than reported as a MAP standard error.
+/// **Finding 5.** Neither covariance estimator built on `S` can carry a prior,
+/// so `s` and `rsr` are both refused rather than reported as MAP standard
+/// errors.
+///
+/// `s` is the obvious half: `S⁻¹` is the unpenalized information outright.
+/// `rsr` is the half that was missed when this gate first landed — `R⁻¹ S R⁻¹`
+/// *looks* safe because both `R⁻¹` factors carry the prior's curvature, but the
+/// `S` between them does not, so the sandwich is neither the penalized
+/// estimator nor the unpenalized one and under-states the SE on every priored
+/// coordinate. The old `s` diagnostic recommended `rsr` by name, which is why
+/// the suggestion is asserted here too.
 #[test]
-fn a_prior_with_the_cross_product_covariance_is_refused() {
+fn a_prior_with_an_s_based_covariance_is_refused() {
     let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
     let pop = warfarin_population();
 
-    let mut s_method = short_focei();
-    s_method.run_covariance_step = true;
-    s_method.covariance_method = ferx_core::types::CovarianceMethod::CrossProduct;
-    let err = fit_model(&model, &pop, &s_method)
-        .expect_err("covariance_method = s cannot represent a prior");
-    assert!(err.contains("covariance_method = s"), "{err}");
+    let with_cov = |m: ferx_core::types::CovarianceMethod| {
+        let mut o = short_focei();
+        o.run_covariance_step = true;
+        o.covariance_method = m;
+        o
+    };
+
+    for (label, method) in [
+        ("s", ferx_core::types::CovarianceMethod::CrossProduct),
+        ("rsr", ferx_core::types::CovarianceMethod::Sandwich),
+    ] {
+        let err = fit_model(&model, &pop, &with_cov(method))
+            .expect_err("an S-based covariance method cannot represent a prior");
+        assert!(
+            err.contains(&format!("covariance_method = {label}")),
+            "the message must name the rejected method: {err}"
+        );
+        // The suggestion must not send the user to the other broken estimator.
+        assert!(
+            !err.contains("`rsr`"),
+            "`rsr` is rejected too and must not be recommended: {err}"
+        );
+
+        // And an unpriored fit may still use it, so the rejection is about the
+        // prior and not about the method.
+        let plain = warfarin_with(BASE_PARAMS);
+        assert!(
+            fit_model(&plain, &pop, &with_cov(method)).is_ok(),
+            "`{label}` without a prior must be untouched"
+        );
+    }
 
     // The straddle: the same model with the default `r` is accepted, so the gate
     // rejects the estimator rather than every priored covariance step.
-    let mut r_method = short_focei();
-    r_method.run_covariance_step = true;
-    r_method.covariance_method = ferx_core::types::CovarianceMethod::Hessian;
-    assert!(fit_model(&model, &pop, &r_method).is_ok());
-
-    // And an unpriored fit may still use `s`, so the rejection is about the
-    // prior and not about the method.
-    let plain = warfarin_with(BASE_PARAMS);
-    assert!(fit_model(&plain, &pop, &s_method).is_ok());
+    assert!(fit_model(
+        &model,
+        &pop,
+        &with_cov(ferx_core::types::CovarianceMethod::Hessian)
+    )
+    .is_ok());
 }
 
 /// **Finding 3.** SIR must resample against the *penalized* objective.

--- a/tests/parameter_priors.rs
+++ b/tests/parameter_priors.rs
@@ -148,6 +148,74 @@ fn fit_refuses_a_prior_the_final_method_cannot_apply() {
     assert!(fit_model(&model, &pop, &short_focei()).is_ok());
 }
 
+/// The penalty has to reach every optimizer that claims to apply priors, not
+/// only the default one.
+///
+/// `foce`/`focei` route through NLopt by default, so the built-in BFGS outer
+/// loop and the Gauss-Newton optimizer each assemble the penalized objective in
+/// their *own* code — `run_bfgs_outer`'s `f_only`/`fdfg`/`clean_ofv_at`, and
+/// `gauss_newton`'s BHHH assembly. A prior dropped in either is invisible: the
+/// fit converges, the report recomputes `ofv_prior` at the final estimate and
+/// shows a plausible non-zero penalty, and only the estimate is wrong.
+///
+/// So the assertion is the *identity* `ofv == ofv_data + ofv_prior` with
+/// `ofv_prior > 0` — `ofv_prior > 0` alone passes on an engine that never saw
+/// the penalty, since the report computes it independently.
+#[test]
+fn every_prior_applying_optimizer_carries_the_penalty() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let pop = warfarin_population();
+
+    let cases: [(&str, FitOptions); 3] = [
+        ("builtin bfgs", {
+            let mut o = short_focei();
+            o.optimizer = ferx_core::types::Optimizer::Bfgs;
+            o
+        }),
+        ("gn", short_fit_options(EstimationMethod::FoceGn)),
+        (
+            "gn_hybrid",
+            short_fit_options(EstimationMethod::FoceGnHybrid),
+        ),
+    ];
+
+    for (label, opts) in cases {
+        let r = fit_model(&model, &pop, &opts)
+            .unwrap_or_else(|e| panic!("{label} must accept a prior: {e}"));
+        assert!(
+            r.ofv_prior > 0.0,
+            "{label}: the prior half must be reported"
+        );
+        assert!(
+            (r.ofv - (r.ofv_data + r.ofv_prior)).abs() < 1e-9,
+            "{label}: ofv {} != ofv_data {} + ofv_prior {}",
+            r.ofv,
+            r.ofv_data,
+            r.ofv_prior
+        );
+        assert!(r.ofv.is_finite() && r.ofv_data.is_finite(), "{label}");
+        assert_eq!(r.prior_summary.len(), 1, "{label}");
+        assert_eq!(r.prior_summary[0].name, "TVCL", "{label}");
+    }
+
+    // The control: the unpriored twin under the same three engines reports a
+    // zero prior half, so the identity above is not satisfied by an engine that
+    // reports `ofv_data == ofv` regardless.
+    let unpriored = warfarin_with(BASE_PARAMS);
+    let mut bfgs = short_focei();
+    bfgs.optimizer = ferx_core::types::Optimizer::Bfgs;
+    for (label, opts) in [
+        ("builtin bfgs", bfgs),
+        ("gn", short_fit_options(EstimationMethod::FoceGn)),
+    ] {
+        let r = fit_model(&unpriored, &pop, &opts)
+            .unwrap_or_else(|e| panic!("{label} unpriored must fit: {e}"));
+        assert_eq!(r.ofv_prior, 0.0, "{label}");
+        assert_eq!(r.ofv_data, r.ofv, "{label}");
+        assert!(r.prior_summary.is_empty(), "{label}");
+    }
+}
+
 /// A chain whose *final* stage applies priors is fine even when an earlier one
 /// does not — the last stage is the one whose estimates are reported.
 #[test]

--- a/tests/parameter_priors.rs
+++ b/tests/parameter_priors.rs
@@ -1,0 +1,424 @@
+//! Integration tests for per-parameter priors / penalized-ML (MAP) estimation
+//! (#254).
+//!
+//! Tier-2 here: the validation rejects return an `Err` immediately, and the
+//! objective-split test runs a couple of outer iterations rather than a
+//! convergence loop. The behavioural claims that need a converged fit — a weak
+//! prior reproducing the MLE, a strong one shrinking toward it, and the prior's
+//! curvature reaching the reported SE — are Tier-3 and gated behind
+//! `slow-tests` at the bottom.
+
+use ferx_core::parser::model_parser::parse_model_string;
+use ferx_core::types::Population;
+use ferx_core::{fit, read_nonmem_csv, EstimationMethod, FitOptions};
+use std::path::Path;
+
+/// Warfarin oral 1-cpt model with the `[parameters]` block supplied by the
+/// caller, so each test differs by exactly the prior under test.
+fn warfarin_with(parameters: &str) -> ferx_core::types::CompiledModel {
+    let src = format!(
+        "[parameters]\n{parameters}\n\
+         [individual_parameters]\n\
+         \x20 CL = TVCL * exp(ETA_CL)\n\
+         \x20 V  = TVV  * exp(ETA_V)\n\
+         \x20 KA = TVKA\n\n\
+         [structural_model]\n\
+         \x20 pk one_cpt_oral(cl=CL, v=V, ka=KA)\n\n\
+         [error_model]\n\
+         \x20 DV ~ proportional(PROP_ERR)\n"
+    );
+    parse_model_string(&src).expect("model must parse")
+}
+
+const BASE_PARAMS: &str = "  theta TVCL(0.13, 0.001, 10.0)\n  \
+                           theta TVV(8.0, 0.1, 500.0)\n  \
+                           theta TVKA(1.0, 0.01, 50.0)\n  \
+                           omega ETA_CL ~ 0.09\n  \
+                           omega ETA_V  ~ 0.04\n  \
+                           sigma PROP_ERR ~ 0.01\n\n";
+
+/// `BASE_PARAMS` with a prior on `TVCL`, at the given central value and RSE.
+fn params_with_cl_prior(value: f64, rse_pct: f64) -> String {
+    format!(
+        "  theta TVCL(0.13, 0.001, 10.0) prior({value}, rse = {rse_pct}%)\n  \
+         theta TVV(8.0, 0.1, 500.0)\n  \
+         theta TVKA(1.0, 0.01, 50.0)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         omega ETA_V  ~ 0.04\n  \
+         sigma PROP_ERR ~ 0.01\n\n"
+    )
+}
+
+fn warfarin_population() -> Population {
+    read_nonmem_csv(Path::new("data/warfarin.csv"), None, None).expect("warfarin dataset must load")
+}
+
+/// `fit()` at the model's own declared initial estimates — which is what a
+/// `.ferx` file means and what every test here wants.
+fn fit_model(
+    model: &ferx_core::types::CompiledModel,
+    pop: &Population,
+    opts: &FitOptions,
+) -> Result<ferx_core::types::FitResult, String> {
+    fit(model, pop, &model.default_params, opts)
+}
+
+/// A couple of outer iterations — Tier-2, no convergence loop.
+///
+/// The method is set **here**, not in the model file's `[fit_options]`: these
+/// tests hand `fit()` a `FitOptions` of their own, and a model file's
+/// `[fit_options]` only reaches `fit()` through `ParsedModel::fit_options` (see
+/// #1212). Setting it in both places would let a test pass on the default while
+/// reading as though it had pinned a method.
+fn short_fit_options(method: EstimationMethod) -> FitOptions {
+    let mut opts = FitOptions {
+        method,
+        ..FitOptions::default()
+    };
+    opts.outer_maxiter = 2;
+    opts.run_covariance_step = false;
+    opts
+}
+
+fn short_focei() -> FitOptions {
+    short_fit_options(EstimationMethod::FoceI)
+}
+
+// ── The gate: an inapplicable prior stops the fit ────────────────────────────
+
+/// A prior naming a parameter that does not exist must stop the fit, not be
+/// dropped. This is the gate `estimation::outer_optimizer::build_prior_set`
+/// relies on when it falls back to an empty set.
+#[test]
+fn fit_refuses_an_unresolvable_prior() {
+    let model = warfarin_with(
+        "  theta TVCL(0.13, 0.001, 10.0)\n  \
+         theta TVV(8.0, 0.1, 500.0)\n  \
+         theta TVKA(1.0, 0.01, 50.0) prior(1.0, rse = 20%)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         omega ETA_V  ~ 0.04\n  \
+         sigma PROP_ERR ~ 0.01\n\n",
+    );
+    // The declaration itself is fine; break the *resolution* by renaming the
+    // parameter it points at, which is what a typo produces.
+    let mut model = model;
+    model.priors[0].name = "NO_SUCH_PARAM".into();
+
+    let err = fit_model(&model, &warfarin_population(), &short_focei())
+        .expect_err("a prior on an unknown parameter must stop the fit");
+    assert!(err.contains("NO_SUCH_PARAM"), "{err}");
+}
+
+/// A prior on a `FIX`ed parameter can never move it, so it is a typo rather
+/// than a no-op.
+#[test]
+fn fit_refuses_a_prior_on_a_fixed_parameter() {
+    let model = warfarin_with(
+        "  theta TVCL(0.13, 0.001, 10.0)\n  \
+         theta TVV(8.0, 0.1, 500.0)\n  \
+         theta TVKA(1.0, 0.01, 50.0, FIX) prior(1.0, rse = 20%)\n  \
+         omega ETA_CL ~ 0.09\n  \
+         omega ETA_V  ~ 0.04\n  \
+         sigma PROP_ERR ~ 0.01\n\n",
+    );
+    let err = fit_model(&model, &warfarin_population(), &short_focei())
+        .expect_err("a prior on a FIXed parameter must stop the fit");
+    assert!(err.contains("FIX"), "{err}");
+}
+
+/// A method that does not apply priors must refuse, not quietly return the
+/// unpenalized MLE. An unapplied prior is invisible in the output — the fit
+/// converges, the estimates look reasonable, and nothing says the prior was
+/// dropped.
+#[test]
+fn fit_refuses_a_prior_the_final_method_cannot_apply() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let pop = warfarin_population();
+
+    let err = fit_model(&model, &pop, &short_fit_options(EstimationMethod::Saem))
+        .expect_err("saem does not apply priors and must say so");
+    // The message must name the stage that dropped it, or the user has to guess
+    // which of a chain's methods is the problem.
+    assert!(err.to_lowercase().contains("saem"), "{err}");
+    assert!(err.contains("prior"), "{err}");
+
+    // The straddle: the *identical model* under a FOCE-family method is
+    // accepted, so the gate rejects the unsupported method rather than every
+    // prior. Same model value, one differing input — the method.
+    assert!(fit_model(&model, &pop, &short_focei()).is_ok());
+}
+
+/// A chain whose *final* stage applies priors is fine even when an earlier one
+/// does not — the last stage is the one whose estimates are reported.
+#[test]
+fn a_chain_ending_in_focei_accepts_a_prior() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let mut opts = short_focei();
+    opts.methods = vec![EstimationMethod::Saem, EstimationMethod::FoceI];
+    opts.saem_n_exploration = 1;
+    opts.saem_n_convergence = 1;
+
+    let r = fit_model(&model, &warfarin_population(), &opts);
+    assert!(
+        r.is_ok(),
+        "a chain ending in focei must be accepted: {:?}",
+        r.err()
+    );
+
+    // The straddle: reverse the chain so the *last* stage is the one that
+    // cannot apply priors, and it must be refused. Without this the test would
+    // pass on a gate that looked at any stage, or at none.
+    let mut reversed = short_focei();
+    reversed.methods = vec![EstimationMethod::FoceI, EstimationMethod::Saem];
+    reversed.saem_n_exploration = 1;
+    reversed.saem_n_convergence = 1;
+    assert!(fit_model(&model, &warfarin_population(), &reversed).is_err());
+}
+
+// ── The objective split ──────────────────────────────────────────────────────
+
+/// The reported OFV is the penalized total, the two halves are published
+/// separately, and AIC/BIC come from the data half.
+///
+/// Every assertion here would pass vacuously on an implementation that ignored
+/// the prior entirely *except* `ofv_prior > 0`, which is why that one is first:
+/// it is the check that the penalty actually reached the objective.
+#[test]
+fn a_priored_fit_splits_the_objective_and_keeps_the_ics_on_the_data_half() {
+    let model = warfarin_with(&params_with_cl_prior(0.15, 25.0));
+    let r = fit_model(&model, &warfarin_population(), &short_focei())
+        .expect("short priored fit should run");
+
+    assert!(
+        r.ofv_prior > 0.0,
+        "the prior must contribute to the objective; got {}",
+        r.ofv_prior
+    );
+    assert!((r.ofv - (r.ofv_data + r.ofv_prior)).abs() < 1e-9);
+    // AIC/BIC are computed from the data half: a penalized objective is not a
+    // log-likelihood, and an IC built from one would reward a tighter prior.
+    assert!((r.aic - (r.ofv_data + 2.0 * r.n_parameters as f64)).abs() < 1e-9);
+    assert!(r.aic < r.ofv + 2.0 * r.n_parameters as f64);
+
+    // The per-parameter report reconciles with the total, or the split shown to
+    // the user does not add up to the number next to it.
+    assert_eq!(r.prior_summary.len(), 1);
+    let row = &r.prior_summary[0];
+    assert_eq!(row.name, "TVCL");
+    assert_eq!(row.prior_value, 0.15);
+    assert_eq!(row.family, "lognormal");
+    let total: f64 = r.prior_summary.iter().map(|p| p.penalty).sum();
+    assert!((total - r.ofv_prior).abs() < 1e-9);
+    // The reported estimate is the θ that was estimated, on its declared scale.
+    let i = r.theta_names.iter().position(|n| n == "TVCL").unwrap();
+    assert!((row.estimate - r.theta[i]).abs() < 1e-9);
+}
+
+/// The control: the identical model with no prior reports a zero prior half and
+/// an `ofv` that still equals `ofv_data`, so nothing about an unpriored fit
+/// moved.
+#[test]
+fn an_unpriored_fit_reports_a_zero_prior_half() {
+    let model = warfarin_with(BASE_PARAMS);
+    let r = fit_model(&model, &warfarin_population(), &short_focei())
+        .expect("short unpriored fit should run");
+    assert_eq!(r.ofv_prior, 0.0);
+    assert_eq!(r.ofv, r.ofv_data);
+    assert!(r.prior_summary.is_empty());
+}
+
+/// Two priors centred at different places must give different objectives at the
+/// same starting point — a penalty wired to the wrong coordinate, or dropped,
+/// would give the same one twice.
+#[test]
+fn moving_the_prior_moves_the_objective() {
+    let pop = warfarin_population();
+    let near = fit_model(
+        &warfarin_with(&params_with_cl_prior(0.13, 25.0)),
+        &pop,
+        &short_focei(),
+    )
+    .expect("near-prior fit should run");
+    let far = fit_model(
+        &warfarin_with(&params_with_cl_prior(0.50, 25.0)),
+        &pop,
+        &short_focei(),
+    )
+    .expect("far-prior fit should run");
+
+    // The start is TVCL = 0.13, so the near prior sits on it and the far one is
+    // ~4× away: the penalties must differ by a lot, and in the right direction.
+    assert!(
+        far.ofv_prior > near.ofv_prior + 1.0,
+        "a prior 4x away from the start must penalize more: near {} vs far {}",
+        near.ofv_prior,
+        far.ofv_prior
+    );
+}
+
+/// The prior must reach the **optimizer**, not only the report.
+///
+/// This exists because every other Tier-2 test here can pass without it:
+/// `ofv_prior` and `prior_summary` are recomputed in `fit()` at the final
+/// estimate, so they are non-zero whether or not the objective the optimizer
+/// minimised ever saw the penalty. Verified by mutation — deleting
+/// `priors.penalty(..)` from `outer_optimizer`'s objective leaves every other
+/// test in this file green and reddens only this one (and the Tier-3 straddle,
+/// which does not run on a PR).
+///
+/// Two tight priors on opposite sides of the starting value, a couple of outer
+/// iterations each: the estimates must separate, and in the right order.
+#[test]
+fn a_prior_moves_the_estimates_and_not_only_the_report() {
+    let pop = warfarin_population();
+    // Start is TVCL = 0.13. RSE 1% makes each prior far stronger than the data.
+    let low = fit_model(
+        &warfarin_with(&params_with_cl_prior(0.065, 1.0)),
+        &pop,
+        &short_focei(),
+    )
+    .expect("low-prior fit should run");
+    let high = fit_model(
+        &warfarin_with(&params_with_cl_prior(0.26, 1.0)),
+        &pop,
+        &short_focei(),
+    )
+    .expect("high-prior fit should run");
+
+    let i = low.theta_names.iter().position(|n| n == "TVCL").unwrap();
+    let (cl_low, cl_high) = (low.theta[i], high.theta[i]);
+    assert!(
+        cl_low < cl_high,
+        "the lower prior must pull TVCL below the higher one: {cl_low} vs {cl_high}"
+    );
+    // Not merely ordered — separated. Two runs of the same unpriored fit would
+    // land on the same number, so any separation at all is the prior's doing;
+    // the margin keeps the assertion above optimizer noise.
+    assert!(
+        (cl_high - cl_low) / cl_low > 0.1,
+        "the two priors must pull the estimate materially apart: {cl_low} vs {cl_high}"
+    );
+}
+
+// ── Tier 3: behaviour that needs a converged fit ─────────────────────────────
+
+/// The two halves of the issue's acceptance criteria, asserted **together** as
+/// a straddle.
+///
+/// Each half alone is satisfied by an implementation that ignores the prior: a
+/// weak prior reproducing the MLE is what "no prior at all" also does, and a
+/// shrunk estimate could be chance. They only test anything as a pair, with a
+/// stated minimum shift on the strong side.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn a_weak_prior_reproduces_the_mle_and_a_strong_one_shrinks_toward_it() {
+    let pop = warfarin_population();
+    let mut opts = FitOptions::default();
+    opts.run_covariance_step = false;
+
+    let mle = fit_model(&warfarin_with(BASE_PARAMS), &pop, &opts).expect("unpriored fit");
+    let i = mle.theta_names.iter().position(|n| n == "TVCL").unwrap();
+    let cl_mle = mle.theta[i];
+
+    // A prior centred far from the MLE, so "shrinks toward the prior" has a
+    // direction to be right about.
+    let prior_at = cl_mle * 2.0;
+
+    // RSE 10000% → a log-scale SD of ~4.8, i.e. a 95% interval spanning eight
+    // orders of magnitude. Flat enough to be no prior at all.
+    let weak = fit_model(
+        &warfarin_with(&params_with_cl_prior(prior_at, 10000.0)),
+        &pop,
+        &opts,
+    )
+    .expect("weak-prior fit");
+    let cl_weak = weak.theta[i];
+
+    // RSE 1% → a log-scale SD of 0.01, which pins TVCL to the prior.
+    let strong = fit_model(
+        &warfarin_with(&params_with_cl_prior(prior_at, 1.0)),
+        &pop,
+        &opts,
+    )
+    .expect("strong-prior fit");
+    let cl_strong = strong.theta[i];
+
+    assert!(
+        ((cl_weak - cl_mle) / cl_mle).abs() < 0.02,
+        "a near-flat prior must reproduce the MLE: {cl_mle} vs {cl_weak}"
+    );
+    assert!(
+        ((cl_strong - prior_at) / prior_at).abs() < 0.05,
+        "a tight prior must pin the estimate to it: prior {prior_at}, got {cl_strong}"
+    );
+    // And the straddle itself, so the pair cannot silently become a tautology:
+    // the two fits must actually disagree.
+    assert!(
+        (cl_strong - cl_weak).abs() > 0.3 * cl_mle,
+        "weak and strong must land in different places: {cl_weak} vs {cl_strong}"
+    );
+
+    // Deliberately *not* asserted: `weak.ofv_prior < strong.ofv_prior`. It looks
+    // like it should hold and does not — both are ≈ 0, for opposite reasons. The
+    // weak prior is too flat to penalize anything, and the strong one pulls the
+    // estimate onto its own centre, where the penalty it charges is zero. The
+    // prior half of the OFV measures *disagreement* between data and prior, not
+    // prior strength, so a well-obeyed tight prior costs nothing.
+}
+
+/// The prior's curvature must reach the reported standard error.
+///
+/// With a tight prior on a parameter, the penalized Hessian is dominated by the
+/// prior's `2/s²`, so the SE collapses toward the prior SD. Without the
+/// covariance-step wiring the SE would keep the (much larger) data-only value —
+/// the specific failure that makes MAP SEs meaningless, and the one the
+/// covariance step's own `add_hessian` call is the only thing preventing.
+#[test]
+#[cfg_attr(
+    not(feature = "slow-tests"),
+    ignore = "slow: opt in with --features slow-tests"
+)]
+fn a_tight_prior_tightens_the_reported_standard_error() {
+    let pop = warfarin_population();
+    let mut opts = FitOptions::default();
+    opts.run_covariance_step = true;
+
+    let loose = fit_model(
+        &warfarin_with(&params_with_cl_prior(0.13, 200.0)),
+        &pop,
+        &opts,
+    )
+    .expect("loose-prior fit");
+    let tight = fit_model(
+        &warfarin_with(&params_with_cl_prior(0.13, 2.0)),
+        &pop,
+        &opts,
+    )
+    .expect("tight-prior fit");
+
+    let i = loose.theta_names.iter().position(|n| n == "TVCL").unwrap();
+    let se_loose = loose.se_theta.as_ref().expect("loose SEs")[i];
+    let se_tight = tight.se_theta.as_ref().expect("tight SEs")[i];
+
+    // The log-scale prior SD at RSE 2% is sqrt(ln(1+0.02²)) ≈ 0.02, so on the
+    // natural scale the prior alone would give SE ≈ 0.02·TVCL. The penalized SE
+    // must be at or below that — the data can only add information.
+    let cl = tight.theta[i];
+    assert!(
+        se_tight < 0.021 * cl,
+        "a 2% prior must pin the SE: got {se_tight} at TVCL = {cl}"
+    );
+    // And it must be a *change*, not just a small number. Measured on this
+    // fixture: SE 7.959e-3 at RSE 200% falls to 2.486e-3 at RSE 2%, a ratio of
+    // 0.312. The bound is set at 0.5 — loose enough to survive optimizer noise
+    // in the loose arm, tight enough that dropping the covariance step's
+    // `add_hessian` (which leaves both arms at the data-only SE, ratio 1.0)
+    // fails it.
+    assert!(
+        se_tight < 0.5 * se_loose,
+        "tightening the prior must tighten the SE: {se_loose} -> {se_tight}"
+    );
+}


### PR DESCRIPTION
## Why

Sparse clinical data — rare disease, pediatrics, TDM-led fits — leaves the
likelihood weakly informative: IIV terms collapse onto boundaries and structural
parameters drift. A prior from a published popPK model stabilizes the fit and
lets a small local dataset borrow strength from what is already known. The same
mechanism is model updating (literature model as prior + local sparse data →
regularized estimate), which is the MAP-Bayesian updating behind much of
model-informed precision dosing.

NONMEM's `$PRIOR` does this and is a known source of friction: a separate prior
problem, a variance block for the thetas, an inverse-Wishart on Ω via a prior
matrix plus degrees of freedom, and all the matrix indexing kept aligned by hand.
#254 asks for the opposite — read a number and its RSE off a paper, type it next
to the parameter, done.

One correction to the issue text: it assumes "Enzyme propagates its gradient
automatically". Enzyme was retired in #285/#281 in favour of the hand-rolled
`Dual2` sensitivities. That turns out to make this *easier*, not harder — see
below.

This is **Phase 1**. Three of the issue's eight acceptance criteria are
deliberately not in it; they are listed under Open questions.

## What changed

`prior(value, rse = 25%)` as a trailing modifier on any `theta` / `omega` /
`sigma` / `kappa` declaration:

```toml
[parameters]
  theta TVCL(0.2, 0.001, 10.0)  prior(0.15, rse = 25%)
  omega ETA_CL ~ 0.09           prior(0.09, rse = 40%)
```

**The penalty lives in the optimizer's packed coordinates** (`src/estimation/priors.rs`):

```
OFV_total = OFV_data + Σ ((x − m)/s)²     ∂/∂x = 2(x−m)/s²     ∂²/∂x² = 2/s²
```

Three things follow, and they are why this is ~350 lines rather than a new
sensitivity kernel:

- gradient and Hessian are exact and closed form, and the Hessian is a
  **constant** diagonal. Nothing routes through `sens/`, so no `Dual2`
  instantiation and no added monomorphization on a compile path that is already
  93% LLVM (#971);
- the prior *family* falls out of the packing rather than being a second
  convention. A θ with a non-negative lower bound is estimated as `ln θ`, so a
  normal prior there **is** a lognormal prior on θ — exactly what the issue asks
  for. An Ω diagonal is estimated as `ln(SD)`, so a normal prior there is a
  lognormal prior on the variance: positive, symmetric, no matrix algebra;
- the outer objective, GN, trust-region and the covariance step already work in
  packed space, so there is one form of the penalty rather than one per caller.

**Scale convention:** the prior's value and spread are always on the scale the
parameter was declared on — a variance for a bare `omega X ~ v`, an SD under
`(sd)`. Both come off the same row of the same table, and the user never
converts anything.

Wired into `outer_optimizer` (objective + gradient, NLopt and built-in BFGS),
`gauss_newton` (gradient + BHHH Hessian), `trust_region` (objective + gradient +
Hessian), and `covariance` (Hessian). Parsed by peeling the `prior(...)` tail
**before** the four declaration regexes run, so none of them changed — the same
mechanism `weight =` uses, and for the same reason (they are all unanchored, so a
modifier left on the line is silently dropped).

Reported in the console summary and the fit YAML: the OFV split plus, per priored
parameter, the prior, the estimate, the shift in prior SDs, the penalty, the
realised family, and the implied 95% prior interval.

## Alternatives considered

**Prior scale decoupled from the packing** (always lognormal for positive-support
parameters, chain-ruled into packed space). Removes the bound-coupling trap in
`Open questions`, but costs a non-constant Hessian, adds a second convention, and
contradicts the issue's own rule. Rejected.

**Priors on `FitOptions` rather than `CompiledModel`**, which is where the
covariate-NN regularizer's `nn_l2` lives and would have cost 0 struct-literal
edits instead of 29. Rejected: a prior changes the *estimates*, so a caller who
parses a `.ferx` file and hands `fit()` a `FitOptions::default()` must not
silently get an unpenalized fit. `nn_l2` makes the opposite choice correctly,
because there the penalty is a tuning knob a caller legitimately sweeps.

**Adding the penalty inside the covariance step's `cov_ofv` closure** rather than
post-assembly. Rejected: it would double-count against the analytic R-matrix
route, and it would pay FD noise for a quantity that is known exactly.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#___ | not needed (yet) | after |

No ferx-r change is *required* by this PR — nothing existing breaks. A follow-up
ferx-r PR should surface `ofv_data` / `ofv_prior` / `prior_summary` in the R
`FitResult`, and will need the usual `tools/update-ferx-core-lock.sh` bump to
reach a commit where `ParameterPrior` etc. are public.

## Breaking changes

- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [x] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [ ] None

Additive only — no existing field, syntax or default changed. The new API surface
and who needs it:

| Added item | Needed by |
|---|---|
| `types::ParameterPrior`, `types::PriorSpread` | ferx-r, to build a priored model programmatically (the R wrapper constructs `CompiledModel` rather than always going through the parser) |
| `CompiledModel::priors` | same — and it is the field the parser writes |
| `FitResult::{ofv_data, ofv_prior}` | ferx-r and any consumer that wants the likelihood half of a MAP fit for model comparison |
| `FitResult::prior_summary`, `types::PriorSummary` | ferx-r, to render the per-parameter prior table |

The existing surface does not suffice: there is no way to express "this parameter
has a prior" or to read back the data/prior split without these. All four are
reachable from ferx-r as an ordinary external crate.

`FitResult`'s three new fields carry `#[serde(default)]` and
`skip_serializing_if`, so an unpriored fit's YAML is byte-identical to before and
a pre-#254 artifact still deserializes.

<details>
<summary>Migration notes (if breaking)</summary>

None. `prior(...)` is opt-in; a model without one takes a bit-identical path
(`penalty()` over an empty term list returns exactly `0.0`, and `is_active()`
guards the gradient allocation).

</details>

## Numerical validation

- [x] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: **an independent evaluation of the unpriored −2 log L at
      the priored optimum** (see below). NONMEM anchors are Phase 2 — see Open
      questions.
- [x] Reference values:

The load-bearing check is that `ofv_data` really is the unpenalized −2 log L,
computed **outside the priored code path**: take the priored fit's estimates,
put them into the plain unpriored model at `maxiter = 0`, and read the OFV.

```
# priored fit (examples/warfarin_prior.ferx)
ofv:       -282.615993
ofv_data:  -284.323764
ofv_prior:    1.707772
aic:       -270.323764      # = ofv_data + 2k, not ofv + 2k
bic:       -251.420402

TVCL 0.132917   TVV 7.781867   TVKA 0.842959
ETA_CL 0.045947  ETA_V 0.014078  ETA_KA 0.337464   PROP_ERR 0.010564

# the SAME estimates, evaluated by the UNPRIORED model at maxiter = 0
OFV:  -284.3237        # reproduces ofv_data exactly
```

Per-parameter report from that run — every estimate lands inside its prior's 95%
interval, with shifts under one prior SD:

```
  name: TVCL     prior 0.134   est 0.132917   shift -0.054   pen 0.003   [0.1000, 0.1795]
  name: TVV      prior 8.100   est 7.781867   shift -0.402   pen 0.161   [6.6616, 9.8490]
  name: TVKA     prior 1.000   est 0.842959   shift -0.443   pen 0.197   [0.4700, 2.1278]
  name: ETA_CL   prior 0.070   est 0.045947   shift -0.891   pen 0.794   [0.0277, 0.1767]
```

**An observation worth flagging rather than claiming credit for:** the stock
unpriored `examples/warfarin.ferx` converges to OFV **−280.364**, which is
*higher* than the priored run's `ofv_data` of −284.324 — from identical starting
values. The unpriored fit is therefore sitting in a worse local optimum (TVKA
0.725 vs 0.843) and the prior pulled the optimizer out of it. That is consistent
with the known FOCEI start-sensitivity on this model, but it is an incidental
finding on one dataset, not a claim about what priors do in general.

Beyond the fixture: 5196 tests pass, including every existing NONMEM anchor,
which is the real evidence that unpriored fits are byte-identical.

## Performance

- [x] No significant impact expected
- [ ] Faster — benchmark: `______` (before) → `______` (after)
- [ ] Slower — justified because: `______`

Unpriored models take a bit-identical path. A priored model adds one
`Σ ((x−m)/s)²` per objective evaluation over the priored coordinates only —
unmeasurable next to a population inner loop. The covariance step adds **zero**
evaluations, because the penalty's curvature is a constant diagonal added
analytically rather than differenced.

## Tests

- [x] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: `______`)

**Tier 1** — `src/estimation/priors_tests.rs` (18): the closed forms against
hand-computed values, not tolerances; the lognormal/normal straddle across
`theta_packs_log`; the variance-vs-`(sd)` differential pair (identical model,
identical prior location, penalties differing by exactly 4×, which is the only
thing that can distinguish the two scales); central-FD parity on gradient and
Hessian (realised worst error 2.12e-10 / 2.48e-5, bounds set ~4× above); and
every rejection.

**Tier 1** — `src/parser/model_parser_tests.rs` (9): the grammar, `25%` ≡ `0.25`,
the ambiguous-bare-`rse` reject *and* its straddle, coexistence with `FIX` and
`(sd)`, and the `weight =` ordering (a prior written after a kappa weight is
still seen — without the peel order the model parses cleanly and fits
unpenalized).

**Tier 2 / 3** — `tests/parameter_priors.rs` (9): the gate rejects, the objective
split, and two `slow-tests`-gated convergence tests for the issue's acceptance
criteria.

### What mutation testing found

Both of these were written, run green, and believed before being mutated:

- **The Tier-2 objective test passed with the penalty deleted from the
  optimizer.** `ofv_prior` and `prior_summary` are recomputed in `fit()` at the
  final estimate, so they read non-zero whether or not the objective ever saw the
  penalty. Added `a_prior_moves_the_estimates_and_not_only_the_report`, which
  puts two tight priors on opposite sides of the start and asserts the estimates
  separate; it is the only Tier-2 test that dies under that mutation.
- **Deleting only the gradient splice left the entire suite green.** An optimizer
  minimising a penalized objective with an unpenalized gradient still crawls
  toward the prior, just badly — no outcome assertion catches it reliably. Fixed
  structurally rather than with another assertion: value and gradient now come
  from one `penalty_and_gradient` call (the `nn_reg` pattern), so one mutation
  removes both.

Each wiring site was then mutated separately and named its own failing test —
the covariance `add_hessian` reddens only `a_tight_prior_tightens_the_reported_standard_error`,
the objective reddens only the two above.

## Example (user-facing features only)

- [x] Example added to `examples/` or inline below
- [ ] Not applicable (internal / refactor / fix with no new API surface)

`examples/warfarin_prior.ferx` — the model-updating pattern, with output above.

## Docs

- [x] `docs/` updated for user-visible changes
- [x] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI)
- [ ] No user-visible change

New `docs/estimation/priors.qmd` (scale table, the bounds trap, reading the
output, why the SEs are MAP SEs, what is out of scope, and a `$PRIOR` comparison
table), plus a cross-reference from `docs/model-file/parameters.qmd`.
`cargo run -p docs-lint -- --check` is clean.

## Checklist

- [x] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), public-API baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable — **not touched at all**; the penalty is closed-form in packed space and never enters `sens/`
- [ ] `Cargo.toml` version bumped if breaking — not breaking

`cargo test --features ci`: **5196 passed, 0 failed, 176 ignored** across 186
binaries.

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book

`prior(...)` is new DSL syntax and `examples/warfarin_prior.ferx` is a new
example, so both boxes need a follow-up in ferx-site / ferx-book. No new data
file (it reuses `data/warfarin.csv`). Flagging rather than silently ticking.

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened

### Example execution
- [x] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core — not needed, no ferx-r change in this PR
- [x] All affected `examples/*.ferx` run cleanly via CLI (`warfarin_prior.ferx` and the unchanged `warfarin.ferx`)
- [ ] All affected ferx-site example `.qmd` pages render cleanly — see above
- [ ] All affected ferx-book chapters render cleanly — see above

## Reviewer hints

Read in this order:

1. **`src/estimation/priors.rs`** — the whole design. `PriorScale` is the single
   derivation of "what scale is this prior on"; if the mean and the spread
   disagreed about it the error would be a factor of two and would still look
   plausible, which is why they share one enum.
2. **`api/validation.rs::check_parameter_priors`** — the gate. Everything else
   assumes a prior that reaches an optimizer has already been checked against the
   same `ModelParameters` layout, which is why `build_prior_set` can fall back to
   an empty set.
3. **`covariance.rs`**, the `cov_priors.add_hessian` block — the decision I feel
   most strongly about, with the reasoning in the comment. Note the existing NN
   penalty is *absent* from the covariance Hessian; priors deliberately do not
   inherit that gap, and I did not change `nn_reg` here.

Skimmable: the 29 `priors: Vec::new()` struct-literal additions, and the 51
widened `parse_parameters` destructurings in the parser tests.

## Open questions

**Phase 2, not in this PR** (three of the eight acceptance criteria):

- IMP / IMPMAP penalized M-step — the issue's "composes with at least FOCE and
  one EM method". Their M-steps are BOBYQA over the packed vector
  (`impmap.rs:2479`, `:2599`), so this is a straightforward extension. SAEM's
  closed-form M-step needs a conjugate MAP update and is a larger piece.
- `[priors] from_fit = "…"` — the one-call import from a previous ferx fit
  (`value = estimate`, `rse = SE/estimate`), which is the actual model-updating
  ergonomics.
- **NONMEM anchors.** My first read was that the Ω prior needs a
  no-equivalent-estimator exception, since NWPRI's Ω prior is inverse-Wishart and
  ours is lognormal-on-the-variance. On a second pass I think we can anchor both
  families exactly, if the control stream is written in the matching
  parameterization: a log-packed θ against NWPRI on `THETA(1)` in a model written
  `CL = EXP(THETA(1))`, and a diagonal Ω against NWPRI on `THETA(k)` in a model
  written `$OMEGA 1 FIX` with `CL = TVCL*EXP(EXP(THETA(k))*ETA(1))` — which *is*
  normal on ln(SD), i.e. our packed Ω coordinate. The Ω one leans on FOCE's
  marginal being invariant under a linear rescaling of η, so it is only an anchor
  if that invariance holds numerically in NONMEM: step 1 is a **null control run**
  (no prior, both parameterizations, assert identical OFV) and the priored
  comparison is anchored on ΔOFV against that twin so the normalization constants
  cancel. If the null run disagrees, I will say the anchor does not exist rather
  than tune a tolerance until it passes.

**Decisions worth overruling if you disagree** — these four change user-visible
behaviour, and I would rather argue now than after it ships:

- **The prior's family follows the declared bounds.** Widening a θ's lower bound
  below zero silently moves its prior from lognormal to normal. The mitigation is
  visibility (the report prints the realised family and 95% interval) rather than
  a second convention, but it is a real coupling.
- **AIC/BIC on `ofv_data`.** Defensible, but it means a priored fit's AIC is not
  comparable to the number NONMEM prints for the same run.
- **The penalty in the covariance step.** Makes the SE depend on the prior's
  strength, mechanically. I think that is correct and the docs say so plainly,
  but it is the sort of thing a reviewer should push back on if they disagree.
- **Hard error on an unapplied prior.** The existing `nn_l2` analogue warns
  instead. I think the asymmetry is right — a dropped regularizer changes a
  tuning knob, a dropped prior changes the model — but it is a deliberate
  inconsistency.

Closes #254 partially; I would keep the issue open for Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014u63GvTSbfYB1hL8cd3Z4X
