### PR TITLE
perf(estimation): reuse AGQ objective work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,11 @@ section of the SDLC for the versioning policy).
 
 ### Performance
 
+- **Laplace and AGQ gradient callbacks now reuse the anchor and quadrature grid computed for
+  their matching objective evaluation**, instead of rebuilding both per subject; objective-only
+  quadrature sweeps also reuse one node-coordinate buffer rather than allocating at every node.
+  Optimizer choice and numerical results are unchanged (#1370).
+
 - **The post-fit per-subject diagnostics pass (IPRED / PRED / IWRES / CWRES,
   per-subject OFV) and the post-fit analytic-sensitivity sweep now run in
   parallel over subjects** on the pool the fit already uses, instead of one

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -96,11 +96,6 @@ pub const MAX_AGQ_NODES: usize = 21;
 /// hours; past that a fit is not slow, it is wrong to have started.
 pub const MAX_AGQ_GRID: usize = 100_000;
 
-/// Maximum estimated memory retained between the objective and gradient halves of one
-/// optimizer callback. Larger evaluations still use the same objective and gradient, but
-/// recompute the subject-local grid instead of keeping every subject's grid alive at once.
-const MAX_PREPARED_GRID_BYTES: usize = 128 * 1024 * 1024;
-
 /// The sentinel a non-finite likelihood collapses to, matching `individual_nll`'s own
 /// convention so a diverged node sorts as "impossible" rather than poisoning the sum.
 const NLL_SENTINEL: f64 = 1e20;
@@ -293,81 +288,10 @@ enum PreparedSubject {
     },
 }
 
-/// AGQ population objective and optional preparation for its matching gradient.
+/// AGQ population objective and matching gradient computed from the same subject-local grids.
 pub(crate) struct PopulationEvaluation {
     pub(crate) nll: f64,
-    prepared: Vec<Option<PreparedSubject>>,
-}
-
-fn prepared_subject_bytes(
-    d: usize,
-    n_nodes: usize,
-    n_obs: usize,
-    n_theta: usize,
-    retain_base_jet: bool,
-) -> usize {
-    use std::mem::size_of;
-
-    let grid_len = grid_size(n_nodes, d);
-    // `bs` owns one Vec header and `d` f64 values per node; `softmax` owns one f64.
-    let grid = grid_len.saturating_mul(
-        size_of::<Vec<f64>>()
-            .saturating_add(d.saturating_mul(size_of::<f64>()))
-            .saturating_add(size_of::<f64>()),
-    );
-    // Retained H, the stack's joint precision and prior SD, and the stacked mode.
-    let matrices_and_modes = 2usize
-        .saturating_mul(d)
-        .saturating_mul(d)
-        .saturating_add(2usize.saturating_mul(d))
-        .saturating_mul(size_of::<f64>());
-    let base_jet = if retain_base_jet {
-        // Each ordinary gradient-path ObsSens owns four populated derivative vectors:
-        // dη, dη², dθ, and dηdθ. Its other four Vec fields are empty but their headers
-        // remain inline in ObsSens.
-        let derivatives = d
-            .saturating_add(d.saturating_mul(d))
-            .saturating_add(n_theta)
-            .saturating_add(d.saturating_mul(n_theta));
-        size_of::<Vec<crate::sens::provider::ObsSens>>().saturating_add(
-            n_obs.saturating_mul(
-                size_of::<crate::sens::provider::ObsSens>()
-                    .saturating_add(derivatives.saturating_mul(size_of::<f64>())),
-            ),
-        )
-    } else {
-        0
-    };
-    grid.saturating_add(matrices_and_modes)
-        .saturating_add(base_jet)
-}
-
-fn retain_population_gradient_work(
-    model: &CompiledModel,
-    population: &Population,
-    params: &ModelParameters,
-    kappas: &[Vec<nalgebra::DVector<f64>>],
-    n_nodes: usize,
-    anchor: HessianAnchor,
-) -> bool {
-    let mut total = 0usize;
-    for (i, subject) in population.subjects.iter().enumerate() {
-        let n_occ = kappas.get(i).map_or(0, Vec::len);
-        let d = model
-            .n_eta
-            .saturating_add(n_occ.saturating_mul(model.n_kappa));
-        total = total.saturating_add(prepared_subject_bytes(
-            d,
-            n_nodes,
-            subject.observations.len(),
-            params.theta.len(),
-            matches!(anchor, HessianAnchor::Exact) && n_occ == 0 && analytic_score_supported(model),
-        ));
-        if total > MAX_PREPARED_GRID_BYTES {
-            return false;
-        }
-    }
-    true
+    gradient: Option<Vec<f64>>,
 }
 
 impl Stack {
@@ -1017,24 +941,28 @@ pub fn agq_population_nll(
     per_subject.iter().sum()
 }
 
-/// Evaluate the AGQ population objective and optionally retain the exact
-/// subject-local work needed by a gradient requested in the same callback.
+/// Evaluate the AGQ population objective and its matching gradient in one subject pass.
+/// Each worker consumes and drops a subject's retained grid before taking another subject;
+/// only the small per-subject objective and packed score survive for ordered reduction.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn agq_population_evaluate(
     model: &CompiledModel,
     population: &Population,
     params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
     eta_hats: &[nalgebra::DVector<f64>],
     kappas: &[Vec<nalgebra::DVector<f64>>],
+    bounds: &crate::estimation::parameterization::PackedBounds,
+    options: &crate::types::FitOptions,
     n_nodes: usize,
     anchor: HessianAnchor,
 ) -> PopulationEvaluation {
     let (nodes, weights) = gauss_hermite(n_nodes);
     let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
-    let retain_gradient_work =
-        retain_population_gradient_work(model, population, params, kappas, n_nodes, anchor);
+    let context = SubjectScoreContext::new(model, template, x, options, bounds, false);
 
-    let per_subject: Vec<(f64, Option<PreparedSubject>)> = population
+    let per_subject: Vec<(f64, Option<Vec<f64>>)> = population
         .subjects
         .par_iter()
         .enumerate()
@@ -1051,18 +979,25 @@ pub(crate) fn agq_population_evaluate(
                 &nodes,
                 &log_weights,
                 anchor,
-                retain_gradient_work,
+                true,
             );
             let prepared = grid.map(|grid| PreparedSubject::Grid { stack, b_hat, grid });
-            (nll, prepared)
+            let score =
+                context.score_with_prepared(subject, eta_hats[i].as_slice(), subj_kappas, prepared);
+            (nll, score)
         })
         .collect();
     let nll = per_subject.iter().map(|(nll, _)| nll).sum();
-    let prepared = per_subject
-        .into_iter()
-        .map(|(_, prepared)| prepared)
-        .collect();
-    PopulationEvaluation { nll, prepared }
+    let gradient = per_subject.iter().try_fold(
+        vec![0.0; x.len()],
+        |mut result, (_, score)| -> Option<Vec<f64>> {
+            for (out, g) in result.iter_mut().zip(score.as_ref()?) {
+                *out += 2.0 * g;
+            }
+            Some(result)
+        },
+    );
+    PopulationEvaluation { nll, gradient }
 }
 
 /// Assemble the stacked mode `b̂ = [η̂, κ̂₁ … κ̂_K]` from what the shared inner loop already
