### PR TITLE
perf(estimation): reuse inner optimizer scratch buffers

### DIFF
--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -2800,6 +2800,7 @@ fn lbfgs_core(
     let mut rho_hist: Vec<f64> = Vec::new();
     let mut g = grad(x);
     let mut f_cur = obj(x);
+    let mut line_search_point = vec![0.0; n];
     // Objective-stall convergence (see [`objective_stalled`] / [`INNER_FTOL_REL`]): for ODE
     // objectives whose gradient norm is floored above `tol` by solver noise, a search that
     // reached the mode declares convergence rather than spinning to `max_iter`. Gated on
@@ -2835,7 +2836,8 @@ fn lbfgs_core(
             };
         }
 
-        let (alpha, f_new) = backtracking_line_search(obj, x, &d, &g, n, f_cur);
+        let (alpha, f_new) =
+            backtracking_line_search(obj, x, &d, &g, f_cur, &mut line_search_point);
         // No sufficient-decrease step found: report non-convergence so the caller takes the
         // argmin Nelder–Mead fallback rather than accepting a non-stationary η̂.
         if alpha == 0.0 {
@@ -2895,6 +2897,15 @@ fn dense_bfgs_core(
 ) -> bool {
     let mut h_inv = init_h_inv(n, precond);
     let mut g = grad(x);
+    let mut g_vec = DVector::zeros(n);
+    let mut d_vec = DVector::zeros(n);
+    let mut d = vec![0.0; n];
+    let mut s = vec![0.0; n];
+    let mut y = vec![0.0; n];
+    let mut s_vec = DVector::zeros(n);
+    let mut y_vec = DVector::zeros(n);
+    let eye = DMatrix::identity(n, n);
+    let mut line_search_point = vec![0.0; n];
     // Track the objective at the current iterate so the line search never has to
     // recompute `obj(x)` (one prediction walk per inner step on the hot path).
     let mut f_cur = obj(x);
@@ -2929,9 +2940,9 @@ fn dense_bfgs_core(
             return true;
         }
 
-        let g_vec = DVector::from_column_slice(&g);
-        let d_vec = -&h_inv * &g_vec;
-        let d: Vec<f64> = d_vec.iter().copied().collect();
+        g_vec.as_mut_slice().copy_from_slice(&g);
+        d_vec.gemv(-1.0, &h_inv, &g_vec, 0.0);
+        d.copy_from_slice(d_vec.as_slice());
 
         let dg: f64 = d.iter().zip(g.iter()).map(|(di, gi)| di * gi).sum();
         if dg >= 0.0 {
@@ -2939,8 +2950,10 @@ fn dense_bfgs_core(
             // identity — for FREM the preconditioner is what keeps the descent
             // direction commensurate across the multi-scale dimensions.
             h_inv = init_h_inv(n, precond);
-            let d: Vec<f64> = (-&h_inv * &g_vec).iter().copied().collect();
-            let (alpha, f_new) = backtracking_line_search(obj, x, &d, &g, n, f_cur);
+            d_vec.gemv(-1.0, &h_inv, &g_vec, 0.0);
+            d.copy_from_slice(d_vec.as_slice());
+            let (alpha, f_new) =
+                backtracking_line_search(obj, x, &d, &g, f_cur, &mut line_search_point);
             // Even steepest descent found no sufficient-decrease step: report
             // non-convergence so the caller takes the argmin Nelder–Mead fallback.
             if alpha == 0.0 {
@@ -2959,15 +2972,16 @@ fn dense_bfgs_core(
             continue;
         }
 
-        let (alpha, f_new) = backtracking_line_search(obj, x, &d, &g, n, f_cur);
+        let (alpha, f_new) =
+            backtracking_line_search(obj, x, &d, &g, f_cur, &mut line_search_point);
         // No sufficient-decrease step found: report non-convergence so the caller takes the
         // argmin Nelder–Mead fallback rather than accepting a non-stationary η̂.
         if alpha == 0.0 {
             return false;
         }
 
-        let s: Vec<f64> = (0..n).map(|i| alpha * d[i]).collect();
         for i in 0..n {
+            s[i] = alpha * d[i];
             x[i] += s[i];
         }
         let obj_flat = objective_stalled(f_cur, f_new, &mut stall);
@@ -2978,14 +2992,15 @@ fn dense_bfgs_core(
         }
 
         let g_new = grad(x);
-        let y: Vec<f64> = (0..n).map(|i| g_new[i] - g[i]).collect();
+        for i in 0..n {
+            y[i] = g_new[i] - g[i];
+        }
 
-        let s_vec = DVector::from_column_slice(&s);
-        let y_vec = DVector::from_column_slice(&y);
+        s_vec.as_mut_slice().copy_from_slice(&s);
+        y_vec.as_mut_slice().copy_from_slice(&y);
         let sy = s_vec.dot(&y_vec);
         if sy > 1e-12 {
             let rho = 1.0 / sy;
-            let eye = DMatrix::identity(n, n);
             let s_yt = rho * &s_vec * y_vec.transpose();
             let y_st = rho * &y_vec * s_vec.transpose();
             let s_st = rho * &s_vec * s_vec.transpose();
@@ -3025,9 +3040,17 @@ fn nelder_mead_minimize(
     }
 
     let mut fvals: Vec<f64> = simplex.iter().map(|p| obj(p)).collect();
+    let mut indices: Vec<usize> = (0..=n).collect();
+    let mut centroid = vec![0.0; n];
+    let mut reflected = vec![0.0; n];
+    let mut expanded = vec![0.0; n];
+    let mut contracted = vec![0.0; n];
+    let mut best_point = vec![0.0; n];
 
     for _iter in 0..max_iter {
-        let mut indices: Vec<usize> = (0..=n).collect();
+        for (i, index) in indices.iter_mut().enumerate() {
+            *index = i;
+        }
         // NaN-safe: a non-finite objective (e.g. an ODE prediction that blew
         // up at a simplex vertex) sorts as worst rather than panicking on the
         // `None` that `partial_cmp` returns for NaN. See issue #97.
@@ -3047,7 +3070,7 @@ fn nelder_mead_minimize(
             return true;
         }
 
-        let mut centroid = vec![0.0; n];
+        centroid.fill(0.0);
         for &idx in &indices[..n] {
             for j in 0..n {
                 centroid[j] += simplex[idx][j];
@@ -3058,43 +3081,43 @@ fn nelder_mead_minimize(
         }
 
         // Reflection
-        let reflected: Vec<f64> = (0..n)
-            .map(|j| centroid[j] + alpha * (centroid[j] - simplex[worst][j]))
-            .collect();
+        for j in 0..n {
+            reflected[j] = centroid[j] + alpha * (centroid[j] - simplex[worst][j]);
+        }
         let fr = obj(&reflected);
 
         if fr < fvals[second_worst] && fr >= fvals[best] {
-            simplex[worst] = reflected;
+            std::mem::swap(&mut simplex[worst], &mut reflected);
             fvals[worst] = fr;
             continue;
         }
 
         if fr < fvals[best] {
-            let expanded: Vec<f64> = (0..n)
-                .map(|j| centroid[j] + gamma * (reflected[j] - centroid[j]))
-                .collect();
+            for j in 0..n {
+                expanded[j] = centroid[j] + gamma * (reflected[j] - centroid[j]);
+            }
             let fe = obj(&expanded);
             if fe < fr {
-                simplex[worst] = expanded;
+                std::mem::swap(&mut simplex[worst], &mut expanded);
                 fvals[worst] = fe;
             } else {
-                simplex[worst] = reflected;
+                std::mem::swap(&mut simplex[worst], &mut reflected);
                 fvals[worst] = fr;
             }
             continue;
         }
 
-        let contracted: Vec<f64> = (0..n)
-            .map(|j| centroid[j] + rho * (simplex[worst][j] - centroid[j]))
-            .collect();
+        for j in 0..n {
+            contracted[j] = centroid[j] + rho * (simplex[worst][j] - centroid[j]);
+        }
         let fc = obj(&contracted);
         if fc < fvals[worst] {
-            simplex[worst] = contracted;
+            std::mem::swap(&mut simplex[worst], &mut contracted);
             fvals[worst] = fc;
             continue;
         }
 
-        let best_point = simplex[best].clone();
+        best_point.copy_from_slice(&simplex[best]);
         for i in 0..=n {
             if i != best {
                 for j in 0..n {
@@ -3250,8 +3273,8 @@ fn backtracking_line_search(
     x: &[f64],
     d: &[f64],
     g: &[f64],
-    n: usize,
     f0: f64,
+    x_new: &mut [f64],
 ) -> (f64, f64) {
     let c1 = 1e-4;
     let dg: f64 = d.iter().zip(g.iter()).map(|(di, gi)| di * gi).sum();
@@ -3265,9 +3288,8 @@ fn backtracking_line_search(
     }
 
     let mut alpha = 1.0;
-    let mut x_new = vec![0.0; n];
     for _ in 0..MAX_LINE_SEARCH_TRIALS {
-        for i in 0..n {
+        for i in 0..x.len() {
             x_new[i] = x[i] + alpha * d[i];
         }
         let f_new = obj(&x_new);

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1,5 +1,43 @@
+#![allow(unexpected_cfgs)]
+
 use super::*;
 use std::collections::HashMap;
+#[cfg(profiling_allocations)]
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+#[cfg(profiling_allocations)]
+struct CountingAllocator;
+
+#[cfg(profiling_allocations)]
+static ALLOCATION_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(profiling_allocations)]
+static ALLOCATED_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(profiling_allocations)]
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCATION_CALLS.fetch_add(1, Ordering::Relaxed);
+        ALLOCATED_BYTES.fetch_add(new_size, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+#[cfg(profiling_allocations)]
+static TEST_ALLOCATOR: CountingAllocator = CountingAllocator;
 
 /// An endpoint-only mixed-effects CTMM (#759): no `[structural_model]`, so no Gaussian
 /// data term and no PK provider — the inner objective is `½(η'Ω⁻¹η + log|Ω|) + D_ctmm(η)`.
@@ -853,6 +891,334 @@ fn inner_solver_scaling_bench() {
     }
 }
 
+/// Pre-scratch-reuse dense BFGS, retained only as a bitwise regression oracle.
+fn legacy_dense_bfgs(
+    obj: &dyn Fn(&[f64]) -> f64,
+    grad: &dyn Fn(&[f64]) -> Vec<f64>,
+    x: &mut [f64],
+    n: usize,
+    max_iter: usize,
+    tol: f64,
+) -> bool {
+    let mut h_inv = DMatrix::identity(n, n);
+    let mut g = grad(x);
+    let mut f_cur = obj(x);
+    let mut first_step = true;
+
+    for _ in 0..max_iter {
+        let gnorm = grad_norm_metric(&g, None);
+        if first_step && gnorm > 1.0 {
+            h_inv *= 1.0 / gnorm;
+            first_step = false;
+        }
+        if gnorm < tol {
+            return true;
+        }
+
+        let g_vec = DVector::from_column_slice(&g);
+        let d_vec = -&h_inv * &g_vec;
+        let d: Vec<f64> = d_vec.iter().copied().collect();
+        if d.iter().zip(&g).map(|(di, gi)| di * gi).sum::<f64>() >= 0.0 {
+            h_inv = DMatrix::identity(n, n);
+            let d: Vec<f64> = (-&h_inv * &g_vec).iter().copied().collect();
+            let (alpha, f_new) = legacy_line_search(obj, x, &d, &g, n, f_cur);
+            if alpha == 0.0 {
+                return false;
+            }
+            for i in 0..n {
+                x[i] += alpha * d[i];
+            }
+            f_cur = f_new;
+            g = grad(x);
+            continue;
+        }
+
+        let (alpha, f_new) = legacy_line_search(obj, x, &d, &g, n, f_cur);
+        if alpha == 0.0 {
+            return false;
+        }
+        let s: Vec<f64> = (0..n).map(|i| alpha * d[i]).collect();
+        for i in 0..n {
+            x[i] += s[i];
+        }
+        f_cur = f_new;
+
+        let g_new = grad(x);
+        let y: Vec<f64> = (0..n).map(|i| g_new[i] - g[i]).collect();
+        let s_vec = DVector::from_column_slice(&s);
+        let y_vec = DVector::from_column_slice(&y);
+        let sy = s_vec.dot(&y_vec);
+        if sy > 1e-12 {
+            let rho = 1.0 / sy;
+            let eye = DMatrix::identity(n, n);
+            let s_yt = rho * &s_vec * y_vec.transpose();
+            let y_st = rho * &y_vec * s_vec.transpose();
+            let s_st = rho * &s_vec * s_vec.transpose();
+            h_inv = (&eye - &s_yt) * &h_inv * (&eye - &y_st) + s_st;
+        }
+        g = g_new;
+    }
+    false
+}
+
+fn legacy_line_search(
+    obj: &dyn Fn(&[f64]) -> f64,
+    x: &[f64],
+    d: &[f64],
+    g: &[f64],
+    n: usize,
+    f0: f64,
+) -> (f64, f64) {
+    let c1 = 1e-4;
+    let dg: f64 = d.iter().zip(g.iter()).map(|(di, gi)| di * gi).sum();
+    if !(dg < 0.0) || !dg.is_finite() {
+        return (0.0, f0);
+    }
+    let mut alpha = 1.0;
+    let mut x_new = vec![0.0; n];
+    for _ in 0..MAX_LINE_SEARCH_TRIALS {
+        for i in 0..n {
+            x_new[i] = x[i] + alpha * d[i];
+        }
+        let f_new = obj(&x_new);
+        if f_new.is_finite() && f_new <= f0 + c1 * alpha * dg {
+            return (alpha, f_new);
+        }
+        let denom = 2.0 * (f_new - f0 - dg * alpha);
+        let alpha_quad = if f_new.is_finite() && denom > 0.0 {
+            -dg * alpha * alpha / denom
+        } else {
+            0.5 * alpha
+        };
+        alpha = alpha_quad.clamp(0.1 * alpha, 0.5 * alpha);
+        if alpha < 1e-16 {
+            break;
+        }
+    }
+    (0.0, f0)
+}
+
+fn legacy_nelder_mead(
+    obj: &dyn Fn(&[f64]) -> f64,
+    x: &mut [f64],
+    n: usize,
+    max_iter: usize,
+    tol: f64,
+) -> bool {
+    let mut simplex = Vec::with_capacity(n + 1);
+    simplex.push(x.to_vec());
+    for i in 0..n {
+        let mut point = x.to_vec();
+        let delta = if point[i].abs() > 1e-8 {
+            0.05 * point[i].abs()
+        } else {
+            0.00025
+        };
+        point[i] += delta;
+        simplex.push(point);
+    }
+    let mut fvals: Vec<f64> = simplex.iter().map(|p| obj(p)).collect();
+
+    for _ in 0..max_iter {
+        let mut indices: Vec<usize> = (0..=n).collect();
+        indices.sort_by(|&a, &b| {
+            fvals[a]
+                .partial_cmp(&fvals[b])
+                .unwrap_or(std::cmp::Ordering::Greater)
+        });
+        let best = indices[0];
+        let worst = indices[n];
+        let second_worst = indices[n - 1];
+        if fvals[worst] - fvals[best] < tol {
+            x.copy_from_slice(&simplex[best]);
+            return true;
+        }
+
+        let mut centroid = vec![0.0; n];
+        for &idx in &indices[..n] {
+            for j in 0..n {
+                centroid[j] += simplex[idx][j];
+            }
+        }
+        for value in &mut centroid {
+            *value /= n as f64;
+        }
+
+        let reflected: Vec<f64> = (0..n)
+            .map(|j| centroid[j] + (centroid[j] - simplex[worst][j]))
+            .collect();
+        let fr = obj(&reflected);
+        if fr < fvals[second_worst] && fr >= fvals[best] {
+            simplex[worst] = reflected;
+            fvals[worst] = fr;
+            continue;
+        }
+        if fr < fvals[best] {
+            let expanded: Vec<f64> = (0..n)
+                .map(|j| centroid[j] + 2.0 * (reflected[j] - centroid[j]))
+                .collect();
+            let fe = obj(&expanded);
+            if fe < fr {
+                simplex[worst] = expanded;
+                fvals[worst] = fe;
+            } else {
+                simplex[worst] = reflected;
+                fvals[worst] = fr;
+            }
+            continue;
+        }
+
+        let contracted: Vec<f64> = (0..n)
+            .map(|j| centroid[j] + 0.5 * (simplex[worst][j] - centroid[j]))
+            .collect();
+        let fc = obj(&contracted);
+        if fc < fvals[worst] {
+            simplex[worst] = contracted;
+            fvals[worst] = fc;
+            continue;
+        }
+
+        let best_point = simplex[best].clone();
+        for i in 0..=n {
+            if i != best {
+                for j in 0..n {
+                    simplex[i][j] = best_point[j] + 0.5 * (simplex[i][j] - best_point[j]);
+                }
+                fvals[i] = obj(&simplex[i]);
+            }
+        }
+    }
+    let best = fvals
+        .iter()
+        .enumerate()
+        .min_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Greater))
+        .map(|(i, _)| i)
+        .unwrap();
+    x.copy_from_slice(&simplex[best]);
+    false
+}
+
+fn run_dense_scratch_fixture(n: usize, legacy: bool) -> (bool, Vec<u64>, u64, usize, usize) {
+    let obj_evals = std::cell::Cell::new(0usize);
+    let grad_evals = std::cell::Cell::new(0usize);
+    let obj = |x: &[f64]| {
+        obj_evals.set(obj_evals.get() + 1);
+        x.iter()
+            .enumerate()
+            .map(|(i, &xi)| {
+                let target = (i + 1) as f64 / n as f64;
+                let residual = xi - target;
+                0.5 * (i + 1) as f64 * residual * residual + 0.01 * residual.powi(4)
+            })
+            .sum::<f64>()
+    };
+    let grad = |x: &[f64]| {
+        grad_evals.set(grad_evals.get() + 1);
+        x.iter()
+            .enumerate()
+            .map(|(i, &xi)| {
+                let target = (i + 1) as f64 / n as f64;
+                let residual = xi - target;
+                (i + 1) as f64 * residual + 0.04 * residual.powi(3)
+            })
+            .collect::<Vec<_>>()
+    };
+    let mut x = vec![1.5; n];
+    let converged = if legacy {
+        legacy_dense_bfgs(&obj, &grad, &mut x, n, 200, 1e-10)
+    } else {
+        dense_bfgs_core(&obj, &grad, &mut x, n, 200, 1e-10, None, None, false)
+    };
+    let final_objective = obj(&x).to_bits();
+    (
+        converged,
+        x.iter().map(|v| v.to_bits()).collect(),
+        final_objective,
+        obj_evals.get(),
+        grad_evals.get(),
+    )
+}
+
+#[test]
+fn dense_bfgs_scratch_reuse_is_bitwise_identical_to_legacy() {
+    for n in [2, 4, 8] {
+        assert_eq!(
+            run_dense_scratch_fixture(n, false),
+            run_dense_scratch_fixture(n, true),
+            "dense BFGS changed its path at eta dimension {n}"
+        );
+    }
+}
+
+#[test]
+fn nelder_mead_scratch_reuse_is_bitwise_identical_to_legacy() {
+    for n in [2, 4, 8] {
+        let run = |legacy: bool| {
+            let evals = std::cell::Cell::new(0usize);
+            let obj = |x: &[f64]| {
+                evals.set(evals.get() + 1);
+                x.iter()
+                    .enumerate()
+                    .map(|(i, &xi)| {
+                        let residual = xi - (i + 1) as f64 / n as f64;
+                        (i + 1) as f64 * residual * residual + 0.01 * residual.powi(4)
+                    })
+                    .sum::<f64>()
+            };
+            let mut x = vec![1.5; n];
+            let converged = if legacy {
+                legacy_nelder_mead(&obj, &mut x, n, 2_000, 1e-12)
+            } else {
+                nelder_mead_minimize(&obj, &mut x, n, 2_000, 1e-12)
+            };
+            let final_objective = obj(&x).to_bits();
+            (
+                converged,
+                x.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                final_objective,
+                evals.get(),
+            )
+        };
+        assert_eq!(
+            run(false),
+            run(true),
+            "Nelder-Mead changed its path at eta dimension {n}"
+        );
+    }
+}
+
+#[test]
+#[cfg(profiling_allocations)]
+#[ignore = "allocation microbenchmark: run alone with --ignored --nocapture"]
+fn dense_bfgs_scratch_allocation_bench() {
+    for n in [2, 4, 8] {
+        ALLOCATION_CALLS.store(0, Ordering::Relaxed);
+        ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+        std::hint::black_box(run_dense_scratch_fixture(n, true));
+        let current = (
+            ALLOCATION_CALLS.load(Ordering::Relaxed),
+            ALLOCATED_BYTES.load(Ordering::Relaxed),
+        );
+
+        ALLOCATION_CALLS.store(0, Ordering::Relaxed);
+        ALLOCATED_BYTES.store(0, Ordering::Relaxed);
+        std::hint::black_box(run_dense_scratch_fixture(n, false));
+        let legacy = (
+            ALLOCATION_CALLS.load(Ordering::Relaxed),
+            ALLOCATED_BYTES.load(Ordering::Relaxed),
+        );
+        eprintln!(
+            "n={n}: scratch={} allocs/{} bytes; legacy={} allocs/{} bytes",
+            current.0, current.1, legacy.0, legacy.1
+        );
+        assert!(
+            current.0 < legacy.0,
+            "scratch reuse must reduce allocations"
+        );
+        assert!(current.1 < legacy.1, "scratch reuse must reduce bytes");
+    }
+}
+
 /// The interpolating backtracking line search returns a step that satisfies
 /// the Armijo sufficient-decrease test and strictly lowers the objective,
 /// using only a handful of trial evaluations (the property the FOCEI inner
@@ -871,7 +1237,8 @@ fn line_search_finds_armijo_step_quickly() {
         evals.set(evals.get() + 1);
         obj(xx)
     };
-    let (alpha, f_new) = backtracking_line_search(&counting, &x, &d, &g, 1, f0);
+    let mut trial = [0.0];
+    let (alpha, f_new) = backtracking_line_search(&counting, &x, &d, &g, f0, &mut trial);
     let evals = evals.get();
     assert!(alpha > 0.0, "a descent step must be found");
     let c1 = 1e-4;
@@ -897,7 +1264,8 @@ fn line_search_rejects_non_descent_direction() {
     let g = [2.0 * (x[0] - 3.0)]; // = −6
     let d = [g[0]]; // SAME sign as g → dg = +36 ≥ 0 (ascent)
     let f0 = obj(&x);
-    let (alpha, f_new) = backtracking_line_search(&obj, &x, &d, &g, 1, f0);
+    let mut trial = [0.0];
+    let (alpha, f_new) = backtracking_line_search(&obj, &x, &d, &g, f0, &mut trial);
     assert_eq!(alpha, 0.0);
     assert_eq!(f_new, f0);
 }
@@ -918,12 +1286,13 @@ fn line_search_survives_non_finite_objective() {
     let f0 = 10.0;
     // Every trial step returns NaN — must not panic, must report no step.
     let nan_obj = |_: &[f64]| -> f64 { f64::NAN };
-    let (alpha, f_new) = backtracking_line_search(&nan_obj, &x, &d, &g, 1, f0);
+    let mut trial = [0.0];
+    let (alpha, f_new) = backtracking_line_search(&nan_obj, &x, &d, &g, f0, &mut trial);
     assert_eq!(alpha, 0.0, "a never-finite objective yields no step");
     assert_eq!(f_new, f0, "baseline objective is returned unchanged");
     // +inf trials behave identically (never accepted, never a panic).
     let inf_obj = |_: &[f64]| -> f64 { f64::INFINITY };
-    let (alpha, f_new) = backtracking_line_search(&inf_obj, &x, &d, &g, 1, f0);
+    let (alpha, f_new) = backtracking_line_search(&inf_obj, &x, &d, &g, f0, &mut trial);
     assert_eq!(alpha, 0.0);
     assert_eq!(f_new, f0);
 }
@@ -938,7 +1307,8 @@ fn line_search_rejects_non_finite_direction() {
     let g = [-6.0];
     let d = [f64::INFINITY]; // dg = −inf: a non-finite "descent" direction
     let f0 = obj(&x);
-    let (alpha, f_new) = backtracking_line_search(&obj, &x, &d, &g, 1, f0);
+    let mut trial = [0.0];
+    let (alpha, f_new) = backtracking_line_search(&obj, &x, &d, &g, f0, &mut trial);
     assert_eq!(alpha, 0.0);
     assert_eq!(f_new, f0);
 }

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1194,7 +1194,7 @@ fn dense_bfgs_scratch_allocation_bench() {
     for n in [2, 4, 8] {
         ALLOCATION_CALLS.store(0, Ordering::Relaxed);
         ALLOCATED_BYTES.store(0, Ordering::Relaxed);
-        std::hint::black_box(run_dense_scratch_fixture(n, true));
+        std::hint::black_box(run_dense_scratch_fixture(n, false));
         let current = (
             ALLOCATION_CALLS.load(Ordering::Relaxed),
             ALLOCATED_BYTES.load(Ordering::Relaxed),
@@ -1202,7 +1202,7 @@ fn dense_bfgs_scratch_allocation_bench() {
 
         ALLOCATION_CALLS.store(0, Ordering::Relaxed);
         ALLOCATED_BYTES.store(0, Ordering::Relaxed);
-        std::hint::black_box(run_dense_scratch_fixture(n, false));
+        std::hint::black_box(run_dense_scratch_fixture(n, true));
         let legacy = (
             ALLOCATION_CALLS.load(Ordering::Relaxed),
             ALLOCATED_BYTES.load(Ordering::Relaxed),


### PR DESCRIPTION
## Why

The usual 2–8 ETA inner problems use dense BFGS. Each iteration rebuilt its gradient/direction adapters, step and curvature vectors, identity matrix, and line-search trial point. The Nelder–Mead fallback likewise rebuilt ordering and geometry buffers each iteration. These allocator calls sit inside every subject's EBE search for every outer-objective evaluation.

## What changed

- Allocate dense-BFGS vector/matrix adapters and the line-search trial point once per inner solve and overwrite them in place.
- Allocate the invariant identity matrix once per dense-BFGS solve.
- Reuse the L-BFGS line-search trial point.
- Reuse Nelder–Mead ordering, centroid, reflection, expansion, contraction, and best-point buffers; accepted points are swapped into the simplex.
- Add test-only copies of the previous algorithms and compare convergence, final ETA bits, final objective bits, and evaluation counts at dimensions 2, 4, and 8.
- Add an opt-in counting-allocator microbenchmark for allocation calls and bytes.

The BFGS inverse-Hessian expression and its operation order are unchanged.

## Alternatives considered

Expanding the inverse-Hessian update into an algebraically equivalent rank-two formula could remove more matrix temporaries, but it would reassociate floating-point operations and could change the inner optimization path. This PR deliberately keeps that expression intact.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

Not applicable.

</details>

## Numerical validation

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [ ] Compared against: NONMEM / nlmixr2 / prior ferx commit `______`
- [x] Reference values: test oracles require exact bitwise equality with the pre-change algorithms at ETA dimensions 2, 4, and 8, including convergence and evaluation counts.
- [ ] Not applicable (docs / refactor / CI only)

The full unit-test binary could not be code-generated in the current constrained container: rustc was SIGKILLed at the memory ceiling in both debug and `ci-fast` profiles. `RAYON_NUM_THREADS=1 cargo check -j 1 --profile ci-fast --tests` passes on the rebased branch. A standalone nalgebra check also confirmed scratch-backed `gemv` matches the prior `-&H * &g` expression bit-for-bit for 30,000 randomized matrix-vector products.

## Performance
- [ ] No significant impact expected
- [ ] Faster — benchmark: pending execution of the included allocation microbenchmark on a normal-memory runner
- [ ] Slower — justified because: `______`

Run the allocation benchmark alone with:

```bash
rtk env RUSTFLAGS='--cfg profiling_allocations' RAYON_NUM_THREADS=1 cargo test -j 1 --profile ci-fast --lib dense_bfgs_scratch_allocation_bench -- --ignored --nocapture
```

## Tests
- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression oracles added for exact dense-BFGS and Nelder–Mead path equivalence
- [ ] No new tests needed (why: `______`)

All test targets type-check. Execution remains pending because of the container memory limit described above.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

Not applicable.

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` N/A: internal allocation optimization with no behavior or API change
- [x] No user-visible change

## Checklist
- [ ] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), public-API baseline
- [x] Functions on the `Dual2` sensitivity path stay differentiable (no sensitivity or prediction code changed)
- [x] `Cargo.toml` version bump not needed; no breaking change

`cargo fmt --check` and `cargo check -j 1 --profile ci-fast --tests` are green with `RAYON_NUM_THREADS=1`.

## Docs & examples

### ferx-site
- [x] No DSL syntax, examples, or data changed

### ferx-book
- [x] No estimator, DSL feature, or fit option changed

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI
- [ ] All affected ferx-site example `.qmd` pages render cleanly
- [ ] All affected ferx-book chapters render cleanly
- [x] No example execution step needed (internal refactor / no user-visible change)

## Reviewer hints

The sensitive point is floating-point identity: review the use of scratch-backed `gemv`, the unchanged inverse-Hessian matrix expression, and the buffer swaps in Nelder–Mead. The test-only legacy implementations pin final bits and evaluation order.

## Open questions

- Run the allocation benchmark and the focused unit tests on a normal-memory runner before marking ready for review.
