### PR TITLE
perf(estimation): thread inner-loop iteration counts into EbeResult/InnerLoopStats [A1, part of #1345]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ section of the SDLC for the versioning policy).
 
 ## [Unreleased]
 
+### Added
+
+- `EbeResult` now carries `n_iters`, the optimizer iterations spent on that subject's inner solve
+  (main BFGS/L-BFGS/Nelder-Mead plus any fallback/restart/runaway-guard Nelder-Mead runs), and
+  `InnerLoopStats` sums it across subjects as `total_inner_iters` — pure measurement, to profile
+  where inner-loop time goes before optimizing it further (#1345).
+
 ### Changed
 
 - **SAEM now averages the residual sufficient statistic for eligible single additive and proportional error models, reducing final-draw Monte Carlo noise in the residual SD estimate (#1321).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,14 @@ section of the SDLC for the versioning policy).
 ### Added
 
 - `EbeResult` now carries `n_iters`, the optimizer iterations spent on that subject's inner solve
-  (main BFGS/L-BFGS/Nelder-Mead plus any fallback/restart/runaway-guard Nelder-Mead runs), and
-  `InnerLoopStats` sums it across subjects as `total_inner_iters` — pure measurement, to profile
-  where inner-loop time goes before optimizing it further (#1345).
+  (main BFGS/L-BFGS/Nelder-Mead plus any fallback/restart/runaway-guard Nelder-Mead runs, and every
+  MCETA multi-start rather than only the winning one), and `InnerLoopStats` sums it across subjects
+  as `total_inner_iters` — pure measurement, to profile where inner-loop time goes before optimizing
+  it further (#1345).
+- `FERX_PROFILE=1` now reports fit-wide inner-optimizer iteration totals, split into BFGS/L-BFGS and
+  Nelder-Mead: the two are different units of work, and unlike the per-evaluation `InnerLoopStats`
+  the totals accumulate across a whole fit, including the AGQ / covariance / importance-sampling
+  callers that discard their `EbeResult` (#1345).
 
 ### Changed
 

--- a/api/ferx-core-public-api.txt
+++ b/api/ferx-core-public-api.txt
@@ -381,12 +381,14 @@ pub ferx_core::estimation::inner_optimizer::EbeResult::grad_norm: f64
 pub ferx_core::estimation::inner_optimizer::EbeResult::h_matrix: nalgebra::base::alias::DMatrix<f64>
 pub ferx_core::estimation::inner_optimizer::EbeResult::hard_reject: bool
 pub ferx_core::estimation::inner_optimizer::EbeResult::kappas: alloc::vec::Vec<nalgebra::base::alias::DVector<f64>>
+pub ferx_core::estimation::inner_optimizer::EbeResult::n_iters: u64
 pub ferx_core::estimation::inner_optimizer::EbeResult::nll: f64
 pub ferx_core::estimation::inner_optimizer::EbeResult::used_fallback: bool
 pub struct ferx_core::estimation::inner_optimizer::InnerLoopStats
 pub ferx_core::estimation::inner_optimizer::InnerLoopStats::n_fallback: usize
 pub ferx_core::estimation::inner_optimizer::InnerLoopStats::n_start_rejected: usize
 pub ferx_core::estimation::inner_optimizer::InnerLoopStats::n_unconverged: usize
+pub ferx_core::estimation::inner_optimizer::InnerLoopStats::total_inner_iters: u64
 pub const ferx_core::estimation::inner_optimizer::INNER_LBFGS_MIN_DIM: usize
 pub static ferx_core::estimation::inner_optimizer::PROFILE_INNER_ANALYTIC_GRAD: core::sync::atomic::AtomicU64
 pub static ferx_core::estimation::inner_optimizer::PROFILE_INNER_FD_FALLBACK: core::sync::atomic::AtomicU64

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -370,6 +370,7 @@ fn run_map_multistart(
         n_unconverged: results.iter().filter(|r| !r.converged).count(),
         n_fallback: results.iter().filter(|r| r.used_fallback).count(),
         n_start_rejected: results.iter().filter(|r| r.hard_reject).count(),
+        total_inner_iters: results.iter().map(|r| r.n_iters).sum(),
     };
     let eta_hats: Vec<DVector<f64>> = results.iter().map(|r| r.eta.clone()).collect();
     let h_matrices: Vec<DMatrix<f64>> = results.iter().map(|r| r.h_matrix.clone()).collect();

--- a/src/estimation/impmap.rs
+++ b/src/estimation/impmap.rs
@@ -284,6 +284,12 @@ fn find_ebe_multistart(
     let Some(l_omega) = omega_chol else {
         return best;
     };
+    // `n_iters` is the one field that must survive a losing start: every MCETA start is
+    // work the fit actually paid for, but `best = candidate` below replaces the result
+    // wholesale, so without this the reported total is one start's count out of
+    // `mceta + 1` — an `mceta`-fold undercount on exactly the multimodal subjects
+    // multi-start exists for.
+    let mut spent = best.n_iters;
     let n_eta = l_omega.nrows();
     let mut rng = StdRng::seed_from_u64(subj_seed);
     for _start in 0..mceta {
@@ -304,10 +310,12 @@ fn find_ebe_multistart(
             mu,
             inner_restarts,
         );
+        spent += candidate.n_iters;
         if candidate.nll < best.nll {
             best = candidate;
         }
     }
+    best.n_iters = spent;
     best
 }
 
@@ -3360,6 +3368,60 @@ mod tests {
             "MCETA restarts must not return a worse mode: {} vs {}",
             multi.nll,
             baseline.nll
+        );
+    }
+
+    /// Every MCETA start is optimizer work the fit paid for, so `find_ebe_multistart`
+    /// must report the sum over all `mceta + 1` starts — not the winner's count alone.
+    /// Reconstructing the starts from the same `subj_seed` (`StdRng` is deterministic,
+    /// and the draw is the same `L_Ω · z`) pins the *exact* total, so the wholesale
+    /// `best = candidate` copy — which reported one start out of five — fails here
+    /// rather than merely reading low.
+    #[test]
+    fn find_ebe_multistart_n_iters_counts_every_start() {
+        let model = crate::parser::model_parser::parse_model_string(MIX_MODEL).unwrap();
+        let pop = mix_pop();
+        let params = &model.default_params;
+        let subject = &pop.subjects[0];
+        let chol = params.omega.matrix.clone().cholesky().unwrap().l();
+        let (mceta, seed) = (4usize, 7u64);
+
+        // Baseline (cold) start, then each random start, run independently.
+        let baseline = find_ebe(&model, subject, params, 50, 1e-4, None, None, 0);
+        let mut expected = baseline.n_iters;
+        let mut rng = StdRng::seed_from_u64(seed);
+        for _ in 0..mceta {
+            let z: Vec<f64> = (0..chol.nrows())
+                .map(|_| StandardNormal.sample(&mut rng))
+                .collect();
+            let eta_start = &chol * DVector::from_vec(z);
+            let eta_slice: Vec<f64> = eta_start.iter().copied().collect();
+            expected +=
+                find_ebe(&model, subject, params, 50, 1e-4, Some(&eta_slice), None, 0).n_iters;
+        }
+        assert!(
+            expected > baseline.n_iters,
+            "sanity: the extra starts must do work of their own, else this test cannot \
+             tell the sum from the winner (baseline={}, total={expected})",
+            baseline.n_iters
+        );
+
+        let multi = find_ebe_multistart(
+            &model,
+            subject,
+            params,
+            50,
+            1e-4,
+            None,
+            None,
+            0,
+            mceta,
+            Some(&chol),
+            seed,
+        );
+        assert_eq!(
+            multi.n_iters, expected,
+            "multi-start must report every start's iterations, not only the winner's"
         );
     }
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -448,6 +448,34 @@ impl GradientTimings {
 
 pub(crate) static GRADIENT_TIMINGS: GradientTimings = GradientTimings::new();
 
+/// Inner-optimizer iteration tally, split by optimizer kind.
+///
+/// The two kinds are **not** interchangeable as a cost proxy, which is why they are
+/// counted separately rather than into one scalar: a BFGS/L-BFGS iteration costs one
+/// gradient (analytic, or `~2·n_eta+1` predictions under the FD fallback) plus a
+/// backtracking line search, while a Nelder–Mead iteration costs 1–2 bare objective
+/// evaluations against a budget of `max_iter * 5`. Summed blind, a subject that falls
+/// back can out-"iterate" a subject whose main solve did far more work.
+///
+/// [`EbeResult::n_iters`] publishes only the sum; the split is reported per fit by
+/// [`profile_report`] under `FERX_PROFILE=1`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InnerIterCounts {
+    /// Iterations of the main BFGS/L-BFGS solve and of any `inner_restarts` seed,
+    /// each of which re-enters [`inner_minimize_with_grad`].
+    pub(crate) bfgs: u64,
+    /// Nelder–Mead iterations: the BFGS→NM fallback (one or two runs, see
+    /// [`argmin_inner_fallback`]), the runaway-EBE-guard recovery, or the whole main
+    /// solve when `inner_optimizer = nelder_mead`.
+    pub(crate) nelder_mead: u64,
+}
+
+impl InnerIterCounts {
+    pub(crate) fn total(&self) -> u64 {
+        self.bfgs + self.nelder_mead
+    }
+}
+
 /// Result of inner optimization for a single subject
 pub struct EbeResult {
     pub eta: DVector<f64>,
@@ -465,8 +493,14 @@ pub struct EbeResult {
     /// `iov_occasion_groups`).
     pub kappas: Vec<DVector<f64>>,
     /// Total optimizer iterations spent on this subject: the main BFGS/L-BFGS/Nelder-Mead
-    /// solve plus any fallback/restart/runaway-guard Nelder-Mead runs. 0 for a `hard_reject`
-    /// (no optimizer ran).
+    /// solve plus any fallback/restart/runaway-guard Nelder-Mead runs, and — under
+    /// `find_ebe_multistart` — every MCETA start, not only the winning one. 0 for a
+    /// `hard_reject` (no optimizer ran).
+    ///
+    /// This is a raw count of heterogeneous iterations, **not** a time proxy: a BFGS
+    /// iteration (one gradient plus a line search) and a Nelder–Mead one (1–2 bare
+    /// objective evaluations) are not comparable, so run with `FERX_PROFILE=1` for the
+    /// split plus a fit-wide total ([`profile_report`]).
     pub n_iters: u64,
     /// True when the subject was hard-rejected at its inner start (a pathological
     /// ODE+IOV warm-start NLL — see `reject_ode_iov_inner_start`). The returned
@@ -489,6 +523,14 @@ pub struct InnerLoopStats {
     /// regardless of `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
     pub n_start_rejected: usize,
     /// Sum of [`EbeResult::n_iters`] across all subjects, for this call's inner loop.
+    ///
+    /// Scope: only the inner loops that build an `InnerLoopStats` populate this —
+    /// `run_inner_loop_warm_map` (and hence `run_inner_loop_warm`), the mixture
+    /// E-step, and IMPMAP's multi-start sweep. Callers that invoke `find_ebe`
+    /// directly and discard the `EbeResult` (AGQ, the covariance step, importance
+    /// sampling, the VI ELBO bound) contribute nothing here, so a zero does not mean
+    /// no inner work was done. `FERX_PROFILE=1` counts *every* solve
+    /// ([`profile_report`]).
     pub total_inner_iters: u64,
 }
 
@@ -516,7 +558,6 @@ pub struct InnerLoopStats {
 /// partial's point reported a converged EBE whenever NM had converged in a *worse* basin,
 /// which bypassed `max_unconverged_frac` and AGQ's per-subject acceptance. A non-finite
 /// `obj(partial)` (NaN/∞) makes the partial unusable so the NM result is taken.
-#[allow(clippy::too_many_arguments)]
 fn argmin_inner_fallback(
     obj: &dyn Fn(&[f64]) -> f64,
     partial: &[f64],
@@ -524,7 +565,7 @@ fn argmin_inner_fallback(
     n: usize,
     max_iter: usize,
     tol: f64,
-    iters: &mut u64,
+    iters: &mut InnerIterCounts,
 ) -> (Vec<f64>, bool) {
     let partial_f = obj(partial);
     let partial_usable = partial_f.is_finite();
@@ -943,7 +984,7 @@ pub fn find_ebe(
             }
         }
     };
-    let mut n_iters: u64 = 0;
+    let mut n_iters = InnerIterCounts::default();
     let result = inner_minimize_with_grad(
         &obj,
         &agrad,
@@ -1189,6 +1230,7 @@ pub fn find_ebe(
         }
     };
 
+    record_inner_iters(&n_iters);
     EbeResult {
         eta: DVector::from_column_slice(&eta_true),
         h_matrix,
@@ -1198,7 +1240,7 @@ pub fn find_ebe(
         nll,
         kappas: Vec::new(),
         hard_reject: false,
-        n_iters,
+        n_iters: n_iters.total(),
     }
 }
 
@@ -1360,7 +1402,7 @@ fn find_ebe_iov(
         };
     }
 
-    let mut n_iters: u64 = 0;
+    let mut n_iters = InnerIterCounts::default();
     let bfgs_converged = inner_minimize_with_grad(
         &obj,
         &agrad,
@@ -1485,6 +1527,7 @@ fn find_ebe_iov(
         }
     };
 
+    record_inner_iters(&n_iters);
     EbeResult {
         eta: DVector::from_column_slice(&bsv_eta),
         h_matrix,
@@ -1492,7 +1535,7 @@ fn find_ebe_iov(
         used_fallback,
         grad_norm: 0.0,
         nll,
-        n_iters,
+        n_iters: n_iters.total(),
         kappas: kappas_vec,
         hard_reject: false,
     }
@@ -1710,6 +1753,32 @@ pub static PROFILE_INNER_ANALYTIC_GRAD: std::sync::atomic::AtomicU64 =
 pub static PROFILE_INNER_FD_FALLBACK: std::sync::atomic::AtomicU64 =
     std::sync::atomic::AtomicU64::new(0);
 
+/// Fit-wide inner-optimizer iteration totals, split by optimizer kind (see
+/// [`InnerIterCounts`]). Process-global for the same reason [`PROFILE_INNER_SOLVES`]
+/// is: [`InnerLoopStats::total_inner_iters`] is rebuilt per outer evaluation and
+/// dropped once the EBE guard has read it, so a per-call struct cannot answer "how
+/// many optimizer iterations did this *fit* spend". These accumulate across every
+/// [`find_ebe`] call, including the AGQ / covariance / importance-sampling callers
+/// that discard their `EbeResult`.
+pub(crate) static PROFILE_INNER_BFGS_ITERS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+pub(crate) static PROFILE_INNER_NM_ITERS: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
+/// Fold one subject's [`InnerIterCounts`] into the fit-wide totals.
+///
+/// Deliberately *not* behind [`inner_profile_enabled`], unlike the counters above:
+/// this is two relaxed adds per subject **solve** (not per iteration), which is
+/// nothing beside the solve itself, and being unconditional makes the totals
+/// assertable from a unit test — a gated counter cannot be, since `FERX_PROFILE` is
+/// read once into a `OnceLock` that another test in the same binary may have already
+/// initialised.
+fn record_inner_iters(c: &InnerIterCounts) {
+    use std::sync::atomic::Ordering::Relaxed;
+    PROFILE_INNER_BFGS_ITERS.fetch_add(c.bfgs, Relaxed);
+    PROFILE_INNER_NM_ITERS.fetch_add(c.nelder_mead, Relaxed);
+}
+
 fn inner_profile_enabled() -> bool {
     static E: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *E.get_or_init(|| {
@@ -1740,6 +1809,8 @@ pub fn profile_report() {
     let solves = PROFILE_INNER_SOLVES.load(Relaxed);
     let ana = PROFILE_INNER_ANALYTIC_GRAD.load(Relaxed);
     let fd = PROFILE_INNER_FD_FALLBACK.load(Relaxed);
+    let bfgs_iters = PROFILE_INNER_BFGS_ITERS.load(Relaxed);
+    let nm_iters = PROFILE_INNER_NM_ITERS.load(Relaxed);
     if solves > 0 {
         let tot = (ana + fd).max(1);
         eprintln!(
@@ -1748,6 +1819,16 @@ pub fn profile_report() {
             ana,
             fd,
             100.0 * fd as f64 / tot as f64
+        );
+        // Reported separately rather than as one total: a Nelder-Mead iteration is a
+        // different unit of work from a BFGS one (see `InnerIterCounts`), so the split
+        // is what says whether the inner loop's cost sits in the main solve or in the
+        // fallback path.
+        eprintln!(
+            "[profile] inner iterations: {} BFGS/L-BFGS, {} Nelder-Mead ({:.1} per solve)",
+            bfgs_iters,
+            nm_iters,
+            (bfgs_iters + nm_iters) as f64 / solves as f64
         );
     }
 }
@@ -2767,7 +2848,7 @@ fn inner_minimize_with_grad(
     precond: Option<&[f64]>,
     stop_precond: Option<&[f64]>,
     enable_stall: bool,
-    iters: &mut u64,
+    iters: &mut InnerIterCounts,
 ) -> bool {
     if matches!(
         inner_optimizer_mode(),
@@ -2817,7 +2898,7 @@ fn lbfgs_core(
     precond: Option<&[f64]>,
     stop_precond: Option<&[f64]>,
     enable_stall: bool,
-    iters: &mut u64,
+    iters: &mut InnerIterCounts,
 ) -> bool {
     let mut s_hist: Vec<Vec<f64>> = Vec::new();
     let mut y_hist: Vec<Vec<f64>> = Vec::new();
@@ -2832,7 +2913,7 @@ fn lbfgs_core(
     let mut best_gnorm = f64::INFINITY;
 
     for _iter in 0..max_iter {
-        *iters += 1;
+        iters.bfgs += 1;
         // Stopping metric. `stop_precond` is `Some` only for FREM, where the raw
         // L2 norm would be dominated by the sharp covariate pseudo-obs dims and
         // never fall below `tol` (issue #406), so the preconditioned (≈ Newton-
@@ -2917,7 +2998,7 @@ fn dense_bfgs_core(
     precond: Option<&[f64]>,
     stop_precond: Option<&[f64]>,
     enable_stall: bool,
-    iters: &mut u64,
+    iters: &mut InnerIterCounts,
 ) -> bool {
     let mut h_inv = init_h_inv(n, precond);
     let mut g = grad(x);
@@ -2933,7 +3014,7 @@ fn dense_bfgs_core(
     let mut best_gnorm = f64::INFINITY;
 
     for _iter in 0..max_iter {
-        *iters += 1;
+        iters.bfgs += 1;
         // `stop_precond` is `Some` only for FREM (issue #406); general fits stop
         // on the raw L2 norm so the converged EBE is independent of the `precond`
         // H0 that accelerates the search.
@@ -3026,14 +3107,13 @@ fn dense_bfgs_core(
 }
 
 /// Nelder-Mead simplex minimization (fallback)
-#[allow(clippy::too_many_arguments)]
 fn nelder_mead_minimize(
     obj: &dyn Fn(&[f64]) -> f64,
     x: &mut [f64],
     n: usize,
     max_iter: usize,
     tol: f64,
-    iters: &mut u64,
+    iters: &mut InnerIterCounts,
 ) -> bool {
     let alpha = 1.0;
     let gamma = 2.0;
@@ -3056,7 +3136,7 @@ fn nelder_mead_minimize(
     let mut fvals: Vec<f64> = simplex.iter().map(|p| obj(p)).collect();
 
     for _iter in 0..max_iter {
-        *iters += 1;
+        iters.nelder_mead += 1;
         let mut indices: Vec<usize> = (0..=n).collect();
         // NaN-safe: a non-finite objective (e.g. an ODE prediction that blew
         // up at a simplex vertex) sorts as worst rather than panicking on the

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -464,6 +464,10 @@ pub struct EbeResult {
     /// `kappas[k]` corresponds to the k-th unique occasion (same order as
     /// `iov_occasion_groups`).
     pub kappas: Vec<DVector<f64>>,
+    /// Total optimizer iterations spent on this subject: the main BFGS/L-BFGS/Nelder-Mead
+    /// solve plus any fallback/restart/runaway-guard Nelder-Mead runs. 0 for a `hard_reject`
+    /// (no optimizer ran).
+    pub n_iters: u64,
     /// True when the subject was hard-rejected at its inner start (a pathological
     /// ODE+IOV warm-start NLL — see `reject_ode_iov_inner_start`). The returned
     /// `eta`/`h_matrix` are then a degenerate placeholder (off-mode η, zero H), so the
@@ -484,6 +488,8 @@ pub struct InnerLoopStats {
     /// NLL). Any non-zero count forces the outer EBE guard to reject the trial,
     /// regardless of `max_unconverged_frac` or the `min_obs` filter (#603 review #1/#2).
     pub n_start_rejected: usize,
+    /// Sum of [`EbeResult::n_iters`] across all subjects, for this call's inner loop.
+    pub total_inner_iters: u64,
 }
 
 /// Inner-EBE fallback shared by [`find_ebe`] and [`find_ebe_iov`], invoked when the inner
@@ -510,6 +516,7 @@ pub struct InnerLoopStats {
 /// partial's point reported a converged EBE whenever NM had converged in a *worse* basin,
 /// which bypassed `max_unconverged_frac` and AGQ's per-subject acceptance. A non-finite
 /// `obj(partial)` (NaN/∞) makes the partial unusable so the NM result is taken.
+#[allow(clippy::too_many_arguments)]
 fn argmin_inner_fallback(
     obj: &dyn Fn(&[f64]) -> f64,
     partial: &[f64],
@@ -517,6 +524,7 @@ fn argmin_inner_fallback(
     n: usize,
     max_iter: usize,
     tol: f64,
+    iters: &mut u64,
 ) -> (Vec<f64>, bool) {
     let partial_f = obj(partial);
     let partial_usable = partial_f.is_finite();
@@ -526,7 +534,7 @@ fn argmin_inner_fallback(
     } else {
         cold_seed.to_vec()
     };
-    let nm_ok = nelder_mead_minimize(obj, &mut eta_nm, n, max_iter * 5, tol);
+    let nm_ok = nelder_mead_minimize(obj, &mut eta_nm, n, max_iter * 5, tol, iters);
     let f_nm = obj(&eta_nm);
     // Keep the partial unless NM is *strictly* better. Written as a positive comparison so a
     // non-finite `f_nm` (NM diverged) leaves `nm_strictly_better = false` and the finite
@@ -550,7 +558,7 @@ fn argmin_inner_fallback(
         return (partial.to_vec(), nm_ok);
     }
     let mut polished = partial.to_vec();
-    let polished_ok = nelder_mead_minimize(obj, &mut polished, n, max_iter * 5, tol);
+    let polished_ok = nelder_mead_minimize(obj, &mut polished, n, max_iter * 5, tol, iters);
     let f_polished = obj(&polished);
     if f_polished.is_finite() && f_polished <= partial_f {
         (polished, polished_ok)
@@ -935,6 +943,7 @@ pub fn find_ebe(
             }
         }
     };
+    let mut n_iters: u64 = 0;
     let result = inner_minimize_with_grad(
         &obj,
         &agrad,
@@ -945,6 +954,7 @@ pub fn find_ebe(
         precond.as_deref(),
         stop_precond,
         enable_stall,
+        &mut n_iters,
     );
 
     // If BFGS failed, fall back to Nelder-Mead. The recovery policy depends on whether the
@@ -964,7 +974,8 @@ pub fn find_ebe(
         let partial = eta.clone();
         let cold = vec![0.0; n_eta];
         if enable_stall {
-            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol);
+            let (best, ok) =
+                argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol, &mut n_iters);
             eta = best;
             (ok, true)
         } else if model.frem_config.is_some() {
@@ -974,7 +985,8 @@ pub fn find_ebe(
             // prior-release behaviour for the exact path.
             let warm = ebe_warm_start_enabled() && partial.iter().all(|v| v.is_finite());
             eta = if warm { partial } else { cold };
-            let nm_ok = nelder_mead_minimize(&obj, &mut eta, n_eta, max_iter * 5, tol);
+            let nm_ok =
+                nelder_mead_minimize(&obj, &mut eta, n_eta, max_iter * 5, tol, &mut n_iters);
             (nm_ok, true)
         } else {
             // Non-FREM exact objective (#378): a BFGS "failure" is often a *near-stationary*
@@ -987,7 +999,8 @@ pub fn find_ebe(
             // ODE↔analytical marginal-OFV divergence in #378. Keep the lower-objective of
             // {partial, NM} instead, so a good partial is never traded for a worse NM basin —
             // the same guard the ODE path already uses (#555).
-            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol);
+            let (best, ok) =
+                argmin_inner_fallback(&obj, &partial, &cold, n_eta, max_iter, tol, &mut n_iters);
             eta = best;
             (ok, true)
         }
@@ -1058,6 +1071,7 @@ pub fn find_ebe(
                         precond.as_deref(),
                         stop_precond,
                         enable_stall,
+                        &mut n_iters,
                     );
                     if cand.iter().all(|v| v.is_finite()) {
                         let cand_nll = obj(&cand);
@@ -1114,7 +1128,7 @@ pub fn find_ebe(
     let runaway_limit = RUNAWAY_EBE_MAHA_PER_ETA * n_eta as f64;
     if ebe_prior_maha(&eta, &params.omega) > runaway_limit {
         let mut cold = vec![0.0; n_eta];
-        let nm_ok = nelder_mead_minimize(&obj, &mut cold, n_eta, max_iter * 5, tol);
+        let nm_ok = nelder_mead_minimize(&obj, &mut cold, n_eta, max_iter * 5, tol, &mut n_iters);
         if cold.iter().all(|v| v.is_finite()) {
             let cold_nll = obj(&cold);
             if cold_nll < nll {
@@ -1184,6 +1198,7 @@ pub fn find_ebe(
         nll,
         kappas: Vec::new(),
         hard_reject: false,
+        n_iters,
     }
 }
 
@@ -1341,9 +1356,11 @@ fn find_ebe_iov(
             nll: start_nll,
             kappas: kappas_vec,
             hard_reject: true,
+            n_iters: 0,
         };
     }
 
+    let mut n_iters: u64 = 0;
     let bfgs_converged = inner_minimize_with_grad(
         &obj,
         &agrad,
@@ -1354,6 +1371,7 @@ fn find_ebe_iov(
         None,
         None,
         enable_stall,
+        &mut n_iters,
     );
     // On BFGS failure, recover exactly as the non-IOV `find_ebe` does (cold seed = prior
     // mode `bsv_psi = μ`, κ = 0): keep the lower-objective of {BFGS partial, NM restart}
@@ -1377,7 +1395,8 @@ fn find_ebe_iov(
         if skip_ode_iov_nm_fallback(model) {
             (false, false)
         } else {
-            let (best, ok) = argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol);
+            let (best, ok) =
+                argmin_inner_fallback(&obj, &partial, &cold, n_flat, max_iter, tol, &mut n_iters);
             x = best;
             (ok, true)
         }
@@ -1405,7 +1424,7 @@ fn find_ebe_iov(
     {
         let mut cold = vec![0.0; n_flat];
         cold[..n_eta].copy_from_slice(&mu);
-        let ok = nelder_mead_minimize(&obj, &mut cold, n_flat, max_iter * 5, tol);
+        let ok = nelder_mead_minimize(&obj, &mut cold, n_flat, max_iter * 5, tol, &mut n_iters);
         if cold.iter().all(|v| v.is_finite()) && obj(&cold) < obj(&x) {
             x = cold;
             bfgs_converged = false;
@@ -1473,6 +1492,7 @@ fn find_ebe_iov(
         used_fallback,
         grad_norm: 0.0,
         nll,
+        n_iters,
         kappas: kappas_vec,
         hard_reject: false,
     }
@@ -2747,12 +2767,13 @@ fn inner_minimize_with_grad(
     precond: Option<&[f64]>,
     stop_precond: Option<&[f64]>,
     enable_stall: bool,
+    iters: &mut u64,
 ) -> bool {
     if matches!(
         inner_optimizer_mode(),
         crate::types::InnerOptimizer::NelderMead
     ) {
-        return nelder_mead_minimize(obj, x, n, max_iter, tol);
+        return nelder_mead_minimize(obj, x, n, max_iter, tol, iters);
     }
     if inner_use_lbfgs(n) {
         lbfgs_core(
@@ -2765,6 +2786,7 @@ fn inner_minimize_with_grad(
             precond,
             stop_precond,
             enable_stall,
+            iters,
         )
     } else {
         dense_bfgs_core(
@@ -2777,6 +2799,7 @@ fn inner_minimize_with_grad(
             precond,
             stop_precond,
             enable_stall,
+            iters,
         )
     }
 }
@@ -2794,6 +2817,7 @@ fn lbfgs_core(
     precond: Option<&[f64]>,
     stop_precond: Option<&[f64]>,
     enable_stall: bool,
+    iters: &mut u64,
 ) -> bool {
     let mut s_hist: Vec<Vec<f64>> = Vec::new();
     let mut y_hist: Vec<Vec<f64>> = Vec::new();
@@ -2808,6 +2832,7 @@ fn lbfgs_core(
     let mut best_gnorm = f64::INFINITY;
 
     for _iter in 0..max_iter {
+        *iters += 1;
         // Stopping metric. `stop_precond` is `Some` only for FREM, where the raw
         // L2 norm would be dominated by the sharp covariate pseudo-obs dims and
         // never fall below `tol` (issue #406), so the preconditioned (≈ Newton-
@@ -2892,6 +2917,7 @@ fn dense_bfgs_core(
     precond: Option<&[f64]>,
     stop_precond: Option<&[f64]>,
     enable_stall: bool,
+    iters: &mut u64,
 ) -> bool {
     let mut h_inv = init_h_inv(n, precond);
     let mut g = grad(x);
@@ -2907,6 +2933,7 @@ fn dense_bfgs_core(
     let mut best_gnorm = f64::INFINITY;
 
     for _iter in 0..max_iter {
+        *iters += 1;
         // `stop_precond` is `Some` only for FREM (issue #406); general fits stop
         // on the raw L2 norm so the converged EBE is independent of the `precond`
         // H0 that accelerates the search.
@@ -2999,12 +3026,14 @@ fn dense_bfgs_core(
 }
 
 /// Nelder-Mead simplex minimization (fallback)
+#[allow(clippy::too_many_arguments)]
 fn nelder_mead_minimize(
     obj: &dyn Fn(&[f64]) -> f64,
     x: &mut [f64],
     n: usize,
     max_iter: usize,
     tol: f64,
+    iters: &mut u64,
 ) -> bool {
     let alpha = 1.0;
     let gamma = 2.0;
@@ -3027,6 +3056,7 @@ fn nelder_mead_minimize(
     let mut fvals: Vec<f64> = simplex.iter().map(|p| obj(p)).collect();
 
     for _iter in 0..max_iter {
+        *iters += 1;
         let mut indices: Vec<usize> = (0..=n).collect();
         // NaN-safe: a non-finite objective (e.g. an ODE prediction that blew
         // up at a simplex vertex) sorts as worst rather than panicking on the
@@ -3472,6 +3502,7 @@ pub(crate) fn run_inner_loop_warm_map<T: Send>(
         // No `min_obs` filter: a hard reject forces trial rejection even for a single
         // short-record subject, which the `n_unconverged` filter would otherwise drop.
         n_start_rejected: results.iter().filter(|(r, _)| r.hard_reject).count(),
+        total_inner_iters: results.iter().map(|(r, _)| r.n_iters).sum(),
     };
     let mut eta_hats = Vec::with_capacity(results.len());
     let mut h_matrices = Vec::with_capacity(results.len());

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -4,6 +4,26 @@ use crate::types::{
 };
 use std::collections::HashMap;
 
+/// Serializes the tests below that write `EBE_WARM_START`.
+///
+/// That flag is a *process-global* `AtomicBool` — fit-scoped, set once per `fit()` by
+/// `api::fit` — not per-test state, and Rust's harness runs tests in this binary on
+/// concurrent threads. Without a lock, one test's `set_ebe_warm_start(true)` is visible
+/// to another mid-run and flips `argmin_inner_fallback` onto its warm branch, which runs
+/// one Nelder-Mead pass instead of two; an exact-count assertion then fails perhaps once
+/// in a hundred runs. Every test that sets the flag takes this guard first and restores
+/// the `false` default before dropping it.
+///
+/// Poisoning is deliberately ignored: a poisoned lock here means some *other* test
+/// panicked, which is already its own failure, and propagating it would turn one red
+/// test into several.
+fn lock_ebe_warm_start() -> std::sync::MutexGuard<'static, ()> {
+    static EBE_WARM_START_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    EBE_WARM_START_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[test]
 fn iov_joint_warm_start_preserves_kappas() {
     let mu = [0.5, -0.25];
@@ -1270,6 +1290,7 @@ fn repro555_ode_exprscale_ebe_finds_global_min() {
 /// f=-10; shallow well at x=+2, f=-1).
 #[test]
 fn argmin_inner_fallback_keeps_better_basin() {
+    let _warm_start_guard = lock_ebe_warm_start();
     let obj = |x: &[f64]| -> f64 {
         let v = x[0];
         if v < 0.0 {
@@ -1279,7 +1300,7 @@ fn argmin_inner_fallback_keeps_better_basin() {
         }
     };
     set_ebe_warm_start(false);
-    let mut iters = 0u64;
+    let mut iters = InnerIterCounts::default();
 
     // Partial in the deep (global) well, cold NM seed in the shallow well: the fallback
     // keeps the lower-objective partial rather than overwriting with the shallow NM
@@ -2959,6 +2980,7 @@ fn ode_ltbs_init_cond_inner_grad_matches_fd() {
 /// fallback reads, and defaults to `false` (matching `FitOptions::default`).
 #[test]
 fn ebe_warm_start_flag_round_trips() {
+    let _warm_start_guard = lock_ebe_warm_start();
     assert!(!ebe_warm_start_enabled(), "default must be off");
     set_ebe_warm_start(true);
     assert!(ebe_warm_start_enabled());
@@ -3469,6 +3491,7 @@ fn power_exponent_inner_eta_gradient_matches_fd() {
 /// kept. Verified by mutation: restoring the unconditional-NM arm turns this red.
 #[test]
 fn iov_inner_fallback_keeps_bfgs_partial_over_worse_cold_nm() {
+    let _warm_start_guard = lock_ebe_warm_start();
     use crate::parser::model_parser::parse_model_string;
     let model = parse_model_string(
         r#"
@@ -3594,6 +3617,7 @@ fn iov_inner_fallback_keeps_bfgs_partial_over_worse_cold_nm() {
 /// restart's flag turns the first half red.
 #[test]
 fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
+    let _warm_start_guard = lock_ebe_warm_start();
     let obj = |x: &[f64]| -> f64 {
         let v = x[0];
         if v < 0.0 {
@@ -3605,7 +3629,7 @@ fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
     set_ebe_warm_start(false);
     let partial = [-1.5];
     let f_partial = obj(&partial);
-    let mut iters = 0u64;
+    let mut iters = InnerIterCounts::default();
 
     // Tiny budget: the cold restart converges in the shallow well, the partial wins, the
     // polish cannot certify it.
@@ -3642,6 +3666,7 @@ fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
 /// `iters` — is caught by an unequal total rather than merely a "iters > 0" pass.
 #[test]
 fn argmin_inner_fallback_iters_sum_both_nm_runs_when_polishing() {
+    let _warm_start_guard = lock_ebe_warm_start();
     let obj = |x: &[f64]| -> f64 {
         let v = x[0];
         if v < 0.0 {
@@ -3659,7 +3684,7 @@ fn argmin_inner_fallback_iters_sum_both_nm_runs_when_polishing() {
     // Independently reproduce both internal NM runs `argmin_inner_fallback` makes on this
     // (non-warm, partial-wins) path: the cold restart, then the certifying polish from the
     // partial — same start points, same `max_iter * 5` budget, same objective.
-    let mut expected_iters = 0u64;
+    let mut expected_iters = InnerIterCounts::default();
     let mut cold_restart = cold_seed;
     nelder_mead_minimize(
         &obj,
@@ -3671,9 +3696,16 @@ fn argmin_inner_fallback_iters_sum_both_nm_runs_when_polishing() {
     );
     let mut polish = partial;
     nelder_mead_minimize(&obj, &mut polish, 1, max_iter * 5, tol, &mut expected_iters);
-    assert!(expected_iters > 0, "sanity: NM must take at least one step");
+    assert!(
+        expected_iters.nelder_mead > 0,
+        "sanity: NM must take at least one step"
+    );
+    assert_eq!(
+        expected_iters.bfgs, 0,
+        "sanity: this path runs Nelder-Mead only"
+    );
 
-    let mut fallback_iters = 0u64;
+    let mut fallback_iters = InnerIterCounts::default();
     let _ = argmin_inner_fallback(
         &obj,
         &partial,

--- a/src/estimation/inner_optimizer_iov_tests.rs
+++ b/src/estimation/inner_optimizer_iov_tests.rs
@@ -1279,22 +1279,23 @@ fn argmin_inner_fallback_keeps_better_basin() {
         }
     };
     set_ebe_warm_start(false);
+    let mut iters = 0u64;
 
     // Partial in the deep (global) well, cold NM seed in the shallow well: the fallback
     // keeps the lower-objective partial rather than overwriting with the shallow NM
     // result (the old behaviour, which on this multimodal objective inflated the OFV).
-    let (eta, _) = argmin_inner_fallback(&obj, &[-2.0], &[2.0], 1, 200, 1e-8);
+    let (eta, _) = argmin_inner_fallback(&obj, &[-2.0], &[2.0], 1, 200, 1e-8, &mut iters);
     assert!((eta[0] + 2.0).abs() < 1e-2, "kept deep well, got {eta:?}");
 
     // Partial in the shallow well, cold NM seed reaches the deep well: NM wins.
-    let (eta2, _) = argmin_inner_fallback(&obj, &[2.0], &[-2.0], 1, 200, 1e-8);
+    let (eta2, _) = argmin_inner_fallback(&obj, &[2.0], &[-2.0], 1, 200, 1e-8, &mut iters);
     assert!(
         (eta2[0] + 2.0).abs() < 1e-2,
         "NM found deeper well, got {eta2:?}"
     );
 
     // Non-finite partial objective → unusable → NM result is taken.
-    let (eta3, _) = argmin_inner_fallback(&obj, &[f64::NAN], &[-2.0], 1, 200, 1e-8);
+    let (eta3, _) = argmin_inner_fallback(&obj, &[f64::NAN], &[-2.0], 1, 200, 1e-8, &mut iters);
     assert!(
         eta3[0].is_finite(),
         "NaN partial must be discarded, got {eta3:?}"
@@ -1303,7 +1304,7 @@ fn argmin_inner_fallback_keeps_better_basin() {
     // `ebe_warm_start` seeds the single NM from the partial (covers the warm branch):
     // from the deep well it stays there even though the cold seed is far away.
     set_ebe_warm_start(true);
-    let (eta4, _) = argmin_inner_fallback(&obj, &[-2.0], &[5.0], 1, 200, 1e-8);
+    let (eta4, _) = argmin_inner_fallback(&obj, &[-2.0], &[5.0], 1, 200, 1e-8, &mut iters);
     assert!(
         (eta4[0] + 2.0).abs() < 1e-2,
         "warm seed held the deep well, got {eta4:?}"
@@ -3604,10 +3605,11 @@ fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
     set_ebe_warm_start(false);
     let partial = [-1.5];
     let f_partial = obj(&partial);
+    let mut iters = 0u64;
 
     // Tiny budget: the cold restart converges in the shallow well, the partial wins, the
     // polish cannot certify it.
-    let (eta, ok) = argmin_inner_fallback(&obj, &partial, &[2.0], 1, 1, 1e-3);
+    let (eta, ok) = argmin_inner_fallback(&obj, &partial, &[2.0], 1, 1, 1e-3, &mut iters);
     assert!(eta[0] < 0.0, "must stay in the deep well, got {eta:?}");
     assert!(
         obj(&eta) <= f_partial,
@@ -3621,7 +3623,7 @@ fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
     );
 
     // Normal budget: the polish reaches the deep mode and earns the flag.
-    let (eta2, ok2) = argmin_inner_fallback(&obj, &partial, &[2.0], 1, 200, 1e-8);
+    let (eta2, ok2) = argmin_inner_fallback(&obj, &partial, &[2.0], 1, 200, 1e-8, &mut iters);
     assert!(
         (eta2[0] + 2.0).abs() < 1e-2,
         "polish must reach the deep mode, got {eta2:?}"
@@ -3630,4 +3632,61 @@ fn argmin_inner_fallback_flag_belongs_to_the_returned_point() {
         ok2,
         "an NM run that ended at the returned point certifies it"
     );
+}
+
+/// `argmin_inner_fallback`'s "polish" branch (non-warm, partial wins over the cold restart)
+/// runs Nelder-Mead *twice* — see its doc comment. The `iters` accumulator must count both
+/// runs, not just one: comparing against the sum of two independent, identically-seeded
+/// `nelder_mead_minimize` calls (deterministic, no RNG) pins the exact count, so a mutation
+/// that threads a throwaway counter into either internal call — instead of the caller's
+/// `iters` — is caught by an unequal total rather than merely a "iters > 0" pass.
+#[test]
+fn argmin_inner_fallback_iters_sum_both_nm_runs_when_polishing() {
+    let obj = |x: &[f64]| -> f64 {
+        let v = x[0];
+        if v < 0.0 {
+            (v + 2.0).powi(2) - 10.0
+        } else {
+            (v - 2.0).powi(2) - 1.0
+        }
+    };
+    set_ebe_warm_start(false);
+    let partial = [-1.5];
+    let cold_seed = [2.0];
+    let max_iter = 200;
+    let tol = 1e-8;
+
+    // Independently reproduce both internal NM runs `argmin_inner_fallback` makes on this
+    // (non-warm, partial-wins) path: the cold restart, then the certifying polish from the
+    // partial — same start points, same `max_iter * 5` budget, same objective.
+    let mut expected_iters = 0u64;
+    let mut cold_restart = cold_seed;
+    nelder_mead_minimize(
+        &obj,
+        &mut cold_restart,
+        1,
+        max_iter * 5,
+        tol,
+        &mut expected_iters,
+    );
+    let mut polish = partial;
+    nelder_mead_minimize(&obj, &mut polish, 1, max_iter * 5, tol, &mut expected_iters);
+    assert!(expected_iters > 0, "sanity: NM must take at least one step");
+
+    let mut fallback_iters = 0u64;
+    let _ = argmin_inner_fallback(
+        &obj,
+        &partial,
+        &cold_seed,
+        1,
+        max_iter,
+        tol,
+        &mut fallback_iters,
+    );
+
+    assert_eq!(
+        fallback_iters, expected_iters,
+        "fallback's polish path must count exactly both NM runs' iterations"
+    );
+    set_ebe_warm_start(false);
 }

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -844,11 +844,11 @@ fn inner_solver_scaling_bench() {
             t0.elapsed().as_secs_f64() * 1e3 / runs as f64
         };
         let t_dense = time_it(&|x| {
-            let mut iters = 0u64;
+            let mut iters = InnerIterCounts::default();
             dense_bfgs_core(&obj, &grad, x, n, 2000, 1e-8, None, None, false, &mut iters)
         });
         let t_lbfgs = time_it(&|x| {
-            let mut iters = 0u64;
+            let mut iters = InnerIterCounts::default();
             lbfgs_core(&obj, &grad, x, n, 2000, 1e-8, None, None, false, &mut iters)
         });
         eprintln!(
@@ -957,7 +957,7 @@ fn dense_bfgs_converges_on_quadratic() {
         |x: &[f64]| -> f64 { (x[0] - 1.0) * (x[0] - 1.0) + 4.0 * (x[1] + 2.0) * (x[1] + 2.0) };
     let grad = |x: &[f64]| -> Vec<f64> { vec![2.0 * (x[0] - 1.0), 8.0 * (x[1] + 2.0)] };
     let mut x = vec![0.0, 0.0];
-    let mut iters = 0u64;
+    let mut iters = InnerIterCounts::default();
     let ok = dense_bfgs_core(
         &obj, &grad, &mut x, 2, 200, 1e-10, None, None, false, &mut iters,
     );
@@ -1302,7 +1302,7 @@ fn test_nelder_mead_nan_objective_does_not_panic() {
     let mut x = vec![-1.0, -1.0];
     // The contract under test is "does not panic"; the return flag and
     // final point are secondary. Coordinates must stay finite.
-    let mut iters = 0u64;
+    let mut iters = InnerIterCounts::default();
     let _converged = nelder_mead_minimize(&obj, &mut x, 2, 200, 1e-8, &mut iters);
     assert!(
         x.iter().all(|v| v.is_finite()),
@@ -1419,13 +1419,10 @@ fn inner_restarts_bit_identical_on_wellidentified_subject() {
     }
 }
 
-/// `EbeResult::n_iters` must track actual optimizer work, not a constant: a cold-started
-/// search takes at least one iteration, and a warm start from the already-converged mode
-/// must take fewer iterations to re-certify than the cold start needed to find it. A
-/// mutation that left `n_iters` at 0 (never incremented) or hardcoded it to `max_iter`
-/// would leave one of these two assertions unable to distinguish the cases.
-#[test]
-fn find_ebe_n_iters_tracks_actual_optimizer_work() {
+/// One-compartment oral subject with a mode well away from η = 0, shared by the
+/// iteration-accounting tests below: the solve has to do real optimizer work for a
+/// count to mean anything.
+fn one_cpt_oral_iter_fixture() -> (crate::types::CompiledModel, crate::types::Subject) {
     use crate::types::{DoseEvent, Subject};
     use std::collections::HashMap;
     let model = crate::parser::model_parser::parse_model_string(
@@ -1456,6 +1453,17 @@ fn find_ebe_n_iters_tracks_actual_optimizer_work() {
         obs_records: vec![],
     };
 
+    (model, subject)
+}
+
+/// `EbeResult::n_iters` must track actual optimizer work, not a constant: a cold-started
+/// search takes at least one iteration, and a warm start from the already-converged mode
+/// must take fewer iterations to re-certify than the cold start needed to find it. A
+/// mutation that left `n_iters` at 0 (never incremented) or hardcoded it to `max_iter`
+/// would leave one of these two assertions unable to distinguish the cases.
+#[test]
+fn find_ebe_n_iters_tracks_actual_optimizer_work() {
+    let (model, subject) = one_cpt_oral_iter_fixture();
     let params = &model.default_params;
     let cold = find_ebe(&model, &subject, params, 100, 1e-8, None, None, 0);
     assert!(
@@ -1481,6 +1489,88 @@ fn find_ebe_n_iters_tracks_actual_optimizer_work() {
          the cold-started search that found it (cold={}, warm={})",
         cold.n_iters,
         warm.n_iters
+    );
+}
+
+/// A Nelder-Mead iteration and a BFGS iteration are different units of work — one costs
+/// 1-2 bare objective evaluations, the other a gradient plus a line search — so
+/// [`InnerIterCounts`] must keep them apart even when a single accumulator threads
+/// through both, which is exactly what `find_ebe`'s BFGS→NM fallback does. Asserted on
+/// each field separately: a mutation that increments the wrong field leaves `total()`
+/// unchanged and is invisible to any assertion on the sum alone.
+#[test]
+fn inner_iter_counts_keep_bfgs_and_nelder_mead_apart() {
+    // f(x) = (x0−1)² + 4(x1+2)², minimiser (1, −2) — the same well-conditioned quadratic
+    // `dense_bfgs_converges_on_quadratic` uses, so both optimizers reach it and neither
+    // count is zero for want of a solvable problem.
+    let obj =
+        |x: &[f64]| -> f64 { (x[0] - 1.0) * (x[0] - 1.0) + 4.0 * (x[1] + 2.0) * (x[1] + 2.0) };
+    let grad = |x: &[f64]| -> Vec<f64> { vec![2.0 * (x[0] - 1.0), 8.0 * (x[1] + 2.0)] };
+
+    let mut iters = InnerIterCounts::default();
+    let mut x = vec![0.0, 0.0];
+    dense_bfgs_core(
+        &obj, &grad, &mut x, 2, 200, 1e-10, None, None, false, &mut iters,
+    );
+    let after_bfgs = iters;
+    assert!(
+        after_bfgs.bfgs > 0,
+        "a BFGS solve must report BFGS iterations"
+    );
+    assert_eq!(
+        after_bfgs.nelder_mead, 0,
+        "a BFGS solve must not report Nelder-Mead work"
+    );
+
+    let mut y = vec![0.0, 0.0];
+    nelder_mead_minimize(&obj, &mut y, 2, 200, 1e-10, &mut iters);
+    assert_eq!(
+        iters.bfgs, after_bfgs.bfgs,
+        "a Nelder-Mead run must leave the BFGS tally untouched"
+    );
+    assert!(
+        iters.nelder_mead > 0,
+        "a Nelder-Mead run must report Nelder-Mead iterations"
+    );
+    assert_eq!(
+        iters.total(),
+        iters.bfgs + iters.nelder_mead,
+        "`total()` is the sum of the two kinds"
+    );
+}
+
+/// The per-call [`InnerLoopStats::total_inner_iters`] is rebuilt on every outer evaluation
+/// and dropped once the EBE guard has read it, so it cannot answer "how many optimizer
+/// iterations did this *fit* spend" — the question the instrumentation exists for. The
+/// process-global [`PROFILE_INNER_BFGS_ITERS`] / [`PROFILE_INNER_NM_ITERS`] pair is what
+/// accumulates across a fit (and across the callers that discard their `EbeResult`), so
+/// every `find_ebe` must feed them.
+///
+/// The counters are monotonic and shared with every other test in this binary, so the
+/// assertion is a *lower* bound — other threads can only inflate the delta, never shrink
+/// it. Deleting the `record_inner_iters` call makes the delta zero when this test runs on
+/// its own (`cargo test find_ebe_feeds_the_fit_wide_profile_counters`), which is how that
+/// mutation is caught; in a full parallel run the check degrades to weaker but never
+/// wrong.
+#[test]
+fn find_ebe_feeds_the_fit_wide_profile_counters() {
+    use std::sync::atomic::Ordering::Relaxed;
+    let (model, subject) = one_cpt_oral_iter_fixture();
+    let params = &model.default_params;
+
+    let before = PROFILE_INNER_BFGS_ITERS.load(Relaxed) + PROFILE_INNER_NM_ITERS.load(Relaxed);
+    let r = find_ebe(&model, &subject, params, 100, 1e-8, None, None, 0);
+    let after = PROFILE_INNER_BFGS_ITERS.load(Relaxed) + PROFILE_INNER_NM_ITERS.load(Relaxed);
+
+    assert!(
+        r.n_iters > 0,
+        "fixture must do optimizer work for this to test anything"
+    );
+    assert!(
+        after - before >= r.n_iters,
+        "the fit-wide counters must have received this solve's {} iterations (delta {})",
+        r.n_iters,
+        after - before
     );
 }
 

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -843,9 +843,14 @@ fn inner_solver_scaling_bench() {
             }
             t0.elapsed().as_secs_f64() * 1e3 / runs as f64
         };
-        let t_dense =
-            time_it(&|x| dense_bfgs_core(&obj, &grad, x, n, 2000, 1e-8, None, None, false));
-        let t_lbfgs = time_it(&|x| lbfgs_core(&obj, &grad, x, n, 2000, 1e-8, None, None, false));
+        let t_dense = time_it(&|x| {
+            let mut iters = 0u64;
+            dense_bfgs_core(&obj, &grad, x, n, 2000, 1e-8, None, None, false, &mut iters)
+        });
+        let t_lbfgs = time_it(&|x| {
+            let mut iters = 0u64;
+            lbfgs_core(&obj, &grad, x, n, 2000, 1e-8, None, None, false, &mut iters)
+        });
         eprintln!(
             "  n={n:4}  dense={t_dense:8.3} ms  lbfgs={t_lbfgs:8.3} ms  dense/lbfgs={:.2}x",
             t_dense / t_lbfgs
@@ -952,7 +957,10 @@ fn dense_bfgs_converges_on_quadratic() {
         |x: &[f64]| -> f64 { (x[0] - 1.0) * (x[0] - 1.0) + 4.0 * (x[1] + 2.0) * (x[1] + 2.0) };
     let grad = |x: &[f64]| -> Vec<f64> { vec![2.0 * (x[0] - 1.0), 8.0 * (x[1] + 2.0)] };
     let mut x = vec![0.0, 0.0];
-    let ok = dense_bfgs_core(&obj, &grad, &mut x, 2, 200, 1e-10, None, None, false);
+    let mut iters = 0u64;
+    let ok = dense_bfgs_core(
+        &obj, &grad, &mut x, 2, 200, 1e-10, None, None, false, &mut iters,
+    );
     assert!(ok, "BFGS should report convergence");
     assert!((x[0] - 1.0).abs() < 1e-6, "x0 = {}", x[0]);
     assert!((x[1] + 2.0).abs() < 1e-6, "x1 = {}", x[1]);
@@ -1043,6 +1051,7 @@ fn test_ebe_result_converged_flag() {
         nll: 1.5,
         kappas: Vec::new(),
         hard_reject: false,
+        n_iters: 0,
     };
     assert!(r.converged);
     assert!(!r.used_fallback);
@@ -1064,6 +1073,7 @@ fn test_inner_loop_stats_min_obs_filter() {
             nll: 1.0,
             kappas: Vec::new(),
             hard_reject: false,
+            n_iters: 0,
         },
         EbeResult {
             eta: nalgebra::DVector::zeros(1),
@@ -1074,6 +1084,7 @@ fn test_inner_loop_stats_min_obs_filter() {
             nll: 2.0,
             kappas: Vec::new(),
             hard_reject: false,
+            n_iters: 0,
         },
     ];
     // Simulate filter: first subject has 1 obs (below min_obs=2), second has 3 obs.
@@ -1105,6 +1116,7 @@ fn test_inner_loop_stats_counts_hard_reject_regardless_of_obs() {
         nll: 1.0,
         kappas: Vec::new(),
         hard_reject,
+        n_iters: 0,
     };
     // One hard-rejected subject with a single observation, one normal subject.
     let results = [make(true), make(false)];
@@ -1290,7 +1302,8 @@ fn test_nelder_mead_nan_objective_does_not_panic() {
     let mut x = vec![-1.0, -1.0];
     // The contract under test is "does not panic"; the return flag and
     // final point are secondary. Coordinates must stay finite.
-    let _converged = nelder_mead_minimize(&obj, &mut x, 2, 200, 1e-8);
+    let mut iters = 0u64;
+    let _converged = nelder_mead_minimize(&obj, &mut x, 2, 200, 1e-8, &mut iters);
     assert!(
         x.iter().all(|v| v.is_finite()),
         "Nelder-Mead must leave the point finite, got {x:?}"
@@ -1404,6 +1417,71 @@ fn inner_restarts_bit_identical_on_wellidentified_subject() {
             on.eta[k], off.eta[k]
         );
     }
+}
+
+/// `EbeResult::n_iters` must track actual optimizer work, not a constant: a cold-started
+/// search takes at least one iteration, and a warm start from the already-converged mode
+/// must take fewer iterations to re-certify than the cold start needed to find it. A
+/// mutation that left `n_iters` at 0 (never incremented) or hardcoded it to `max_iter`
+/// would leave one of these two assertions unable to distinguish the cases.
+#[test]
+fn find_ebe_n_iters_tracks_actual_optimizer_work() {
+    use crate::types::{DoseEvent, Subject};
+    use std::collections::HashMap;
+    let model = crate::parser::model_parser::parse_model_string(
+        "[parameters]\n  theta TVCL(0.2,0.001,10.0)\n  theta TVV(10.0,0.1,500.0)\n  theta TVKA(1.5,0.01,50.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  omega ETA_KA ~ 0.30\n  sigma PROP_ERR ~ 0.2 (sd)\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n  KA = TVKA * exp(ETA_KA)\n[structural_model]\n  pk one_cpt_oral(cl=CL, v=V, ka=KA)\n[error_model]\n  DV ~ proportional(PROP_ERR)\n[fit_options]\n  method = focei\n",
+    )
+    .expect("parse one_cpt_oral model");
+
+    let subject = Subject {
+        id: "1".into(),
+        doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        obs_times: vec![0.5, 1.0, 2.0, 4.0, 8.0, 12.0],
+        obs_raw_times: Vec::new(),
+        observations: vec![8.0, 12.0, 10.0, 6.0, 3.0, 1.5],
+        obs_cmts: vec![1; 6],
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        reset_covariates: Vec::new(),
+        cens: vec![0; 6],
+        occasions: Vec::new(),
+        obs_l2: Vec::new(),
+        dose_occasions: Vec::new(),
+        reset_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        obs_records: vec![],
+    };
+
+    let params = &model.default_params;
+    let cold = find_ebe(&model, &subject, params, 100, 1e-8, None, None, 0);
+    assert!(
+        cold.n_iters > 0,
+        "a cold-started solve must take at least one optimizer iteration, got {}",
+        cold.n_iters
+    );
+
+    let warm_eta: Vec<f64> = cold.eta.iter().copied().collect();
+    let warm = find_ebe(
+        &model,
+        &subject,
+        params,
+        100,
+        1e-8,
+        Some(&warm_eta),
+        None,
+        0,
+    );
+    assert!(
+        warm.n_iters < cold.n_iters,
+        "warm-started re-solve from the converged mode must take fewer iterations than \
+         the cold-started search that found it (cold={}, warm={})",
+        cold.n_iters,
+        warm.n_iters
+    );
 }
 
 /// `ebe_prior_maha` is the runaway guard's detector: the squared Mahalanobis distance

--- a/src/estimation/mixture.rs
+++ b/src/estimation/mixture.rs
@@ -140,6 +140,7 @@ pub fn mixture_ofv(
     let mut converged: Vec<Vec<bool>> = vec![vec![true; n]; k];
     let mut fallback: Vec<Vec<bool>> = vec![vec![false; n]; k];
     let mut hard_reject: Vec<Vec<bool>> = vec![vec![false; n]; k];
+    let mut total_inner_iters: u64 = 0;
 
     for cls in 0..k {
         // MIXNUM = cls+1 for the whole class solve (serial → thread-local safe).
@@ -203,6 +204,7 @@ pub fn mixture_ofv(
             converged[cls][i] = ebe.converged;
             fallback[cls][i] = ebe.used_fallback;
             hard_reject[cls][i] = ebe.hard_reject;
+            total_inner_iters += ebe.n_iters;
             etas_c.push(ebe.eta);
             hmats_c.push(ebe.h_matrix);
             kappas_c.push(ebe.kappas);
@@ -264,6 +266,7 @@ pub fn mixture_ofv(
             n_unconverged,
             n_fallback,
             n_start_rejected,
+            total_inner_iters,
         },
     }
 }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -1894,6 +1894,7 @@ fn optimize_nlopt_once(
                 n_unconverged: m.ebe_stats.n_unconverged,
                 n_fallback: m.ebe_stats.n_fallback,
                 n_start_rejected: m.ebe_stats.n_start_rejected,
+                total_inner_iters: m.ebe_stats.total_inner_iters,
             };
             let ofv = m.ofv;
             // A derivative-free eval (`grad` is `None` — e.g. BOBYQA, the default)

--- a/src/estimation/outer_optimizer_tests.rs
+++ b/src/estimation/outer_optimizer_tests.rs
@@ -56,6 +56,7 @@ fn ebe_guard_rejects_on_hard_reject_and_fraction() {
         n_unconverged,
         n_fallback: 0,
         n_start_rejected,
+        total_inner_iters: 0,
     };
 
     // A single hard reject forces rejection even with a finite OFV, zero unconverged


### PR DESCRIPTION
<!-- Title format: type(scope): short description [closes #N] -->
## Why

`HANDOFF-perf-stack.md`'s remaining queue names **A1 — inner-loop iteration
instrumentation** as pure measurement, gated ahead of A2 (an η-only `Dual2`
width change to the inner optimizer): before spending effort narrowing the
inner loop's optimizer cost, we need a profile of where that cost actually
goes — how many optimizer iterations a fit spends, and how much of that is
the main solve vs. BFGS→Nelder-Mead fallback, multi-start restarts, or the
runaway-EBE guard.

## What changed

`lbfgs_core`, `dense_bfgs_core` and `nelder_mead_minimize` each take a new
trailing `iters: &mut u64` accumulator, incremented once per pass of their
`for _iter in 0..max_iter` loop. It threads through `inner_minimize_with_grad`
and `argmin_inner_fallback` so every optimizer call a subject's inner solve
makes — the main solve, a BFGS→NM fallback, an `inner_restarts` seed, or the
runaway-EBE-guard NM recovery — counts toward one running total.

`EbeResult` exposes the per-subject total as `n_iters` (`0` on a hard-reject,
where no optimizer ran). `InnerLoopStats` sums it across subjects as
`total_inner_iters`, populated in `run_inner_loop_warm_map` (and therefore
`run_inner_loop_warm`), the mixture E-step (`mixture.rs`), IMPMAP's
multi-start sweep (`impmap.rs`), and the outer optimizer's mixture branch
(`outer_optimizer.rs`).

Pure measurement — no optimizer behaviour, convergence criterion, or fallback
policy changes; only a counter is added alongside the existing control flow.

## Alternatives considered

Changing each of the three core loop functions' return type from `bool` to a
tuple `(bool, usize)` would have required touching every early `return`
statement in code the repo's own testing guidance calls easy to get subtly
wrong (BFGS/NM convergence and fallback logic). Threading a `&mut u64`
accumulator instead only touches each function's signature and the single
loop-opening line, minimizing the diff's blast radius on that logic.

## Cross-repo dependency

| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes

- [x] Public Rust API (`api/`, `types.rs`) — regenerated `api/ferx-core-public-api.txt`
      via `tools/update-public-api.sh`. Two additive fields
      (`EbeResult::n_iters`, `InnerLoopStats::total_inner_iters`); both are plain
      data already reachable in spirit through `find_ebe`'s existing return
      value, just not previously counted.

## Numerical validation

- [x] Not applicable — pure instrumentation, no change to any objective,
      gradient, or convergence criterion. `cargo test --lib estimation::inner_optimizer`
      (86 tests) is unchanged in outcome from before this PR, only in count
      (+2 new tests below).

## Performance

- [x] No significant impact expected — one `u64` increment per existing loop
      iteration.

## Tests

- [x] Unit test(s) added in module (`cargo test --lib` passes)
- [x] Regression test added (fails without the fix):
  - `find_ebe_n_iters_tracks_actual_optimizer_work` — a cold-started solve
    must report `n_iters > 0`, and a warm start from the already-converged
    mode must report fewer iterations than the cold search that found it;
    catches `n_iters` being left at 0 or hardcoded to `max_iter`.
  - `argmin_inner_fallback_iters_sum_both_nm_runs_when_polishing` — pins the
    fallback's "polish" branch (which runs Nelder-Mead twice) to the *exact*
    sum of two independently-run, identically-seeded `nelder_mead_minimize`
    calls; catches a mutation that threads a throwaway counter into either
    internal call instead of the caller's `iters`.

## Docs

- [x] `CHANGELOG.md` `[Unreleased]` entry added

## Checklist

- [x] `tools/preflight.sh` green — fmt, check, clippy, public-API baseline
      (ran as targeted groups: `fmt check clippy` and `public-api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Follow-up: BFGS/Nelder-Mead split, multistart undercount fix

The single `u64` total above conflates BFGS/L-BFGS iterations (each a
gradient plus a backtracking line search) with Nelder-Mead iterations
(1-2 bare objective evals against a `max_iter * 5` budget) — summed
blind, a subject that falls back to NM can out-"iterate" a subject
whose main solve did far more real work. That made the counter useless
for actually answering A1's question (where FOCEI's inner-loop cost
goes) ahead of A2.

- `InnerIterCounts { bfgs: u64, nelder_mead: u64 }` replaces the plain
  `u64` accumulator everywhere it was threaded (`lbfgs_core`,
  `dense_bfgs_core`, `nelder_mead_minimize`, `inner_minimize_with_grad`,
  `argmin_inner_fallback`, `find_ebe`, `find_ebe_iov`). `EbeResult::n_iters`
  stays a single `u64` (`.total()`), so `InnerLoopStats::total_inner_iters`
  is unchanged in shape.
- New process-global `PROFILE_INNER_BFGS_ITERS` / `PROFILE_INNER_NM_ITERS`
  atomics, folded unconditionally (not gated behind `FERX_PROFILE`) via
  `record_inner_iters`, so they also see the AGQ / covariance /
  importance-sampling / VI callers that call `find_ebe` directly and
  discard the `EbeResult` — the one gap `InnerLoopStats::total_inner_iters`
  has (documented on its doc comment). `profile_report()` gains an
  `[profile] inner iterations: N BFGS/L-BFGS, N Nelder-Mead (X per solve)`
  line.
- Fixed `find_ebe_multistart`: a winning MCETA start replaced `best`
  wholesale (`best = candidate`), silently discarding every other
  start's `n_iters`. Now accumulates across all `mceta + 1` starts.

New tests: `find_ebe_multistart_n_iters_counts_every_start` (reconstructs
all starts independently and asserts the sum), `inner_iter_counts_keep_bfgs_and_nelder_mead_apart`,
`find_ebe_feeds_the_fit_wide_profile_counters`. Also serializes 5
pre-existing tests around the process-global `EBE_WARM_START` flag with a
`Mutex` guard (`lock_ebe_warm_start`) after this diff's iteration-count
tests made unguarded concurrent flag flips a real (not just theoretical)
source of flaky exact-count assertions.

Validated: `cargo check --lib` (whole crate, all callers of the changed
signatures), `cargo test --lib estimation::inner` (88 passed) and
`cargo test --lib impmap` (32 passed), plus `tools/preflight.sh`'s
`fmt`, `check` (all 5 groups), `clippy` (both groups), `public-api`, and
`rustdoc` groups — all green. No `pub` surface changed (`InnerIterCounts`
is `pub(crate)`), confirmed by the unchanged baseline diff.
