### PR TITLE
docs(ode): correct stale sequential-slot comments on ODE pk_indices

### DIFF
--- a/docs/api/types.qmd
+++ b/docs/api/types.qmd
@@ -23,7 +23,7 @@ pub struct CompiledModel {
     pub eta_names: Vec<String>,
     pub default_params: ModelParameters,
     pub tv_fn: Option<...>,          // Typical values function for analytical PK
-    pub pk_indices: Vec<usize>,      // Maps eta index -> PK parameter index
+    pub pk_indices: Vec<usize>,      // Individual parameter (declaration order) -> PK slot
     pub ode_spec: Option<OdeSpec>,   // ODE specification (if ODE model)
 }
 ```

--- a/docs/model-file/ode-models.qmd
+++ b/docs/model-file/ode-models.qmd
@@ -961,11 +961,10 @@ absorption lag can differ by route. Mirroring NONMEM's `F1`/`F2` and
   fall back to the bare value (or to `F = 1`, `lag = 0`).
 - The index must refer to a compartment the model actually has — `F3` on a
   two-state model is a parse error, not a silently-ignored parameter.
-- Each declared `Fn`/`ALAGn` occupies one of the seven spare slots in the
-  fixed 16-slot PK parameter layout (shared with other ODE structural
-  parameters). Declaring the full set for many compartments can exhaust them;
-  if so, `ode_param_slots` reports a clear "too many individual parameters"
-  error rather than failing silently.
+- Each declared `Fn`/`ALAGn` occupies one free slot in the fixed PK parameter
+  layout (`MAX_PK_PARAMS`, 128 slots), shared with the model's other individual
+  parameters. A model that runs out gets a clear "too many individual
+  parameters" parse error rather than failing silently.
 
 > ⚠️ **`F{n}` / `ALAG{n}` / `LAGTIME{n}` are reserved names** (just like the
 > bare `F` / `lagtime` above, and exactly as in NONMEM). On an ODE model,

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -360,7 +360,7 @@ fn top_level_assigned_vars(stmts: &[Statement]) -> Vec<String> {
 /// downstream block consumes them (issue #357) — promoting *every* such name
 /// would slot throwaway intermediates into the PK array (silently hijacking the
 /// reserved F/lagtime slots, aliasing the CL slot in `pk_indices`, or
-/// exhausting the 16-slot layout). See `parse_full_model`.
+/// exhausting the `MAX_PK_PARAMS`-slot layout). See `parse_full_model`.
 ///
 /// Motivating case: a PK parameter written only inside symmetric `if`/`else`
 /// branches (the natural NONMEM-style `IF (cond) CL = ...` / `IF (!cond) CL =