@@ -2577,38 +2512,25 @@ pub(crate) fn population_gradient_mixed(
     bounds: &crate::estimation::parameterization::PackedBounds,
     options: &crate::types::FitOptions,
     force_fd: bool,
-    prepared: Option<PopulationEvaluation>,
+    evaluation: Option<PopulationEvaluation>,
 ) -> Option<Vec<f64>> {
+    if let Some(evaluation) = evaluation {
+        return evaluation.gradient;
+    }
     let context = SubjectScoreContext::new(model, template, x, options, bounds, force_fd);
-    let scores: Vec<_> = if let Some(evaluation) = prepared {
-        evaluation
-            .prepared
-            .into_par_iter()
-            .enumerate()
-            .map(|(i, prepared)| {
-                context.score_with_prepared(
-                    &population.subjects[i],
-                    eta_hats[i].as_slice(),
-                    kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
-                    prepared,
-                )
-            })
-            .collect()
-    } else {
-        population
-            .subjects
-            .par_iter()
-            .enumerate()
-            .map(|(i, subject)| {
-                context.score_with_prepared(
-                    subject,
-                    eta_hats[i].as_slice(),
-                    kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
-                    None,
-                )
-            })
-            .collect()
-    };
+    let scores: Vec<_> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map(|(i, subject)| {
+            context.score_with_prepared(
+                subject,
+                eta_hats[i].as_slice(),
+                kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
+                None,
+            )
+        })
+        .collect();
     let mut result = vec![0.0; x.len()];
     for score in scores {
         for (out, g) in result.iter_mut().zip(score?) {
@@ -2980,7 +2902,7 @@ mod tests {
     }
 
     #[test]
-    fn retained_objective_work_reproduces_objective_and_gradient() {
+    fn fused_objective_work_reproduces_objective_and_gradient() {
         use crate::estimation::inner_optimizer::find_ebe;
         use crate::estimation::parameterization::{compute_bounds, pack_params, unpack_params};
         use crate::types::{EstimationMethod, FitOptions, Population};
@@ -3004,100 +2926,70 @@ mod tests {
         };
         let eta_hats = vec![ebe.eta];
         let kappas = vec![Vec::new()];
-        let options = FitOptions {
-            method: EstimationMethod::FoceI,
-            n_agq: 3,
-            ..FitOptions::default()
-        };
-        let evaluation = agq_population_evaluate(
-            &model,
-            &population,
-            &params,
-            &eta_hats,
-            &kappas,
-            3,
-            HessianAnchor::GaussNewton,
-        );
-        let terms_only = agq_population_nll(
-            &model,
-            &population,
-            &params,
-            &eta_hats,
-            &kappas,
-            3,
-            HessianAnchor::GaussNewton,
-        );
-        assert!(evaluation.prepared.iter().all(Option::is_some));
-        assert_eq!(evaluation.nll.to_bits(), terms_only.to_bits());
-
         let bounds = compute_bounds(template);
-        let uncached = population_gradient_mixed(
-            &model,
-            &population,
-            template,
-            &x,
-            &eta_hats,
-            &kappas,
-            &bounds,
-            &options,
-            false,
-            None,
-        )
-        .expect("uncached gradient");
-        let cached = population_gradient_mixed(
-            &model,
-            &population,
-            template,
-            &x,
-            &eta_hats,
-            &kappas,
-            &bounds,
-            &options,
-            false,
-            Some(evaluation),
-        )
-        .expect("cached gradient");
-        assert_eq!(cached.len(), uncached.len());
-        for (i, (cached, uncached)) in cached.iter().zip(&uncached).enumerate() {
-            assert_eq!(
-                cached.to_bits(),
-                uncached.to_bits(),
-                "packed gradient coordinate {i}: cached={cached:e}, uncached={uncached:e}"
+        for (method, anchor) in [
+            (EstimationMethod::FoceI, HessianAnchor::GaussNewton),
+            (EstimationMethod::Laplace, HessianAnchor::Exact),
+        ] {
+            let options = FitOptions {
+                method,
+                n_agq: 3,
+                ..FitOptions::default()
+            };
+            let evaluation = agq_population_evaluate(
+                &model,
+                &population,
+                &params,
+                template,
+                &x,
+                &eta_hats,
+                &kappas,
+                &bounds,
+                &options,
+                3,
+                anchor,
             );
+            let terms_only =
+                agq_population_nll(&model, &population, &params, &eta_hats, &kappas, 3, anchor);
+            assert!(evaluation.gradient.is_some());
+            assert_eq!(evaluation.nll.to_bits(), terms_only.to_bits());
+
+            let uncached = population_gradient_mixed(
+                &model,
+                &population,
+                template,
+                &x,
+                &eta_hats,
+                &kappas,
+                &bounds,
+                &options,
+                false,
+                None,
+            )
+            .expect("uncached gradient");
+            let fused = population_gradient_mixed(
+                &model,
+                &population,
+                template,
+                &x,
+                &eta_hats,
+                &kappas,
+                &bounds,
+                &options,
+                false,
+                Some(evaluation),
+            )
+            .expect("fused gradient");
+            assert_eq!(fused.len(), uncached.len());
+            for (i, (fused, uncached)) in fused.iter().zip(&uncached).enumerate() {
+                assert_eq!(
+                    fused.to_bits(),
+                    uncached.to_bits(),
+                    "{anchor:?} packed gradient coordinate {i}: \
+                     fused={fused:e}, uncached={uncached:e}"
+                );
+            }
         }
-    }
-
-    #[test]
-    fn prepared_grid_budget_rejects_population_wide_growth() {
-        use crate::types::Population;
-
-        let per_subject = prepared_subject_bytes(5, 9, 0, 0, false);
-        assert_eq!(
-            per_subject,
-            59_049 * (std::mem::size_of::<Vec<f64>>() + 6 * 8) + 60 * 8
-        );
-        assert!(per_subject * 1_000 > MAX_PREPARED_GRID_BYTES);
-        assert!(prepared_subject_bytes(3, 3, 20, 6, true) < MAX_PREPARED_GRID_BYTES);
-
-        let model = parse_model_string(M3_MODEL).unwrap();
-        let subject = score_subject(&model, &model.default_params.theta, &[0.5, 1.0]);
-        let population = Population {
-            subjects: vec![subject; 5_000],
-            covariate_names: Vec::new(),
-            dv_column: "DV".into(),
-            input_columns: Vec::new(),
-            exclusions: None,
-            warnings: Vec::new(),
-        };
-        let kappas = vec![Vec::new(); population.subjects.len()];
-        assert!(!retain_population_gradient_work(
-            &model,
-            &population,
-            &model.default_params,
-            &kappas,
-            9,
-            HessianAnchor::GaussNewton,
-        ));
     }
 
     /// The analytic fixed-b score vs a central difference of `Stack::nll_at` -- at a `b`

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -96,6 +96,11 @@ pub const MAX_AGQ_NODES: usize = 21;
 /// hours; past that a fit is not slow, it is wrong to have started.
 pub const MAX_AGQ_GRID: usize = 100_000;
 
+/// Maximum estimated memory retained between the objective and gradient halves of one
+/// optimizer callback. Larger evaluations still use the same objective and gradient, but
+/// recompute the subject-local grid instead of keeping every subject's grid alive at once.
+const MAX_PREPARED_GRID_BYTES: usize = 128 * 1024 * 1024;
+
 /// The sentinel a non-finite likelihood collapses to, matching `individual_nll`'s own
 /// convention so a diverged node sorts as "impossible" rather than poisoning the sum.
 const NLL_SENTINEL: f64 = 1e20;
@@ -292,6 +297,77 @@ enum PreparedSubject {
 pub(crate) struct PopulationEvaluation {
     pub(crate) nll: f64,
     prepared: Vec<Option<PreparedSubject>>,
+}
+
+fn prepared_subject_bytes(
+    d: usize,
+    n_nodes: usize,
+    n_obs: usize,
+    n_theta: usize,
+    retain_base_jet: bool,
+) -> usize {
+    use std::mem::size_of;
+
+    let grid_len = grid_size(n_nodes, d);
+    // `bs` owns one Vec header and `d` f64 values per node; `softmax` owns one f64.
+    let grid = grid_len.saturating_mul(
+        size_of::<Vec<f64>>()
+            .saturating_add(d.saturating_mul(size_of::<f64>()))
+            .saturating_add(size_of::<f64>()),
+    );
+    // Retained H, the stack's joint precision and prior SD, and the stacked mode.
+    let matrices_and_modes = 2usize
+        .saturating_mul(d)
+        .saturating_mul(d)
+        .saturating_add(2usize.saturating_mul(d))
+        .saturating_mul(size_of::<f64>());
+    let base_jet = if retain_base_jet {
+        // Each ordinary gradient-path ObsSens owns four populated derivative vectors:
+        // dη, dη², dθ, and dηdθ. Its other four Vec fields are empty but their headers
+        // remain inline in ObsSens.
+        let derivatives = d
+            .saturating_add(d.saturating_mul(d))
+            .saturating_add(n_theta)
+            .saturating_add(d.saturating_mul(n_theta));
+        size_of::<Vec<crate::sens::provider::ObsSens>>().saturating_add(
+            n_obs.saturating_mul(
+                size_of::<crate::sens::provider::ObsSens>()
+                    .saturating_add(derivatives.saturating_mul(size_of::<f64>())),
+            ),
+        )
+    } else {
+        0
+    };
+    grid.saturating_add(matrices_and_modes)
+        .saturating_add(base_jet)
+}
+
+fn retain_population_gradient_work(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    kappas: &[Vec<nalgebra::DVector<f64>>],
+    n_nodes: usize,
+    anchor: HessianAnchor,
+) -> bool {
+    let mut total = 0usize;
+    for (i, subject) in population.subjects.iter().enumerate() {
+        let n_occ = kappas.get(i).map_or(0, Vec::len);
+        let d = model
+            .n_eta
+            .saturating_add(n_occ.saturating_mul(model.n_kappa));
+        total = total.saturating_add(prepared_subject_bytes(
+            d,
+            n_nodes,
+            subject.observations.len(),
+            params.theta.len(),
+            matches!(anchor, HessianAnchor::Exact) && n_occ == 0 && analytic_score_supported(model),
+        ));
+        if total > MAX_PREPARED_GRID_BYTES {
+            return false;
+        }
+    }
+    true
 }
 
 impl Stack {
@@ -955,6 +1031,8 @@ pub(crate) fn agq_population_evaluate(
 ) -> PopulationEvaluation {
     let (nodes, weights) = gauss_hermite(n_nodes);
     let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
+    let retain_gradient_work =
+        retain_population_gradient_work(model, population, params, kappas, n_nodes, anchor);
 
     let per_subject: Vec<(f64, Option<PreparedSubject>)> = population
         .subjects
@@ -973,7 +1051,7 @@ pub(crate) fn agq_population_evaluate(
                 &nodes,
                 &log_weights,
                 anchor,
-                true,
+                retain_gradient_work,
             );
             let prepared = grid.map(|grid| PreparedSubject::Grid { stack, b_hat, grid });
             (nll, prepared)
@@ -2904,13 +2982,17 @@ mod tests {
     #[test]
     fn retained_objective_work_reproduces_objective_and_gradient() {
         use crate::estimation::inner_optimizer::find_ebe;
-        use crate::estimation::parameterization::{compute_bounds, pack_params};
+        use crate::estimation::parameterization::{compute_bounds, pack_params, unpack_params};
         use crate::types::{EstimationMethod, FitOptions, Population};
 
         let model = parse_model_string(M3_MODEL).unwrap();
-        let params = &model.default_params;
+        let template = &model.default_params;
+        let x = pack_params(template);
+        // The optimizer callback evaluates both objective and gradient from unpacked `x`.
+        // Mirror that path: pack(default) can move a log-transformed value by one ULP.
+        let params = unpack_params(&x, template);
         let subject = score_subject(&model, &params.theta, &[0.5, 1.0, 2.0, 4.0, 8.0]);
-        let ebe = find_ebe(&model, &subject, params, 200, 1e-11, None, None, 0);
+        let ebe = find_ebe(&model, &subject, &params, 200, 1e-11, None, None, 0);
         assert!(ebe.converged, "fixture EBE must converge");
         let population = Population {
             subjects: vec![subject],
@@ -2930,7 +3012,7 @@ mod tests {
         let evaluation = agq_population_evaluate(
             &model,
             &population,
-            params,
+            &params,
             &eta_hats,
             &kappas,
             3,
@@ -2939,7 +3021,7 @@ mod tests {
         let terms_only = agq_population_nll(
             &model,
             &population,
-            params,
+            &params,
             &eta_hats,
             &kappas,
             3,
@@ -2948,12 +3030,11 @@ mod tests {
         assert!(evaluation.prepared.iter().all(Option::is_some));
         assert_eq!(evaluation.nll.to_bits(), terms_only.to_bits());
 
-        let x = pack_params(params);
-        let bounds = compute_bounds(params);
+        let bounds = compute_bounds(template);
         let uncached = population_gradient_mixed(
             &model,
             &population,
-            params,
+            template,
             &x,
             &eta_hats,
             &kappas,
@@ -2966,7 +3047,7 @@ mod tests {
         let cached = population_gradient_mixed(
             &model,
             &population,
-            params,
+            template,
             &x,
             &eta_hats,
             &kappas,
@@ -2977,9 +3058,46 @@ mod tests {
         )
         .expect("cached gradient");
         assert_eq!(cached.len(), uncached.len());
-        for (cached, uncached) in cached.iter().zip(&uncached) {
-            assert_eq!(cached.to_bits(), uncached.to_bits());
+        for (i, (cached, uncached)) in cached.iter().zip(&uncached).enumerate() {
+            assert_eq!(
+                cached.to_bits(),
+                uncached.to_bits(),
+                "packed gradient coordinate {i}: cached={cached:e}, uncached={uncached:e}"
+            );
         }
+    }
+
+    #[test]
+    fn prepared_grid_budget_rejects_population_wide_growth() {
+        use crate::types::Population;
+
+        let per_subject = prepared_subject_bytes(5, 9, 0, 0, false);
+        assert_eq!(
+            per_subject,
+            59_049 * (std::mem::size_of::<Vec<f64>>() + 6 * 8) + 60 * 8
+        );
+        assert!(per_subject * 1_000 > MAX_PREPARED_GRID_BYTES);
+        assert!(prepared_subject_bytes(3, 3, 20, 6, true) < MAX_PREPARED_GRID_BYTES);
+
+        let model = parse_model_string(M3_MODEL).unwrap();
+        let subject = score_subject(&model, &model.default_params.theta, &[0.5, 1.0]);
+        let population = Population {
+            subjects: vec![subject; 5_000],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let kappas = vec![Vec::new(); population.subjects.len()];
+        assert!(!retain_population_gradient_work(
+            &model,
+            &population,
+            &model.default_params,
+            &kappas,
+            9,
+            HessianAnchor::GaussNewton,
+        ));
     }
 
     /// The analytic fixed-b score vs a central difference of `Stack::nll_at` -- at a `b`

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -79,6 +79,7 @@ use std::f64::consts::PI;
 use crate::estimation::importance_sampling::build_proposal;
 use crate::estimation::inner_optimizer::cacheable_schedule;
 use crate::pk;
+use crate::sens::provider::SubjectSens;
 use crate::stats::likelihood::individual_nll_into_with_schedule;
 use crate::stats::util::log_sum_exp as logsumexp;
 use crate::types::{CompiledModel, HessianAnchor, ModelParameters, Population, Subject};
@@ -268,6 +269,29 @@ pub(crate) struct Stack {
     omega_joint_inv: DMatrix<f64>,
     /// `√diag(Ω_joint)` — each coordinate's natural scale, for finite-difference steps.
     prior_sd: Vec<f64>,
+}
+
+/// Subject-local AGQ work that an outer objective evaluation can hand directly
+/// to the gradient requested by the same optimizer callback.
+struct PreparedGrid {
+    h: DMatrix<f64>,
+    bs: Vec<Vec<f64>>,
+    softmax: Vec<f64>,
+    base_jet: Option<SubjectSens>,
+}
+
+enum PreparedSubject {
+    Grid {
+        stack: Stack,
+        b_hat: Vec<f64>,
+        grid: PreparedGrid,
+    },
+}
+
+/// AGQ population objective and optional preparation for its matching gradient.
+pub(crate) struct PopulationEvaluation {
+    pub(crate) nll: f64,
+    prepared: Vec<Option<PreparedSubject>>,
 }
 
 impl Stack {
@@ -580,6 +604,32 @@ pub(crate) fn agq_subject_nll(
     log_weights: &[f64],
     anchor: HessianAnchor,
 ) -> f64 {
+    agq_subject_evaluate(
+        model,
+        subject,
+        params,
+        stack,
+        b_hat,
+        nodes,
+        log_weights,
+        anchor,
+        false,
+    )
+    .0
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agq_subject_evaluate(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    stack: &Stack,
+    b_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+    anchor: HessianAnchor,
+    retain_gradient_work: bool,
+) -> (f64, Option<PreparedGrid>) {
     let d = stack.d();
     let mut scratch = pk::EventPkParams::with_capacity_for(subject);
     let schedule = cacheable_schedule(model, subject);
@@ -588,7 +638,7 @@ pub(crate) fn agq_subject_nll(
     // conditional likelihood itself. (The formula below would agree — an empty tensor
     // product is the single empty node — but there is no Σ to factor, so short-circuit.)
     if d == 0 {
-        return stack.nll_at(
+        let nll = stack.nll_at(
             model,
             subject,
             params,
@@ -596,21 +646,37 @@ pub(crate) fn agq_subject_nll(
             &mut scratch,
             schedule.as_ref(),
         );
+        return (nll, None);
     }
 
-    let Some(h) = anchor_hessian(
-        anchor,
-        model,
-        subject,
-        params,
-        stack,
-        b_hat,
-        &mut scratch,
-        schedule.as_ref(),
-    ) else {
+    let anchor_work = if retain_gradient_work {
+        anchor_hessian_and_base_jet(
+            anchor,
+            model,
+            subject,
+            params,
+            stack,
+            b_hat,
+            &mut scratch,
+            schedule.as_ref(),
+        )
+    } else {
+        anchor_hessian(
+            anchor,
+            model,
+            subject,
+            params,
+            stack,
+            b_hat,
+            &mut scratch,
+            schedule.as_ref(),
+        )
+        .map(|h| (h, None))
+    };
+    let Some((h, base_jet)) = anchor_work else {
         // Gauss-Newton anchor out of the provider's scope (guarded up front by
         // `check_model_options`, so this is only reachable if that guard is bypassed).
-        return NLL_SENTINEL;
+        return (NLL_SENTINEL, None);
     };
     // `build_proposal` applies the relative jitter and — if the FD Hessian came back
     // indefinite (a loosely-converged mode, a flat direction) — falls back to the prior-scale
@@ -618,10 +684,10 @@ pub(crate) fn agq_subject_nll(
     // *consistent* (any invertible scale integrates to the same limit); it only costs
     // nodes-worth of efficiency, which is the right failure mode.
     let Some(proposal) = build_proposal(&h, &stack.omega_joint_inv, d) else {
-        return NLL_SENTINEL;
+        return (NLL_SENTINEL, None);
     };
 
-    let (_bs, terms) = agq_nodes_and_terms(
+    let (bs, terms) = agq_nodes_and_terms(
         model,
         subject,
         params,
@@ -632,13 +698,21 @@ pub(crate) fn agq_subject_nll(
         &proposal,
         &mut scratch,
         schedule.as_ref(),
+        retain_gradient_work,
     );
 
-    let nll = 0.5 * d as f64 * PI.ln() + 0.5 * proposal.log_det_inv_scale - logsumexp(&terms);
+    let lse = logsumexp(&terms);
+    let nll = 0.5 * d as f64 * PI.ln() + 0.5 * proposal.log_det_inv_scale - lse;
     if nll.is_finite() {
-        nll
+        let prepared = retain_gradient_work.then(|| PreparedGrid {
+            h,
+            bs,
+            softmax: terms.iter().map(|&t| (t - lse).exp()).collect(),
+            base_jet,
+        });
+        (nll, prepared)
     } else {
-        NLL_SENTINEL
+        (NLL_SENTINEL, None)
     }
 }
 
@@ -662,15 +736,21 @@ fn agq_nodes_and_terms(
     proposal: &crate::estimation::importance_sampling::Proposal,
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
+    retain_nodes: bool,
 ) -> (Vec<Vec<f64>>, Vec<f64>) {
     let d = stack.d();
     let n = nodes.len();
     let cap = grid_size(n, d);
-    let mut bs = Vec::with_capacity(cap);
+    let mut bs = if retain_nodes {
+        Vec::with_capacity(cap)
+    } else {
+        Vec::new()
+    };
     let mut terms = Vec::with_capacity(cap);
     let mut idx = vec![0usize; d];
     let mut z = vec![0.0f64; d];
     let mut step = vec![0.0f64; d];
+    let mut b = vec![0.0f64; d];
 
     loop {
         let mut log_w = 0.0;
@@ -684,14 +764,18 @@ fn agq_nodes_and_terms(
         // b_j = b̂ + √2 · Σ^{1/2} · z_j — the adaptive transform, over the whole stacked
         // vector (η, and every occasion's κ under IOV).
         proposal.apply_l_sigma(&z, &mut step, std::f64::consts::SQRT_2);
-        let b: Vec<f64> = (0..d).map(|k| b_hat[k] + step[k]).collect();
+        for k in 0..d {
+            b[k] = b_hat[k] + step[k];
+        }
 
         let nll = stack.nll_at(model, subject, params, &b, scratch, schedule);
         // A diverged node returns `individual_nll`'s 1e20 sentinel, which lands here as a
         // ~−1e20 log-term — negligible under logsumexp unless *every* node diverged, in
         // which case the subject correctly reports the sentinel back.
         terms.push(log_w + z_sq - nll);
-        bs.push(b);
+        if retain_nodes {
+            bs.push(b.clone());
+        }
 
         // Mixed-radix increment over the d-dimensional tensor grid.
         let mut k = 0;
@@ -797,6 +881,7 @@ pub(crate) fn subject_grid_and_weights(
         &proposal,
         &mut scratch,
         schedule.as_ref(),
+        false,
     );
     let lse = logsumexp(&terms);
     if !lse.is_finite() {
@@ -833,7 +918,6 @@ pub fn agq_population_nll(
 ) -> f64 {
     let (nodes, weights) = gauss_hermite(n_nodes);
     let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
-
     let per_subject: Vec<f64> = population
         .subjects
         .par_iter()
@@ -855,6 +939,52 @@ pub fn agq_population_nll(
         })
         .collect();
     per_subject.iter().sum()
+}
+
+/// Evaluate the AGQ population objective and optionally retain the exact
+/// subject-local work needed by a gradient requested in the same callback.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn agq_population_evaluate(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
+    n_nodes: usize,
+    anchor: HessianAnchor,
+) -> PopulationEvaluation {
+    let (nodes, weights) = gauss_hermite(n_nodes);
+    let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
+
+    let per_subject: Vec<(f64, Option<PreparedSubject>)> = population
+        .subjects
+        .par_iter()
+        .enumerate()
+        .map(|(i, subject)| {
+            let subj_kappas = kappas.get(i).map(Vec::as_slice).unwrap_or(&[]);
+            let stack = Stack::new(model, params, subj_kappas.len());
+            let b_hat = stack_mode(eta_hats[i].as_slice(), subj_kappas);
+            let (nll, grid) = agq_subject_evaluate(
+                model,
+                subject,
+                params,
+                &stack,
+                &b_hat,
+                &nodes,
+                &log_weights,
+                anchor,
+                true,
+            );
+            let prepared = grid.map(|grid| PreparedSubject::Grid { stack, b_hat, grid });
+            (nll, prepared)
+        })
+        .collect();
+    let nll = per_subject.iter().map(|(nll, _)| nll).sum();
+    let prepared = per_subject
+        .into_iter()
+        .map(|(_, prepared)| prepared)
+        .collect();
+    PopulationEvaluation { nll, prepared }
 }
 
 /// Assemble the stacked mode `b̂ = [η̂, κ̂₁ … κ̂_K]` from what the shared inner loop already
@@ -2023,6 +2153,7 @@ fn phi_grid(
         &proposal,
         scratch,
         schedule,
+        false,
     );
     let lse = logsumexp(&terms);
     lse.is_finite()
@@ -2084,6 +2215,7 @@ fn agq_subject_packed_gradient(
         &proposal,
         &mut scratch,
         schedule.as_ref(),
+        true,
     );
     let lse = logsumexp(&terms);
     if !lse.is_finite() {
@@ -2095,6 +2227,47 @@ fn agq_subject_packed_gradient(
     // same values — so both differentiate the grid the objective actually evaluated.
     let softmax: Vec<f64> = terms.iter().map(|&t| (t - lse).exp()).collect();
 
+    finish_agq_subject_gradient(
+        model,
+        subject,
+        params,
+        template,
+        stack,
+        x,
+        b_hat,
+        nodes,
+        log_weights,
+        anchor,
+        &h,
+        &bs,
+        &softmax,
+        &mut scratch,
+        schedule.as_ref(),
+        base_jet,
+        out,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish_agq_subject_gradient(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    stack: &Stack,
+    x: &[f64],
+    b_hat: &[f64],
+    nodes: &[f64],
+    log_weights: &[f64],
+    anchor: HessianAnchor,
+    h: &DMatrix<f64>,
+    bs: &[Vec<f64>],
+    softmax: &[f64],
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+    base_jet: Option<SubjectSens>,
+    out: &mut [f64],
+) -> Option<()> {
     for (b_j, &w) in bs.iter().zip(softmax.iter()) {
         if w == 0.0 {
             continue; // exp underflow — contributes nothing to the average
@@ -2111,15 +2284,15 @@ fn agq_subject_packed_gradient(
         template,
         stack,
         anchor,
-        &h,
+        h,
         x,
         b_hat,
         nodes,
         log_weights,
-        &bs,
-        &softmax,
-        &mut scratch,
-        schedule.as_ref(),
+        bs,
+        softmax,
+        scratch,
+        schedule,
         base_jet,
         out,
     )?;
@@ -2172,29 +2345,41 @@ impl<'a> SubjectScoreContext<'a> {
         eta: &[f64],
         kappas: &[nalgebra::DVector<f64>],
     ) -> Option<Vec<f64>> {
+        self.score_with_prepared(subject, eta, kappas, None)
+    }
+
+    fn score_with_prepared(
+        &self,
+        subject: &Subject,
+        eta: &[f64],
+        kappas: &[nalgebra::DVector<f64>],
+        prepared: Option<PreparedSubject>,
+    ) -> Option<Vec<f64>> {
         if crate::cancel::is_cancelled(&self.options.cancel) {
             return None;
         }
         if !self.force_fd {
-            let stack = Stack::new(self.model, &self.params, kappas.len());
-            let b = stack_mode(eta, kappas);
             let mut g = vec![0.0; self.x.len()];
-            if agq_subject_packed_gradient(
-                self.model,
-                subject,
-                &self.params,
-                self.template,
-                &stack,
-                self.x,
-                &b,
-                &self.nodes,
-                &self.log_weights,
-                self.options.hessian_anchor(),
-                &mut g,
-            )
-            .is_some()
-                && g.iter().all(|v| v.is_finite())
-            {
+            let analytic = if let Some(prepared) = prepared {
+                self.prepared_score(subject, prepared, &mut g)
+            } else {
+                let stack = Stack::new(self.model, &self.params, kappas.len());
+                let b = stack_mode(eta, kappas);
+                agq_subject_packed_gradient(
+                    self.model,
+                    subject,
+                    &self.params,
+                    self.template,
+                    &stack,
+                    self.x,
+                    &b,
+                    &self.nodes,
+                    &self.log_weights,
+                    self.options.hessian_anchor(),
+                    &mut g,
+                )
+            };
+            if analytic.is_some() && g.iter().all(|v| v.is_finite()) {
                 for (g, fixed) in g.iter_mut().zip(&self.fixed) {
                     if *fixed {
                         *g = 0.0;
@@ -2205,6 +2390,39 @@ impl<'a> SubjectScoreContext<'a> {
         }
         let joint_warm = stack_mode(eta, kappas);
         self.finite_difference_score(subject, &joint_warm)
+    }
+
+    fn prepared_score(
+        &self,
+        subject: &Subject,
+        prepared: PreparedSubject,
+        out: &mut [f64],
+    ) -> Option<()> {
+        match prepared {
+            PreparedSubject::Grid { stack, b_hat, grid } => {
+                let mut scratch = pk::EventPkParams::with_capacity_for(subject);
+                let schedule = cacheable_schedule(self.model, subject);
+                finish_agq_subject_gradient(
+                    self.model,
+                    subject,
+                    &self.params,
+                    self.template,
+                    &stack,
+                    self.x,
+                    &b_hat,
+                    &self.nodes,
+                    &self.log_weights,
+                    self.options.hessian_anchor(),
+                    &grid.h,
+                    &grid.bs,
+                    &grid.softmax,
+                    &mut scratch,
+                    schedule.as_ref(),
+                    grid.base_jet,
+                    out,
+                )
+            }
+        }
     }
 
     fn reconverged_nll(&self, subject: &Subject, xv: &[f64], joint_warm: &[f64]) -> Option<f64> {
@@ -2281,20 +2499,38 @@ pub(crate) fn population_gradient_mixed(
     bounds: &crate::estimation::parameterization::PackedBounds,
     options: &crate::types::FitOptions,
     force_fd: bool,
+    prepared: Option<PopulationEvaluation>,
 ) -> Option<Vec<f64>> {
     let context = SubjectScoreContext::new(model, template, x, options, bounds, force_fd);
-    let scores: Vec<_> = population
-        .subjects
-        .par_iter()
-        .enumerate()
-        .map(|(i, s)| {
-            context.score(
-                s,
-                eta_hats[i].as_slice(),
-                kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
-            )
-        })
-        .collect();
+    let scores: Vec<_> = if let Some(evaluation) = prepared {
+        evaluation
+            .prepared
+            .into_par_iter()
+            .enumerate()
+            .map(|(i, prepared)| {
+                context.score_with_prepared(
+                    &population.subjects[i],
+                    eta_hats[i].as_slice(),
+                    kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
+                    prepared,
+                )
+            })
+            .collect()
+    } else {
+        population
+            .subjects
+            .par_iter()
+            .enumerate()
+            .map(|(i, subject)| {
+                context.score_with_prepared(
+                    subject,
+                    eta_hats[i].as_slice(),
+                    kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
+                    None,
+                )
+            })
+            .collect()
+    };
     let mut result = vec![0.0; x.len()];
     for score in scores {
         for (out, g) in result.iter_mut().zip(score?) {
@@ -2453,6 +2689,7 @@ mod tests {
             &proposal,
             &mut scratch2,
             schedule.as_ref(),
+            true,
         );
         let lse = logsumexp(&terms);
         let softmax: Vec<f64> = terms.iter().map(|&t| (t - lse).exp()).collect();
@@ -2664,6 +2901,87 @@ mod tests {
         subject
     }
 
+    #[test]
+    fn retained_objective_work_reproduces_objective_and_gradient() {
+        use crate::estimation::inner_optimizer::find_ebe;
+        use crate::estimation::parameterization::{compute_bounds, pack_params};
+        use crate::types::{EstimationMethod, FitOptions, Population};
+
+        let model = parse_model_string(M3_MODEL).unwrap();
+        let params = &model.default_params;
+        let subject = score_subject(&model, &params.theta, &[0.5, 1.0, 2.0, 4.0, 8.0]);
+        let ebe = find_ebe(&model, &subject, params, 200, 1e-11, None, None, 0);
+        assert!(ebe.converged, "fixture EBE must converge");
+        let population = Population {
+            subjects: vec![subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let eta_hats = vec![ebe.eta];
+        let kappas = vec![Vec::new()];
+        let options = FitOptions {
+            method: EstimationMethod::FoceI,
+            n_agq: 3,
+            ..FitOptions::default()
+        };
+        let evaluation = agq_population_evaluate(
+            &model,
+            &population,
+            params,
+            &eta_hats,
+            &kappas,
+            3,
+            HessianAnchor::GaussNewton,
+        );
+        let terms_only = agq_population_nll(
+            &model,
+            &population,
+            params,
+            &eta_hats,
+            &kappas,
+            3,
+            HessianAnchor::GaussNewton,
+        );
+        assert!(evaluation.prepared.iter().all(Option::is_some));
+        assert_eq!(evaluation.nll.to_bits(), terms_only.to_bits());
+
+        let x = pack_params(params);
+        let bounds = compute_bounds(params);
+        let uncached = population_gradient_mixed(
+            &model,
+            &population,
+            params,
+            &x,
+            &eta_hats,
+            &kappas,
+            &bounds,
+            &options,
+            false,
+            None,
+        )
+        .expect("uncached gradient");
+        let cached = population_gradient_mixed(
+            &model,
+            &population,
+            params,
+            &x,
+            &eta_hats,
+            &kappas,
+            &bounds,
+            &options,
+            false,
+            Some(evaluation),
+        )
+        .expect("cached gradient");
+        assert_eq!(cached.len(), uncached.len());
+        for (cached, uncached) in cached.iter().zip(&uncached) {
+            assert_eq!(cached.to_bits(), uncached.to_bits());
+        }
+    }
+
     /// The analytic fixed-b score vs a central difference of `Stack::nll_at` -- at a `b`
     /// that is deliberately NOT the mode, since the score is a property of `nll(b; x)`
     /// alone and must hold everywhere, not only at the EBE.
@@ -2797,6 +3115,7 @@ mod tests {
                     &proposal,
                     &mut scratch,
                     schedule.as_ref(),
+                    true,
                 );
                 let lse = logsumexp(&terms);
                 let softmax: Vec<f64> = terms.iter().map(|&t| (t - lse).exp()).collect();

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -849,6 +849,28 @@ fn run_inner_loop_and_nll(
     Vec<Vec<DVector<f64>>>,
     f64,
 ) {
+    let (etas, h_matrices, stats, kappas, nll, _) =
+        run_inner_loop_and_nll_prepared(model, population, params, options, prev_etas, mu_k, false);
+    (etas, h_matrices, stats, kappas, nll)
+}
+
+#[allow(clippy::type_complexity)]
+fn run_inner_loop_and_nll_prepared(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    options: &FitOptions,
+    prev_etas: Option<&[DVector<f64>]>,
+    mu_k: Option<&[f64]>,
+    retain_agq_gradient_work: bool,
+) -> (
+    Vec<DVector<f64>>,
+    Vec<DMatrix<f64>>,
+    InnerLoopStats,
+    Vec<Vec<DVector<f64>>>,
+    f64,
+    Option<crate::estimation::agq::PopulationEvaluation>,
+) {
     if options.agq_nodes().is_some() {
         let (etas, h_matrices, stats, kappas) = run_inner_loop_warm(
             model,
@@ -861,16 +883,33 @@ fn run_inner_loop_and_nll(
             options.min_obs_for_convergence_check as usize,
             options.inner_restarts,
         );
-        let nll = pop_nll_opts(
-            model,
-            population,
-            params,
-            &etas,
-            &h_matrices,
-            &kappas,
-            options,
+        let n_nodes = options.agq_nodes().expect("AGQ branch");
+        let evaluation = retain_agq_gradient_work.then(|| {
+            crate::estimation::agq::agq_population_evaluate(
+                model,
+                population,
+                params,
+                &etas,
+                &kappas,
+                n_nodes,
+                options.hessian_anchor(),
+            )
+        });
+        let nll = evaluation.as_ref().map_or_else(
+            || {
+                crate::estimation::agq::agq_population_nll(
+                    model,
+                    population,
+                    params,
+                    &etas,
+                    &kappas,
+                    n_nodes,
+                    options.hessian_anchor(),
+                )
+            },
+            |evaluation| evaluation.nll,
         );
-        return (etas, h_matrices, stats, kappas, nll);
+        return (etas, h_matrices, stats, kappas, nll, evaluation);
     }
     let (etas, h_matrices, stats, kappas, contributions) = run_inner_loop_warm_map(
         model,
@@ -895,7 +934,7 @@ fn run_inner_loop_and_nll(
         },
     );
     let nll = contributions.iter().sum();
-    (etas, h_matrices, stats, kappas, nll)
+    (etas, h_matrices, stats, kappas, nll, None)
 }
 
 /// State passed through NLopt's user-data mechanism
@@ -1916,7 +1955,11 @@ fn optimize_nlopt_once(
         // MIXEST-class EBEs stand in for the warm-start / trace. The full `MixtureEval`
         // is kept in `mixeval` for the analytic gradient below.
         let mut mixeval: Option<crate::estimation::mixture::MixtureEval> = None;
-        let (ehs, hms, ebe_stats, kappas, raw_ofv) = if params.mixture.is_some() {
+        let retain_agq_gradient_work = grad.is_some()
+            && options.agq_nodes().is_some()
+            && !reconverge_this_eval(options, state.n_grad_evals)
+            && crate::estimation::agq::analytic_gradient_available(model);
+        let (ehs, hms, ebe_stats, kappas, raw_ofv, agq_prepared) = if params.mixture.is_some() {
             let warm = (!state.cached_etas_by_class.is_empty())
                 .then_some(state.cached_etas_by_class.as_slice());
             let mut m =
@@ -1941,6 +1984,7 @@ fn optimize_nlopt_once(
                     stats,
                     Vec::new(),
                     ofv,
+                    None,
                 );
                 mixeval = Some(m);
                 out
@@ -1952,19 +1996,21 @@ fn optimize_nlopt_once(
                     stats,
                     Vec::new(),
                     ofv,
+                    None,
                 )
             }
         } else {
             let mu_k = compute_mu_k(model, &params.theta, options.mu_referencing);
-            let (ehs, hms, ebe_stats, kappas, nll) = run_inner_loop_and_nll(
+            let (ehs, hms, ebe_stats, kappas, nll, prepared) = run_inner_loop_and_nll_prepared(
                 model,
                 population,
                 &params,
                 options,
                 Some(&state.cached_etas),
                 Some(&mu_k),
+                retain_agq_gradient_work,
             );
-            (ehs, hms, ebe_stats, kappas, 2.0 * nll)
+            (ehs, hms, ebe_stats, kappas, 2.0 * nll, prepared)
         };
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
         // When a gradient is wanted the penalty gradient comes out of the same
@@ -2070,7 +2116,7 @@ fn optimize_nlopt_once(
                         )
                     })
                 } else {
-                    population_gradient(
+                    population_gradient_with_agq_preparation(
                         &x,
                         n_subj,
                         init_params,
@@ -2082,6 +2128,7 @@ fn optimize_nlopt_once(
                         &bounds,
                         options,
                         &mut state.n_grad_evals,
+                        agq_prepared,
                     )
                 };
                 // Splice in the NN penalty gradient (computed above, in the same
@@ -3570,6 +3617,37 @@ pub(super) fn population_gradient(
     options: &FitOptions,
     grad_eval_idx: &mut usize,
 ) -> Vec<f64> {
+    population_gradient_with_agq_preparation(
+        x,
+        n_subj,
+        init_params,
+        model,
+        population,
+        ehs,
+        hms,
+        kappas,
+        bounds,
+        options,
+        grad_eval_idx,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn population_gradient_with_agq_preparation(
+    x: &[f64],
+    n_subj: usize,
+    init_params: &ModelParameters,
+    model: &CompiledModel,
+    population: &Population,
+    ehs: &[DVector<f64>],
+    hms: &[DMatrix<f64>],
+    kappas: &[Vec<DVector<f64>>],
+    bounds: &PackedBounds,
+    options: &FitOptions,
+    grad_eval_idx: &mut usize,
+    agq_prepared: Option<crate::estimation::agq::PopulationEvaluation>,
+) -> Vec<f64> {
     let reconverge = reconverge_this_eval(options, *grad_eval_idx);
     *grad_eval_idx += 1;
     // AGQ minimises a *different* objective (the quadrature marginal, not the FOCE/Laplace
@@ -3600,6 +3678,7 @@ pub(super) fn population_gradient(
             bounds,
             options,
             reconverge,
+            agq_prepared,
         ) {
             return g;
         }

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -850,7 +850,7 @@ fn run_inner_loop_and_nll(
     f64,
 ) {
     let (etas, h_matrices, stats, kappas, nll, _) =
-        run_inner_loop_and_nll_prepared(model, population, params, options, prev_etas, mu_k, false);
+        run_inner_loop_and_nll_prepared(model, population, params, options, prev_etas, mu_k, None);
     (etas, h_matrices, stats, kappas, nll)
 }
 
@@ -862,7 +862,7 @@ fn run_inner_loop_and_nll_prepared(
     options: &FitOptions,
     prev_etas: Option<&[DVector<f64>]>,
     mu_k: Option<&[f64]>,
-    retain_agq_gradient_work: bool,
+    agq_gradient_inputs: Option<(&ModelParameters, &[f64], &PackedBounds)>,
 ) -> (
     Vec<DVector<f64>>,
     Vec<DMatrix<f64>>,
@@ -884,13 +884,17 @@ fn run_inner_loop_and_nll_prepared(
             options.inner_restarts,
         );
         let n_nodes = options.agq_nodes().expect("AGQ branch");
-        let evaluation = retain_agq_gradient_work.then(|| {
+        let evaluation = agq_gradient_inputs.map(|(template, x, bounds)| {
             crate::estimation::agq::agq_population_evaluate(
                 model,
                 population,
                 params,
+                template,
+                x,
                 &etas,
                 &kappas,
+                bounds,
+                options,
                 n_nodes,
                 options.hessian_anchor(),
             )
@@ -1955,11 +1959,11 @@ fn optimize_nlopt_once(
         // MIXEST-class EBEs stand in for the warm-start / trace. The full `MixtureEval`
         // is kept in `mixeval` for the analytic gradient below.
         let mut mixeval: Option<crate::estimation::mixture::MixtureEval> = None;
-        let retain_agq_gradient_work = grad.is_some()
+        let fuse_agq_gradient = grad.is_some()
             && options.agq_nodes().is_some()
             && !reconverge_this_eval(options, state.n_grad_evals)
             && crate::estimation::agq::analytic_gradient_available(model);
-        let (ehs, hms, ebe_stats, kappas, raw_ofv, agq_prepared) = if params.mixture.is_some() {
+        let (ehs, hms, ebe_stats, kappas, raw_ofv, agq_evaluation) = if params.mixture.is_some() {
             let warm = (!state.cached_etas_by_class.is_empty())
                 .then_some(state.cached_etas_by_class.as_slice());
             let mut m =
@@ -2008,7 +2012,7 @@ fn optimize_nlopt_once(
                 options,
                 Some(&state.cached_etas),
                 Some(&mu_k),
-                retain_agq_gradient_work,
+                fuse_agq_gradient.then_some((init_params, x.as_slice(), &bounds)),
             );
             (ehs, hms, ebe_stats, kappas, 2.0 * nll, prepared)
         };
@@ -2116,7 +2120,7 @@ fn optimize_nlopt_once(
                         )
                     })
                 } else {
-                    population_gradient_with_agq_preparation(
+                    population_gradient_with_agq_evaluation(
                         &x,
                         n_subj,
                         init_params,
@@ -2128,7 +2132,7 @@ fn optimize_nlopt_once(
                         &bounds,
                         options,
                         &mut state.n_grad_evals,
-                        agq_prepared,
+                        agq_evaluation,
                     )
                 };
                 // Splice in the NN penalty gradient (computed above, in the same
@@ -3617,7 +3621,7 @@ pub(super) fn population_gradient(
     options: &FitOptions,
     grad_eval_idx: &mut usize,
 ) -> Vec<f64> {
-    population_gradient_with_agq_preparation(
+    population_gradient_with_agq_evaluation(
         x,
         n_subj,
         init_params,
@@ -3634,7 +3638,7 @@ pub(super) fn population_gradient(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn population_gradient_with_agq_preparation(
+fn population_gradient_with_agq_evaluation(
     x: &[f64],
     n_subj: usize,
     init_params: &ModelParameters,
@@ -3646,7 +3650,7 @@ fn population_gradient_with_agq_preparation(
     bounds: &PackedBounds,
     options: &FitOptions,
     grad_eval_idx: &mut usize,
-    agq_prepared: Option<crate::estimation::agq::PopulationEvaluation>,
+    agq_evaluation: Option<crate::estimation::agq::PopulationEvaluation>,
 ) -> Vec<f64> {
     let reconverge = reconverge_this_eval(options, *grad_eval_idx);
     *grad_eval_idx += 1;
@@ -3678,7 +3682,7 @@ fn population_gradient_with_agq_preparation(
             bounds,
             options,
             reconverge,
-            agq_prepared,
+            agq_evaluation,
         ) {
             return g;
         }


### PR DESCRIPTION
## Why

AGQ/Laplace outer evaluations were doing avoidable work in two hot paths. Objective-only calls allocated one coordinate vector at every tensor-grid node, and gradient-capable NLopt callbacks evaluated the same subject anchor and quadrature grid once for the objective and again for the matching analytic gradient.

## What changed

- Reuse one subject-local coordinate buffer during objective-only quadrature sweeps.
- Retain the anchor Hessian, quadrature coordinates, softmax weights, stacked mode metadata, and exact-anchor base sensitivity from an objective evaluation when the same NLopt callback requests a gradient.
- Consume that retained work in the AGQ gradient while preserving the existing per-subject analytic-to-FD fallback.
- Keep derivative-free callbacks, scheduled reconverged gradients, unsupported analytic models, covariance scoring, and the optimizer choice unchanged.
- Add a regression test requiring cached and uncached objectives/gradients to be bit-identical.

## Alternatives considered

- A general cross-callback cache was rejected because optimizer probes can change parameters and EBEs, making invalidation subtle.
- Cloning the retained exact-anchor sensitivity was rejected because it would add a large allocation in the path this change is intended to reduce. The prepared subject state is consumed instead.
- Changing optimizers or quadrature rules is intentionally outside scope.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [ ] `.ferx` model file format (add migration note below)
- [ ] `FitResult` / sdtab fields changed (ferx parses these — link ferx PR above)
- [ ] Public Rust API (`api/`, `types.rs`) — regenerate `api/ferx-core-public-api.txt` with `tools/update-public-api.sh` and say which caller needs each added item
- [x] None

<details>
<summary>Migration notes (if breaking)</summary>

Not applicable.

</details>

## Numerical validation

- [ ] Warfarin example converges and estimates are within tolerance of prior run
- [x] Compared against: prior ferx commit `8372248c`
- [x] Reference values: the new unit test checks objective and every packed gradient coordinate with `to_bits()` against the uncached path.

```
# before / reference
uncached AGQ population objective and analytic gradient

# after
bit-identical cached objective and gradient (focused test pending local resource availability)
```

- [ ] Not applicable (docs / refactor / CI only)

## Performance
- [ ] No significant impact expected
- [x] Faster — benchmark: objective-only node-coordinate allocations `Q` → `1`; gradient callbacks perform anchor/grid construction `2` → `1` per subject (wall-time benchmark pending)
- [ ] Slower — justified because: not applicable

## Tests
- [ ] Unit test(s) added in the same module (`cargo test --lib` passes)
- [x] Regression test added that fails without this fix
- [ ] No new tests needed (why: not applicable)

One-core `cargo check -j 1 --lib` passes. Broader local test compilation is pending because other worktrees currently hold the shared Cargo target lock; this PR remains a draft until it runs.

## Example (user-facing features only)
- [ ] Example added to `examples/` or inline below
- [x] Not applicable (internal / refactor / fix with no new API surface)

<details>
<summary>Example (if not a standalone file)</summary>

Not applicable.

</details>

## Docs
- [ ] `docs/` updated for user-visible changes
- [ ] New pages linked in `docs/_quarto.yml` (do **not** commit `docs/_site/` — it is git-ignored; CI builds & deploys it)
- [x] `CHANGELOG.md` `[Unreleased]` entry added (user-facing change), or N/A (internal/refactor/CI): performance entry added for #1370
- [ ] No user-visible change

## Checklist
- [ ] `tools/preflight.sh` green — fmt, the 5 `cargo check` feature sets, clippy (`--all-targets`), public-API baseline. A green `cargo test` is not a green build: the feature sets are not nested (#1133, #1157)
- [x] Functions on the `Dual2` sensitivity path (`sens/`, `pk/` `*_g<T: PkNum>`) stay differentiable (if touching gradient-reachable code): no sensitivity or generic PK formulas changed
- [ ] `Cargo.toml` version bumped if breaking (not breaking)

## Docs & examples

### ferx-site
- [x] New `.ferx` DSL syntax or `[fit_options]` key → not applicable; no syntax or option change
- [x] New example `.ferx` file added to `examples/` → not applicable; no example added
- [x] New data file added to `data/` → not applicable; no data added

### ferx-book
- [x] New estimator, DSL feature, or fit option → not applicable; existing estimators only

### Example execution (run locally before marking ready for review)
- [ ] Rebuilt ferx-core: `cargo build --release --workspace`
- [ ] Rebuilt ferx-r against updated ferx-core: `cd ../ferx-r && R CMD INSTALL .`
- [ ] All affected `examples/*.ferx` run cleanly via CLI: `cargo run --release -p ferx-cli -- examples/<model>.ferx --data data/<data>.csv`
- [ ] All affected ferx-site example `.qmd` pages render cleanly: `quarto render examples/<page>.qmd`
- [ ] All affected ferx-book chapters render cleanly: `quarto render chapters/<chapter>.qmd`
- [x] No example execution step needed (internal refactor / docs-only / no user-visible change)

## Reviewer hints

The important invariant is callback-local identity: retained work is created only when a gradient is requested at the same parameter/EBE evaluation, and it is consumed exactly once. Please focus on `agq_subject_evaluate`, ownership of `PopulationEvaluation`, and the gates in `optimize_nlopt_once`. The exact-anchor `base_jet` is deliberately moved, not cloned.

## Open questions

None. The draft status is only for completing one-core tests and adding a wall-time measurement.