@@ -1738,7 +1738,7 @@ pub fn parse_full_model_with(
     // Promoting *every* all-branch name (the naive fix) would slot throwaway
     // intermediates into the PK array — silently hijacking the reserved
     // F/lagtime slots, aliasing the CL slot in pk_indices, or exhausting the
-    // 16-slot layout. So a branch-only helper used purely to compute another
+    // MAX_PK_PARAMS-slot layout. So a branch-only helper used purely to compute another
     // param stays branch-local. The ParseCtx still receives the full set (via
     // assigned_vars_in_order) so such helpers parse as Variable, not Covariate.
     let indiv_text = indiv_lines.join("\n");
@@ -15728,8 +15728,10 @@ fn build_ruv_magnitude(
 /// expressions, or full `if (...) { ... } else { ... }` statements.
 ///
 /// `var_names` is the deduplicated list of all variables ever assigned in the
-/// block (in first-occurrence order). For analytical PK models the assignment
-/// order doubles as the slot ordering for `PkParams.values`.
+/// block (in first-occurrence order); that order is the evaluator's var-slot
+/// order only. The `PkParams.values` slot comes from `pk_param_map` and its
+/// spare-slot extensions (analytical) or from `ode_slot_map` (ODE and
+/// compartment-free), never from this order.
 /// Build the `pk_param_fn` closure used by every fit / simulate / predict
 /// call site. When the `nn` feature is on and the model has any
 /// `[covariate_nn]` blocks, `covariate_nns` carries each mapper plus the

--- a/src/parser/model_parser.rs
+++ b/src/parser/model_parser.rs
@@ -10700,12 +10700,13 @@ fn collect_indiv_param_reads(
 /// (#993). Unlike its `EveryDose` siblings these are inert until a dose codes
 /// `RATE=-2`/`-1`, so nothing is rejected here — see [`DoseAttrConsumption`].
 ///
-/// `slot_map` is parallel to `indiv_var_names` by position but only as a **prefix**:
-/// the `__ferx_pktime_` desugaring appends names after the slot map was built. `get(i)`
-/// is therefore the correct lookup (and matches [`check_dose_attr_double_use`]) — a
-/// real dose attribute is always a user name, hence inside the prefix, while the
-/// synthetic tail is never one. Empty for analytical models, whose indexed
-/// `D{n}`/`R{n}` are recognised by name alone.
+/// `slot_map` is `ode_slot_map`. It is empty for analytical models, whose indexed
+/// `D{n}`/`R{n}` are recognised by name alone, and full-length on the ODE layout:
+/// every name there, readout synthetics included, is already in `indiv_var_names`
+/// when `ode_param_slots` runs, and the `__ferx_pktime_` desugaring that appends names
+/// later only fires for an analytical `pk(...)` mapping. `get(i)` remains the lookup
+/// (and matches [`check_dose_attr_double_use`]); a real dose attribute is always a
+/// user name, never a synthetic one.
 fn record_coded_rate_reads(
     model: &mut CompiledModel,
     indiv_var_names: &[String],
@@ -11986,8 +11987,9 @@ fn build_ode_spec(
         });
 
     // Build the init_fn closure from the extracted `init(state) = expr`
-    // directives. It mirrors the RHS variable binding: individual parameters
-    // by declaration order (PkParams.values slots), plus state names bound to
+    // directives. It mirrors the RHS variable binding: each individual parameter
+    // read from its `indiv_param_slots` slot in `PkParams.values` (name-based, not
+    // declaration position), plus state names bound to
     // 0.0 (no drug present at init time). Returns the full n_states vector so
     // the caller can both seed the integrator and re-seed after a reset.
     let init_fn: Option<Box<dyn Fn(&[f64]) -> Vec<f64> + Send + Sync>> = if init_specs.is_empty() {

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -10250,6 +10250,14 @@ fn test_lagtime_in_ode_model_routes_to_canonical_slot() {
     // A bare LAGTIME is a canonical name, so `ode_param_slots` routes it to
     // PK_IDX_LAGTIME and `pk_indices` carries the slot on the ODE layout too.
     assert!(
+        parsed
+            .model
+            .pk_indices
+            .contains(&crate::types::PK_IDX_LAGTIME),
+        "pk_indices must carry PK_IDX_LAGTIME on the ODE layout: {:?}",
+        parsed.model.pk_indices
+    );
+    assert!(
         parsed.model.has_lagtime(),
         "has_lagtime() must return true for an ODE model declaring LAGTIME"
     );
@@ -10451,6 +10459,73 @@ fn turnover_ode_model(init_lines: &str) -> String {
 }
 
 #[test]
+fn test_ode_pk_indices_are_name_slotted_not_positional() {
+    // Pins the contract documented on `CompiledModel::indiv_param_names`: on the
+    // ODE layout `pk_indices` is `ode_param_slots`' name→slot map, so canonical
+    // names declared out of PK-slot order (V, KA, LAGTIME) and a non-canonical
+    // one (KE) are read through `pk_indices`, never slot `i`. Every value is
+    // distinct and no name sits at its own position, so a positional read
+    // cannot pass by coincidence (#1355).
+    let model_str = "
+[parameters]
+  theta TVV(20.0, 0.1, 1000.0)
+  theta TVKA(1.5)
+  theta TVKE(0.2)
+  theta TVLAG(0.7)
+  omega ETA_V ~ 0.1
+  sigma EPS ~ 0.01
+
+[individual_parameters]
+  V       = TVV * exp(ETA_V)
+  KA      = TVKA
+  KE      = TVKE
+  LAGTIME = TVLAG
+
+[structural_model]
+  ode(obs_cmt=central, states=[depot, central])
+
+[odes]
+  d/dt(depot)   = -KA * depot
+  d/dt(central) = KA * depot - KE * central
+
+[error_model]
+  DV ~ proportional(EPS)
+";
+    let parsed = super::parse_full_model(model_str).unwrap();
+    let m = &parsed.model;
+    assert_eq!(m.indiv_param_names, vec!["V", "KA", "KE", "LAGTIME"]);
+    assert_eq!(
+        m.pk_indices,
+        vec![
+            crate::types::PK_IDX_V,
+            crate::types::PK_IDX_KA,
+            0,
+            crate::types::PK_IDX_LAGTIME
+        ],
+        "V/KA/LAGTIME take their canonical slots; KE takes the lowest free slot"
+    );
+    let eta = vec![0.0; m.n_eta];
+    let pk = (m.pk_param_fn)(
+        &m.default_params.theta,
+        &eta,
+        &std::collections::HashMap::new(),
+        0.0,
+    );
+    let expected = [20.0, 1.5, 0.2, 0.7];
+    for (i, &want) in expected.iter().enumerate() {
+        let name = &m.indiv_param_names[i];
+        assert_eq!(
+            pk.values[m.pk_indices[i]], want,
+            "{name} read through pk_indices"
+        );
+        assert_ne!(
+            pk.values[i], want,
+            "{name} must not be readable at its positional slot {i}"
+        );
+    }
+}
+
+#[test]
 fn test_init_directive_builds_init_fn() {
     let src = turnover_ode_model("  init(response) = KIN / KOUT");
     let parsed = parse_full_model(&src).unwrap();
@@ -10458,8 +10533,8 @@ fn test_init_directive_builds_init_fn() {
     assert!(ode.init_fn.is_some(), "init_fn should be populated");
 
     // Evaluate at typical values (eta = 0): KIN = 10, KOUT = 2 → 5.0.
-    // For an ODE model, individual params occupy PkParams slots in
-    // declaration order: KIN @ 0, KOUT @ 1.
+    // For an ODE model `ode_param_slots` gives non-canonical names the lowest
+    // free slots, so here KIN @ 0, KOUT @ 1.
     let mut params = [0.0; crate::types::MAX_PK_PARAMS];
     params[0] = 10.0;
     params[1] = 2.0;

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -10248,8 +10248,8 @@ fn test_lagtime_in_ode_model_routes_to_canonical_slot() {
   DV ~ proportional(EPS)
 ";
     let parsed = super::parse_full_model(model_str).unwrap();
-    // ODE models must report has_lagtime() via the indiv_param_names
-    // fallback even when pk_indices doesn't contain PK_IDX_LAGTIME.
+    // A bare LAGTIME is a canonical name, so `ode_param_slots` routes it to
+    // PK_IDX_LAGTIME and `pk_indices` carries the slot on the ODE layout too.
     assert!(
         parsed.model.has_lagtime(),
         "has_lagtime() must return true for an ODE model declaring LAGTIME"

--- a/src/parser/model_parser_tests.rs
+++ b/src/parser/model_parser_tests.rs
@@ -10217,14 +10217,13 @@ fn test_unknown_key_precedes_missing_required() {
 
 #[test]
 fn test_lagtime_in_ode_model_routes_to_canonical_slot() {
-    // Regression for the ODE-with-lagtime path. For ODE models there is
-    // no [structural_model] pk= line, so pk_param_map is empty and
-    // pk_param_fn's ODE branch writes individual parameters by
-    // declaration order. LAGTIME (and ALAG) must also land at the
-    // canonical PK_IDX_LAGTIME slot so `ode_predictions` (which reads
-    // `pk_params_flat[PK_IDX_LAGTIME]`) sees it. `has_lagtime()` must
-    // likewise return true via the indiv_param_names fallback so the
-    // SS/negative-lagtime warning gating fires for ODE users.
+    // Regression for the ODE-with-lagtime path. ODE models have no
+    // [structural_model] pk= line, so pk_param_map is empty and `pk_indices`
+    // is `ode_param_slots`' name→slot map. LAGTIME (and ALAG) is a canonical
+    // name, so it lands at PK_IDX_LAGTIME, where `ode_predictions` (which
+    // reads `pk_params_flat[PK_IDX_LAGTIME]`) sees it, and `has_lagtime()`
+    // must return true so the SS/negative-lagtime warning gating fires for
+    // ODE users.
     let model_str = "
 [parameters]
   theta TVCL(1.0, 0.001, 100.0)
@@ -12875,14 +12874,14 @@ fn test_parse_scaling_y_form_c_on_ode() {
         ),
     };
 
-    // ODE writes indiv params sequentially into pk_params_flat[0..n] in
-    // declaration order: [CL, V, KA] -> pk[0..3]. State order: [depot,
-    // central] -> state[0..2]. So y = central / V = state[1] / pk[1].
+    // ODE params are slotted by name (`ode_param_slots`): [CL, V, KA] ->
+    // pk[0], pk[1], pk[4]. State order: [depot, central] -> state[0..2].
+    // So y = central / V = state[1] / pk[1].
     let state = vec![0.0, 100.0]; // depot=0, central=100
     let mut pk = vec![0.0f64; crate::types::MAX_PK_PARAMS];
     pk[0] = 1.0; // CL
     pk[1] = 50.0; // V
-    pk[2] = 1.0; // KA
+    pk[4] = 1.0; // KA
     let cov = HashMap::new();
     let y = out_fn(&state, &pk, &[], &[], &cov);
     assert!((y - 2.0).abs() < 1e-12, "expected 100/50 = 2, got {}", y);

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -367,10 +367,13 @@ fn run_nca(model: &CompiledModel, population: &Population) -> (PopNca, Vec<Strin
         return (empty_pop_nca(), warnings);
     }
 
-    // ODE models: pk_indices are sequential (slot i = position i), not semantic.
-    // NCA can't reliably map estimates to the user's parameter names (which could
-    // be KE, EMAX, or anything else — not necessarily CL/V).  Fall back to model
-    // defaults and let the nca_sweep method sweep them via rRMSE.
+    // ODE models: `pk_indices` does route a canonical name (CL, V, KA, …) to its PK
+    // slot (`ode_param_slots`), but that is a naming convention, not a structural
+    // guarantee — the `[odes]` RHS decides what a parameter means, so an ODE `CL`
+    // need not be the clearance NCA estimates, every other name (KE, EMAX, …) sits
+    // in a free slot with no PK meaning, and `pk_model` is only a placeholder.
+    // NCA can't reliably map its estimates onto the user's parameters, so fall
+    // back to model defaults and let the nca_sweep method sweep them via rRMSE.
     if model.ode_spec.is_some() {
         warnings.push(
             "inits_from_nca: ODE model detected; NCA estimation skipped (parameter names are user-defined). Use the nca_sweep method for rRMSE-based sweep.".into(),

--- a/src/suggest_start/mod.rs
+++ b/src/suggest_start/mod.rs
@@ -370,10 +370,13 @@ fn run_nca(model: &CompiledModel, population: &Population) -> (PopNca, Vec<Strin
     // ODE models: `pk_indices` does route a canonical name (CL, V, KA, …) to its PK
     // slot (`ode_param_slots`), but that is a naming convention, not a structural
     // guarantee — the `[odes]` RHS decides what a parameter means, so an ODE `CL`
-    // need not be the clearance NCA estimates, every other name (KE, EMAX, …) sits
-    // in a free slot with no PK meaning, and `pk_model` is only a placeholder.
-    // NCA can't reliably map its estimates onto the user's parameters, so fall
-    // back to model defaults and let the nca_sweep method sweep them via rRMSE.
+    // need not be the clearance NCA estimates. Every other name (KE, EMAX, …) takes
+    // the lowest free slot, often a canonical index the model left unused (declare
+    // `V, KA, KE` and KE lands in slot 0 = `PK_IDX_CL`), so a slot lookup such as
+    // `find_theta_for_slot` would take it for that PK parameter; and `pk_model` is
+    // only a placeholder. NCA can't reliably map its estimates onto the user's
+    // parameters, so fall back to model defaults and let the nca_sweep method
+    // sweep them via rRMSE.
     if model.ode_spec.is_some() {
         warnings.push(
             "inits_from_nca: ODE model detected; NCA estimation skipped (parameter names are user-defined). Use the nca_sweep method for rRMSE-based sweep.".into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -367,11 +367,13 @@ impl DoseEvent {
 ///   7: V3      (peripheral volume 2, 3-cmt only)
 ///   8: LAGTIME (dose/absorption lagtime, default 0.0; equivalent to NONMEM ALAG)
 ///
-/// Slots 0–8 are the named PK parameters above. Slots 9.. are spare capacity
-/// for ODE models, whose `[individual_parameters]` may declare additional
-/// "structural" parameters (rate constants, Emax/EC50, baselines, …) beyond the
-/// named PK slots. `ode_param_slots` routes canonical names to slots 0–8 and
-/// structural names to the remaining free slots, while keeping slots
+/// Slots 0–8 are the named PK parameters above. Slots 9–12 hold the analytic
+/// transit / inverse-Gaussian parameters (`PK_IDX_N`, `PK_IDX_MTT`,
+/// `PK_IDX_MAT`, `PK_IDX_CV2`); for an ODE model they, like every higher slot,
+/// are spare capacity for additional "structural" parameters (rate constants,
+/// Emax/EC50, baselines, …). `ode_param_slots` routes any name
+/// `PkParams::name_to_index` recognises to its fixed slot and structural names
+/// to the lowest remaining free slots, while keeping slots
 /// `PK_IDX_F` and `PK_IDX_LAGTIME` reserved so an undeclared F/lagtime keeps its
 /// default rather than being aliased by a structural parameter (issue #122).
 /// The headroom here therefore bounds how many structural parameters an ODE
@@ -3663,12 +3665,17 @@ pub struct CompiledModel {
     pub eta_names: Vec<String>,
     /// IOV kappa names (length == n_kappa). Empty when no IOV.
     pub kappa_names: Vec<String>,
-    /// Names of the individual parameters declared at the top level of the
-    /// `[individual_parameters]` block, in declaration order (followed by the
-    /// parser-synthesized `__ferx_ro_*` / `__ferx_pktime_*` parameters).
+    /// Names of the individual parameters assigned in `[individual_parameters]`,
+    /// in first-assignment order: every top-level assignment, plus a name
+    /// assigned on every branch of an `if`/`else` when `[odes]`,
+    /// `[structural_model]`, `[scaling]` or `[derived]` reads it (#357). The
+    /// parser-synthesized `__ferx_ro_*` / `__ferx_pktime_*` parameters follow.
     /// Parallel to `pk_indices` on both engines: read the i-th name's value from
-    /// `PkParams.values[pk_indices[i]]`, never from slot `i`. Used by the FFI to
-    /// label per-subject EBE individual parameter values (e.g. `CL`, `V`, `Ka`).
+    /// `PkParams.values[pk_indices[i]]`, never from slot `i`. On an analytical
+    /// model that read is valid only for the names described below: a
+    /// placeholder entry cannot yet be told apart from a genuine `CL` entry
+    /// (#1356). Used by the FFI to label per-subject EBE individual parameter
+    /// values (e.g. `CL`, `V`, `Ka`).
     ///
     /// Where `pk_indices[i]` comes from differs by engine:
     /// - **ODE and compartment-free models** route every name through
@@ -3681,7 +3688,8 @@ pub struct CompiledModel {
     ///   name is bound on the `[structural_model]` line (its canonical PK slot)
     ///   or referenced by a readout (#650, a spare slot). Every other name gets
     ///   a placeholder `0`, which aliases the `CL` slot rather than holding that
-    ///   name's value (#1356). Most such names (e.g. an intermediate `TVCL`) are
+    ///   name's value; a name that differs from a bound name only in case (`v`
+    ///   next to `V`) instead gets that bound name's slot (#1356). Most such names (e.g. an intermediate `TVCL`) are
     ///   never written to `PkParams`; a modeled-dose `D{n}`/`R{n}` is written,
     ///   to a spare slot above `PK_IDX_LAGTIME`, but still cannot be read back
     ///   through `pk_indices`.
@@ -3765,6 +3773,12 @@ pub struct CompiledModel {
     /// value to the correct PK slot. Note: the index here is the
     /// assignment/tv index, *not* the eta index — see `eta_map` for the
     /// latter (they diverge when some params are eta-free).
+    ///
+    /// Also parallel to `indiv_param_names`; see that field for how each
+    /// engine assigns the slot. On an analytical model a name that is neither
+    /// bound on the `[structural_model]` line nor referenced by a readout gets a
+    /// placeholder `0`, which aliases `PK_IDX_CL`, or the slot of a bound name
+    /// it matches case-insensitively (#1356).
     pub pk_indices: Vec<usize>,
     /// Per-tv eta index: `eta_map[i]` is the eta index referenced by the
     /// i-th `[individual_parameters]` assignment, or -1 if the assignment
@@ -4471,7 +4485,12 @@ impl CompiledModel {
     ///      routed to the lag slot: on the analytical engine by a `lagtime=` /
     ///      `alag=` binding on the `[structural_model]` line, on the ODE (and
     ///      compartment-free) layout by `ode_param_slots` sending a bare
-    ///      `LAGTIME`/`ALAG` name to its canonical slot.
+    ///      `LAGTIME`/`ALAG` name to its canonical slot. Two analytical
+    ///      exceptions write the lag slot without `pk_indices` recording it: a
+    ///      variable bound to two roles (e.g. `f=X, lagtime=X`) records only one
+    ///      of them, chosen by `HashMap` iteration order (#1359); and a
+    ///      `lagtime=` binding to a name assigned only inside an `if` without
+    ///      `else` is not in `indiv_param_names` at all.
     ///   2. On the ODE engine, a compartment-indexed `ALAGn`/`LAGTIMEn` (#369)
     ///      is not a canonical PK name, so `ode_param_slots` gives it an ordinary
     ///      structural slot that `pk_indices` cannot identify; it is found by
@@ -4482,7 +4501,8 @@ impl CompiledModel {
     ///      compartment-free layout, and on the analytical engine a false
     ///      positive for a `LAGTIME` declared without a `[structural_model]`
     ///      binding — that value never reaches `PK_IDX_LAGTIME` and no lag is
-    ///      applied; the model is only routed onto the slower lag-aware paths.
+    ///      applied, yet the model is taken off the lag-free fast paths (the
+    ///      explicit sensitivity kernels and the cached event schedule).
     pub fn has_lagtime(&self) -> bool {
         if self.pk_indices.contains(&PK_IDX_LAGTIME) {
             return true;
@@ -4581,7 +4601,8 @@ impl CompiledModel {
     /// either engine). Mirrors [`Self::has_lagtime`]: [`PK_IDX_F`] is in
     /// `pk_indices` when `f=` binds it on the analytical `[structural_model]`
     /// line, or when an ODE / compartment-free model declares a bare `F`
-    /// (`ode_param_slots` routes the canonical name to that slot). The name scan
+    /// (`ode_param_slots` routes the canonical name to that slot); the same two
+    /// analytical exceptions as for the lag slot apply to `f=`. The name scan
     /// below adds a compartment-indexed `Fn`, which routes on the ODE engine
     /// only. It also matches a bare `F` on every engine: redundant on the ODE
     /// layout, and on the analytical engine a false positive for an `F` declared

--- a/src/types.rs
+++ b/src/types.rs
@@ -3664,22 +3664,29 @@ pub struct CompiledModel {
     /// IOV kappa names (length == n_kappa). Empty when no IOV.
     pub kappa_names: Vec<String>,
     /// Names of the individual parameters declared at the top level of the
-    /// `[individual_parameters]` block, in declaration order. Parallel to
-    /// `pk_indices`; for analytical models the i-th name is the variable
-    /// whose value lands in `PkParams.values[pk_indices[i]]`. For ODE
-    /// models the i-th name is written sequentially into slot `i` by
-    /// `pk_param_fn`. Used by the FFI to label per-subject EBE individual
-    /// parameter values (e.g. `CL`, `V`, `Ka`).
+    /// `[individual_parameters]` block, in declaration order (followed by any
+    /// parser-synthesized `__ferx_*` parameters). Parallel to `pk_indices` on
+    /// both engines: read the i-th name's value from
+    /// `PkParams.values[pk_indices[i]]`, never from slot `i`. Used by the FFI to
+    /// label per-subject EBE individual parameter values (e.g. `CL`, `V`, `Ka`).
     ///
-    /// Bound: `pk_param_fn` writes at most `MAX_PK_PARAMS` slots (the size
-    /// of the fixed `PkParams.values` array). For analytical models the
-    /// parser already routes assignments through that fixed slot table, so
-    /// excess names are not possible. For ODE models with more than
-    /// `MAX_PK_PARAMS` top-level `[individual_parameters]` assignments,
-    /// names beyond index `MAX_PK_PARAMS - 1` will appear in this list but
-    /// `pk_param_fn` won't store their values — downstream consumers will
-    /// read either zero or NaN for those slots. In practice no PK model
-    /// approaches this limit.
+    /// Where `pk_indices[i]` comes from differs by engine:
+    /// - **ODE and compartment-free models** route every name through
+    ///   `ode_param_slots`: a canonical PK name (`CL`, `V`, `KA`, `F`,
+    ///   `LAGTIME`, …, per `PkParams::name_to_index`) takes its fixed PK slot,
+    ///   and every other name takes the lowest free slot that is not one of the
+    ///   engine-reserved F/lagtime slots. A model declaring `V, KA, KE` in that
+    ///   order therefore stores them at slots `1, 4, 0`, not `0, 1, 2`.
+    /// - **Analytical models** place a name at its PK slot only when it is bound
+    ///   on the `[structural_model]` line, or allocated a spare slot because a
+    ///   readout references it (#650). Any other top-level name (e.g. an
+    ///   intermediate such as `TVCL`) is never written to `PkParams`; its
+    ///   `pk_indices` entry is a placeholder `0`, which aliases the `CL` slot
+    ///   rather than holding that name's value.
+    ///
+    /// Bound: an ODE or compartment-free model whose names do not all fit the
+    /// `MAX_PK_PARAMS`-slot layout is rejected at parse time by
+    /// `ode_param_slots`, so on that layout every entry has a real slot.
     pub indiv_param_names: Vec<String>,
     /// Symbolic partial derivatives of every top-level `[individual_parameters]`
     /// assignment w.r.t. each θ and η axis, precomputed at parse time. Outer
@@ -4458,11 +4465,17 @@ impl CompiledModel {
     /// aware slow paths.
     ///
     /// Checks both routes by which lagtime can be wired in:
-    ///   1. Analytical PK: `pk_indices` contains `PK_IDX_LAGTIME` when the
-    ///      `[structural_model]` line includes `lagtime=` / `alag=`.
-    ///   2. ODE: the LAGTIME/ALAG slot is populated by name in
-    ///      `build_pk_param_fn`'s ODE branch (sequential pk_indices do not
-    ///      reflect this), so we fall back to scanning `indiv_param_names`.
+    ///   1. `pk_indices` contains `PK_IDX_LAGTIME` whenever a parameter is
+    ///      routed to the lag slot: on the analytical engine by a `lagtime=` /
+    ///      `alag=` binding on the `[structural_model]` line, on the ODE (and
+    ///      compartment-free) layout by `ode_param_slots` sending a bare
+    ///      `LAGTIME`/`ALAG` name to its canonical slot.
+    ///   2. A compartment-indexed `ALAGn`/`LAGTIMEn` (#369) is not a canonical
+    ///      PK name, so it takes an ordinary structural slot that `pk_indices`
+    ///      cannot identify; it is found by scanning `indiv_param_names`. The
+    ///      scan also matches a bare `LAGTIME`/`ALAG`, which on the ODE layout
+    ///      route 1 already covers, and which on the analytical engine catches
+    ///      one declared without a `[structural_model]` binding.
     pub fn has_lagtime(&self) -> bool {
         if self.pk_indices.contains(&PK_IDX_LAGTIME) {
             return true;

--- a/src/types.rs
+++ b/src/types.rs
@@ -3664,9 +3664,9 @@ pub struct CompiledModel {
     /// IOV kappa names (length == n_kappa). Empty when no IOV.
     pub kappa_names: Vec<String>,
     /// Names of the individual parameters declared at the top level of the
-    /// `[individual_parameters]` block, in declaration order (followed by any
-    /// parser-synthesized `__ferx_*` parameters). Parallel to `pk_indices` on
-    /// both engines: read the i-th name's value from
+    /// `[individual_parameters]` block, in declaration order (followed by the
+    /// parser-synthesized `__ferx_ro_*` / `__ferx_pktime_*` parameters).
+    /// Parallel to `pk_indices` on both engines: read the i-th name's value from
     /// `PkParams.values[pk_indices[i]]`, never from slot `i`. Used by the FFI to
     /// label per-subject EBE individual parameter values (e.g. `CL`, `V`, `Ka`).
     ///
@@ -3677,12 +3677,14 @@ pub struct CompiledModel {
     ///   and every other name takes the lowest free slot that is not one of the
     ///   engine-reserved F/lagtime slots. A model declaring `V, KA, KE` in that
     ///   order therefore stores them at slots `1, 4, 0`, not `0, 1, 2`.
-    /// - **Analytical models** place a name at its PK slot only when it is bound
-    ///   on the `[structural_model]` line, or allocated a spare slot because a
-    ///   readout references it (#650). Any other top-level name (e.g. an
-    ///   intermediate such as `TVCL`) is never written to `PkParams`; its
-    ///   `pk_indices` entry is a placeholder `0`, which aliases the `CL` slot
-    ///   rather than holding that name's value.
+    /// - **Analytical models** give `pk_indices[i]` a real slot only when the
+    ///   name is bound on the `[structural_model]` line (its canonical PK slot)
+    ///   or referenced by a readout (#650, a spare slot). Every other name gets
+    ///   a placeholder `0`, which aliases the `CL` slot rather than holding that
+    ///   name's value (#1356). Most such names (e.g. an intermediate `TVCL`) are
+    ///   never written to `PkParams`; a modeled-dose `D{n}`/`R{n}` is written,
+    ///   to a spare slot above `PK_IDX_LAGTIME`, but still cannot be read back
+    ///   through `pk_indices`.
     ///
     /// Bound: an ODE or compartment-free model whose names do not all fit the
     /// `MAX_PK_PARAMS`-slot layout is rejected at parse time by
@@ -4470,22 +4472,27 @@ impl CompiledModel {
     ///      `alag=` binding on the `[structural_model]` line, on the ODE (and
     ///      compartment-free) layout by `ode_param_slots` sending a bare
     ///      `LAGTIME`/`ALAG` name to its canonical slot.
-    ///   2. A compartment-indexed `ALAGn`/`LAGTIMEn` (#369) is not a canonical
-    ///      PK name, so it takes an ordinary structural slot that `pk_indices`
-    ///      cannot identify; it is found by scanning `indiv_param_names`. The
-    ///      scan also matches a bare `LAGTIME`/`ALAG`, which on the ODE layout
-    ///      route 1 already covers, and which on the analytical engine catches
-    ///      one declared without a `[structural_model]` binding.
+    ///   2. On the ODE engine, a compartment-indexed `ALAGn`/`LAGTIMEn` (#369)
+    ///      is not a canonical PK name, so `ode_param_slots` gives it an ordinary
+    ///      structural slot that `pk_indices` cannot identify; it is found by
+    ///      scanning `indiv_param_names`. (On the analytical engine an unbound
+    ///      `ALAGn` is rejected at parse time, and one bound via `lagtime=` /
+    ///      `alag=` is covered by route 1.) The scan also matches a bare `LAGTIME`/`ALAG`
+    ///      on every engine: redundant with route 1 on the ODE and
+    ///      compartment-free layout, and on the analytical engine a false
+    ///      positive for a `LAGTIME` declared without a `[structural_model]`
+    ///      binding — that value never reaches `PK_IDX_LAGTIME` and no lag is
+    ///      applied; the model is only routed onto the slower lag-aware paths.
     pub fn has_lagtime(&self) -> bool {
         if self.pk_indices.contains(&PK_IDX_LAGTIME) {
             return true;
         }
         self.indiv_param_names.iter().any(|n| {
             let u = n.to_uppercase();
-            // Bare `lagtime`/`alag` apply on any engine. A compartment-indexed
-            // `ALAGn`/`LAGTIMEn` (issue #369) only routes lag on the ODE engine
-            // — the analytical path has a single fixed dose route, where such a
-            // name lands in an unused spare slot — so gate it on `ode_spec`.
+            // A compartment-indexed `ALAGn`/`LAGTIMEn` (issue #369) only routes lag
+            // on the ODE engine, so gate it on `ode_spec`. The analytical engine has
+            // a single dose route: an unbound `ALAGn` is rejected at parse time, and
+            // a bound one already put `PK_IDX_LAGTIME` into `pk_indices` above.
             u == "LAGTIME"
                 || u == "ALAG"
                 || (self.ode_spec.is_some()
@@ -4571,11 +4578,14 @@ impl CompiledModel {
     }
 
     /// True when the model wires in a bioavailability `F`/`Fn` parameter (on
-    /// either engine). Mirrors [`Self::has_lagtime`]: the analytical route puts
-    /// [`PK_IDX_F`] in `pk_indices` (from `f=` on the `[structural_model]`
-    /// line), while both engines may instead name it `F` (any case) in
-    /// `[individual_parameters]`; a compartment-indexed `Fn` routes on the ODE
-    /// engine only. Used with [`Subject::has_rate_defined_infusion`] to skip the
+    /// either engine). Mirrors [`Self::has_lagtime`]: [`PK_IDX_F`] is in
+    /// `pk_indices` when `f=` binds it on the analytical `[structural_model]`
+    /// line, or when an ODE / compartment-free model declares a bare `F`
+    /// (`ode_param_slots` routes the canonical name to that slot). The name scan
+    /// below adds a compartment-indexed `Fn`, which routes on the ODE engine
+    /// only. It also matches a bare `F` on every engine: redundant on the ODE
+    /// layout, and on the analytical engine a false positive for an `F` declared
+    /// without an `f=` binding, which is never applied. Used with [`Subject::has_rate_defined_infusion`] to skip the
     /// event-driven [`crate::pk::event_driven::EventSchedule`] cache when `F`
     /// could reshape an infusion window across the inner search (#419).
     pub fn has_bioavailability(&self) -> bool {

--- a/tests/map_estimates_outputs.rs
+++ b/tests/map_estimates_outputs.rs
@@ -45,8 +45,10 @@ fn indiv_param_names_mirrors_warfarin_individual_parameters_block() {
         vec!["CL".to_string(), "V".to_string(), "KA".to_string()],
         "indiv_param_names must match the [individual_parameters] block in source order"
     );
-    // Parallel to pk_indices (used by the FFI to read each value out of
-    // the PkParams slot for analytical models).
+    // Parallel to pk_indices on both engines: a consumer such as the R FFI must
+    // read each value from `PkParams.values[pk_indices[i]]`, never slot `i`
+    // (analytical names not bound on [structural_model] carry a placeholder 0;
+    // see #1356).
     assert_eq!(
         model.indiv_param_names.len(),
         model.pk_indices.len(),


### PR DESCRIPTION
## Why

Since d54bb953 (`fix(ode): apply bioavailability F at dose entry`), an ODE model's `CompiledModel.pk_indices` is `ode_slot_map`, built by `ode_param_slots()` in `src/parser/model_parser.rs`. Canonical names (`CL`, `V`, `KA`, `F`, `LAGTIME`, …) take their fixed PK slot via `PkParams::name_to_index`. Every other name takes the lowest free slot outside `RESERVED_PK_SLOTS` (F / LAGTIME). The same layout later became the compartment-free one (#811). Several comments were written before d54bb953 and still describe the old positional layout ("ODE models write sequentially into slot `i`").

That stale doc matches a real downstream bug. ferx-r's `build_individual_estimates` (`src/rust/src/lib.rs:3040`–`3045` on ferx-r `main` `9d48df0`) reads slot `i` for ODE models. With KA at slot 4 and LAGTIME at slot 8, a column can show an unwritten 0, or another parameter's value: an independent review measured V's column showing KE's value and KA's column showing V's.

## What changed

Comments, docs, one test-fixture line and one new unit test; no production code or public API changed. Each claim below was checked against `model_parser.rs`:

| Site | Was | Now | Evidence |
|---|---|---|---|
| `src/types.rs`, `indiv_param_names` doc | "For ODE models the i-th name is written sequentially into slot `i`" | Always read `PkParams.values[pk_indices[i]]`. ODE/compartment-free slots come from `ode_param_slots` (example: `V, KA, KE` → `1, 4, 0`). Analytical names not bound on `[structural_model]` or readout-referenced get a placeholder `0` (#1356), including a modeled-dose `D{n}`/`R{n}`, which *is* written to a spare slot ≥ 9 but cannot be read back through `pk_indices` | `pk_indices = ode_slot_map.clone()` when `pk_param_map` is empty (`model_parser.rs:2803/2830`); analytical `unwrap_or(0)` at `:2823`; `D{n}`/`R{n}` spare slots at `:2316`–`:2418` |
| same doc, "Bound" paragraph | Names past `MAX_PK_PARAMS - 1` are silently not stored | Rejected at parse time by `ode_param_slots` | `Err("…too many individual parameters…")` at `:10382`. Nothing is added to `indiv_var_names` after `:2082` on this layout |
| `src/types.rs`, `has_lagtime` doc and body comment | "sequential pk_indices do not reflect this"; an analytical `ALAGn` "lands in an unused spare slot" | Route 1 (`pk_indices.contains(&PK_IDX_LAGTIME)`) also covers a bare `LAGTIME`/`ALAG` on the ODE and compartment-free layout. The indexed `ALAGn`/`LAGTIMEn` scan is ODE-only; on the analytical engine an unbound `ALAGn` is rejected at parse time (`:2364`) | `name_to_index("lagtime" \| "alag") = PK_IDX_LAGTIME`; `name_to_index("alag1") = None` |
| `src/suggest_start/mod.rs:370` | "pk_indices are sequential (slot i = position i), not semantic" | NCA is skipped because the RHS defines a parameter's meaning; a non-canonical name often lands in an unused canonical slot (KE → slot 0 = `PK_IDX_CL`); `pk_model` is a placeholder | `:2179` |
| `src/parser/model_parser.rs`, `init_fn` comment and `record_coded_rate_reads` doc | "by declaration order"; `slot_map` parallel "only as a prefix" | Name-based `indiv_param_slots`; `slot_map` is full-length on the ODE layout | `:2228` (pktime needs a non-empty `pk_param_map`) |
| `src/parser/model_parser_tests.rs`, two tests | "writes individual parameters by declaration order"; "[CL, V, KA] -> pk[0..3]", `pk[2] = 1.0; // KA` | `ode_param_slots` layout; `pk[4] = 1.0; // KA` | The assertion reads only `pk[1]` (V), so it is unchanged |
| `tests/map_estimates_outputs.rs`, `docs/api/types.qmd` | "for analytical models"; `pk_indices // Maps eta index -> PK parameter index` (pre-existing, wrong) | Both engines; "Individual parameter (declaration order) -> PK slot" | `types.rs` `pk_indices` doc |
| `src/types.rs`, headline rule and `pk_indices` field doc | Unconditional "read `values[pk_indices[i]]`"; field doc silent on placeholders | An analytical placeholder cannot yet be told apart from a genuine `CL` entry (#1356) | `:2823` |
| `src/types.rs`, `has_bioavailability` doc | Both engines "may instead name it `F`" | A bare ODE `F` is already in `pk_indices`; an analytical `F` without `f=` is never applied, so the scan's match there is a false positive | `ode_param_slots` pass 1; `:2352` (only `f=` binds F analytically) |
| Slot-layout docs: `types.rs` `MAX_PK_PARAMS`, `model_parser.rs:363` and `:1741`, `docs/model-file/ode-models.qmd`, `build_pk_param_fn` doc, `model_parser_tests.rs:10462` | "Slots 9.. are spare"; "16-slot layout" / "seven spare slots"; "assignment order doubles as the slot ordering"; "slots in declaration order" | Slots 9–12 are the transit/IG parameters; the layout is `MAX_PK_PARAMS` (128); PK slots come from `pk_param_map` / `ode_slot_map`, not assignment order | `types.rs:391`, `:405`–`:413` |
| `src/parser/model_parser_tests.rs`, new `test_ode_pk_indices_are_name_slotted_not_positional` | — | ODE `V, KA, KE, LAGTIME` gives `pk_indices == [1, 4, 0, 8]`; each value reads back through `pk_indices`, and no value is at its positional slot | Pins the contract so only prose no longer carries it |

The `has_lagtime` name-scan **logic** is not changed. Its bare-name arm is redundant on the ODE and compartment-free layout. On the analytical engine it still matches a `LAGTIME` declared without a `[structural_model]` binding; that is a false positive (no lag is applied, yet the model is taken off the explicit sensitivity kernels and the cached event schedule), now documented as such. `has_bioavailability` has the same shape and is documented the same way. A variable bound to two roles (`f=X, lagtime=X`) is documented too: `pk_indices` records one role, chosen by `HashMap` order.

### Review round

An independent review checked all 34 factual claims in the first commit (`62a87045`) and found 2 wrong and 6 overstated, plus stale sites the first commit missed. A second review, posted on this PR, raised ten findings (five pre-merge). The first review's findings and the `has_bioavailability` doc are addressed in `ae7677b1`; the rest of the second review's pre-merge findings, its stale-slot-doc and pinning-test nits, and the template gaps are addressed in `16c45ab8`. Its follow-up comment's items 11–13 (an unasserted comment in the lagtime test, the already-fixed `record_coded_rate_reads` doc, all-branch names in the `indiv_param_names` doc) are in `16c45ab8` too, and so are doc caveats for its pre-existing E (an `if`-without-`else` `lagtime=` binding missing from `pk_indices`) and F (a case-variant name taking a bound name's slot). The PR comment maps each finding to its fix. Its pre-existing defects A–C are going to #1356.

## Alternatives considered

Removing the `has_lagtime` / `has_bioavailability` analytical false positive, and making `f=X, lagtime=X` deterministic. Rejected here: both are logic changes that need their own tests, and they are out of scope for a comment fix; they are #1359. Defect D from the second review (a compartment-free `F{n}`/`ALAG{n}` rejected by the analytical dose-attribute loop) is #1358.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | FeRx-NLME/ferx-r#357 | open. Independent: it fixes ferx-r's ODE positional read (`src/rust/src/lib.rs:3040`–`3045` on `main` `9d48df0`) and needs no ferx-core change. It still hits the analytical placeholder (#1356) | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [x] None (doc and comment text, one unit-test fixture line and one new unit test; the `Public API baseline` job passed on `62a87045`)

## Numerical validation
- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [ ] Reference values (paste key theta/omega/OFV, or link to output file):
- [x] Not applicable (docs / refactor / CI only)

## Performance
- [x] No significant impact expected

## Tests
- [x] Unit test(s) added in the same module: `test_ode_pk_indices_are_name_slotted_not_positional`
- [ ] Regression test added that fails without this fix
- [ ] No new tests needed
- Run locally (`cargo test --lib --no-default-features --features ci`): `test_ode_pk_indices_are_name_slotted_not_positional`, `test_lagtime_in_ode_model_routes_to_canonical_slot`, `test_parse_scaling_y_form_c_on_ode` and `test_init_directive_builds_init_fn`: 4 passed on `16c45ab8`

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs
- [x] `docs/` updated: `docs/api/types.qmd` (wrong one-line `pk_indices` description) and `docs/model-file/ode-models.qmd` (stale 16-slot layout)
- [ ] New pages linked in `docs/_quarto.yml`
- [x] `CHANGELOG.md` `[Unreleased]` entry: N/A. Internal doc comments, no user-facing behaviour change
- [ ] No user-visible change

## Checklist
- [ ] `tools/preflight.sh` green. Run locally on `16c45ab8`: `fmt`, `clippy` (`--all-targets`, `ci,markov,nn`, plus the member crates) and `docs` (docs-lint) all OK. The `check`, `rustdoc` and public-API groups were not run locally; CI runs them
- [x] Functions on the `Dual2` sensitivity path stay differentiable (untouched)
- [ ] `Cargo.toml` version bumped if breaking

## Docs & examples

### ferx-site
- [ ] New `.ferx` DSL syntax or `[fit_options]` key → `ferx-site/model-dsl/` page updated or PR opened
- [ ] New example `.ferx` file added to `examples/` → matching entry in ferx-site examples and ferx-book
- [ ] New data file added to `data/` → mirrored to `ferx-r/inst/examples/data/` and referenced in site/book
- [x] None of the above: no DSL, example or data change

### ferx-book
- [ ] New estimator, DSL feature, or fit option → relevant book chapter updated or PR opened
- [x] Not applicable

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -p ferx-cli -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

Most worth a second look: the analytical half of the new `indiv_param_names` doc. A name that is neither bound on `[structural_model]` nor readout-referenced gets `pk_indices[i] == 0` (`model_parser.rs:2823`). For an intermediate like `TVCL` the value is never written; for a modeled-dose `D{n}`/`R{n}` it is written to a spare slot that `pk_indices` does not record. Either way, reading through `pk_indices` returns CL's value. That was true before this PR; the doc now says so, and #1356 tracks the fix.

## Open questions

How to fix the placeholder (look values up by name, a sentinel, or refuse): see the options in #1356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
