### PR TITLE
perf(estimation): reuse classical estimator hot-path buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,10 @@ section of the SDLC for the versioning policy).
 
 ### Performance
 
+- **FOCE, FOCEI, Laplace, and AGQ now reuse prediction and prior-matrix storage across
+  repeated conditional-likelihood evaluations.** AGQ also caches invariant Hermite rules;
+  IOV quadrature borrows occasion effects and uses the covariance inverses already cached in
+  the model parameters instead of copying and refactorizing them at every node (#1374).
 
 - **ODE AutoSwitch now reuses accepted RK45 stages to detect stiffness without extra
   right-hand-side evaluations and carries its verdict history across dose and covariate

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -24,7 +24,8 @@
 //!    term for term. This is not an approximation of an approximation; it is an identity,
 //!    and `tests::one_node_agq_equals_laplace` pins it.
 //! 2. **No Gaussian-residual assumption.** `l_i` is evaluated through
-//!    [`individual_nll_into_with_schedule`], the model's *actual* likelihood — so
+//!    [`crate::stats::likelihood::individual_nll_into_with_schedule`], the model's *actual*
+//!    likelihood — so
 //!    time-to-event and categorical endpoints are integrated as faithfully as Gaussian
 //!    ones. That is what FOCE/FOCEI structurally cannot do, and why AGQ exists here.
 //!

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -81,9 +81,7 @@ use crate::estimation::importance_sampling::build_proposal;
 use crate::estimation::inner_optimizer::cacheable_schedule;
 use crate::pk;
 use crate::sens::provider::SubjectSens;
-use crate::stats::likelihood::{
-    individual_nll_into_prepared_with_schedule, individual_nll_into_with_schedule,
-};
+use crate::stats::likelihood::individual_nll_into_prepared_with_schedule;
 use crate::stats::util::log_sum_exp as logsumexp;
 use crate::types::{CompiledModel, HessianAnchor, ModelParameters, Population, Subject};
 
@@ -382,8 +380,50 @@ impl Stack {
         scratch: &mut pk::EventPkParams,
         schedule: Option<&pk::event_driven::EventSchedule>,
     ) -> f64 {
+        // Low-call-count sites (FD sweeps, single-node scoring): hoist nothing, just
+        // allocate scratch for this one call and dispatch through the shared branch.
+        let err_keys = (!self.is_iov()).then(|| model.error_spec.obs_keys(subject));
+        let ruv_mult = (!self.is_iov())
+            .then(|| model.ruv_obs_mult(subject, &params.theta))
+            .flatten();
+        self.nll_at_with_recycle(
+            model,
+            subject,
+            params,
+            b,
+            scratch,
+            schedule,
+            err_keys.as_deref(),
+            ruv_mult.as_deref(),
+            &mut Vec::new(),
+            &mut DVector::zeros(self.n_eta),
+            &mut DVector::zeros(self.n_eta),
+        )
+    }
+
+    /// Same dispatch as [`Stack::nll_at`], but takes the `err_keys`/`ruv_mult`/scratch as
+    /// caller-hoisted arguments instead of computing or allocating them per call. The hot
+    /// per-node sweep in [`agq_nodes_and_terms`] hoists these once for the whole grid (the
+    /// same hoist `node_nll_gradient` gets); routing both call shapes through this one
+    /// IOV/non-IOV branch keeps a single copy of the dispatch instead of two that must be
+    /// kept in sync.
+    #[allow(clippy::too_many_arguments)]
+    fn nll_at_with_recycle(
+        &self,
+        model: &CompiledModel,
+        subject: &Subject,
+        params: &ModelParameters,
+        b: &[f64],
+        scratch: &mut pk::EventPkParams,
+        schedule: Option<&pk::event_driven::EventSchedule>,
+        err_keys: Option<&[usize]>,
+        ruv_mult: Option<&[Vec<f64>]>,
+        pred_recycle: &mut Vec<f64>,
+        eta_work: &mut DVector<f64>,
+        prior_work: &mut DVector<f64>,
+    ) -> f64 {
         if !self.is_iov() {
-            return individual_nll_into_with_schedule(
+            return individual_nll_into_prepared_with_schedule(
                 model,
                 subject,
                 &params.theta,
@@ -395,6 +435,11 @@ impl Stack {
                 &params.residual_correlations,
                 scratch,
                 schedule,
+                err_keys.expect("non-IOV error keys"),
+                ruv_mult,
+                pred_recycle,
+                eta_work,
+                prior_work,
             );
         }
         let (eta, kappas) = self.split(b);
@@ -764,7 +809,9 @@ fn agq_nodes_and_terms(
     let mut step = vec![0.0f64; d];
     let mut b = vec![0.0f64; d];
     let err_keys = (!stack.is_iov()).then(|| model.error_spec.obs_keys(subject));
-    let ruv_mult = (!stack.is_iov()).then(|| model.ruv_obs_mult(subject, &params.theta));
+    let ruv_mult = (!stack.is_iov())
+        .then(|| model.ruv_obs_mult(subject, &params.theta))
+        .flatten();
     let mut pred_recycle = Vec::new();
     let mut eta_work = DVector::zeros(stack.n_eta);
     let mut prior_work = DVector::zeros(stack.n_eta);
@@ -785,45 +832,19 @@ fn agq_nodes_and_terms(
             b[k] = b_hat[k] + step[k];
         }
 
-        let nll = if stack.is_iov() {
-            let kappa_views: Vec<&[f64]> = (0..stack.n_occ)
-                .map(|occasion| {
-                    let start = stack.n_eta + occasion * stack.n_kappa;
-                    &b[start..start + stack.n_kappa]
-                })
-                .collect();
-            crate::stats::likelihood::individual_nll_iov_with_scratch(
-                model,
-                subject,
-                &params.theta,
-                &b[..stack.n_eta],
-                &kappa_views,
-                &params.omega,
-                params.omega_iov.as_ref(),
-                &params.sigma.values,
-                scratch,
-            )
-        } else {
-            individual_nll_into_prepared_with_schedule(
-                model,
-                subject,
-                &params.theta,
-                &b,
-                &params.omega,
-                &params.sigma.values,
-                &params.residual_correlations,
-                scratch,
-                schedule,
-                err_keys.as_ref().expect("non-IOV error keys").as_ref(),
-                ruv_mult
-                    .as_ref()
-                    .expect("non-IOV residual multiplier")
-                    .as_deref(),
-                &mut pred_recycle,
-                &mut eta_work,
-                &mut prior_work,
-            )
-        };
+        let nll = stack.nll_at_with_recycle(
+            model,
+            subject,
+            params,
+            &b,
+            scratch,
+            schedule,
+            err_keys.as_deref(),
+            ruv_mult.as_deref(),
+            &mut pred_recycle,
+            &mut eta_work,
+            &mut prior_work,
+        );
         // A diverged node returns `individual_nll`'s 1e20 sentinel, which lands here as a
         // ~−1e20 log-term — negligible under logsumexp unless *every* node diverged, in
         // which case the subject correctly reports the sentinel back.
@@ -1596,9 +1617,14 @@ fn grid_response_correction(
     // the whole per-node likelihood cost of the correction, paid once instead of `2·n_free`
     // times. `None` if any node is out of the inner provider's scope; the loop then takes the
     // `phi_grid` re-sweep for every coordinate (all-or-nothing, matching the anchor).
-    // Hoisted once for the whole sweep — see `node_nll_gradient`.
+    // Hoisted once for the whole sweep — see `node_nll_gradient`. The scratch buffers below
+    // are reused across every node instead of allocated fresh per call, the same hoist
+    // `mult`/`err_keys` already get (this loop runs up to `MAX_AGQ_GRID` times per subject).
     let mult = model.ruv_obs_mult(subject, &params.theta);
     let err_keys = model.error_spec.obs_keys(subject);
+    let mut obs_grad_recycle = Vec::new();
+    let mut eta_work = DVector::zeros(model.n_eta);
+    let mut prior_work = DVector::zeros(model.n_eta);
     let node_grads: Option<Vec<Vec<f64>>> = bs
         .iter()
         .map(|b| {
@@ -1611,6 +1637,9 @@ fn grid_response_correction(
                 schedule,
                 mult.as_deref(),
                 err_keys.as_ref(),
+                &mut obs_grad_recycle,
+                &mut eta_work,
+                &mut prior_work,
             )
         })
         .collect();
@@ -2070,6 +2099,7 @@ fn grid_z_at(j: usize, nodes: &[f64], d: usize, out: &mut [f64]) {
 /// `analytic_eta_nll_gradient` rebuilds the `EventSchedule` and recomputes the residual-magnitude
 /// multiplier on every call, which is per-call setup the inner BFGS loop already learned to
 /// hoist (#449 re-review #6); paying it per node made the sweep several times its own cost.
+#[allow(clippy::too_many_arguments)]
 fn node_nll_gradient(
     model: &CompiledModel,
     subject: &Subject,
@@ -2079,6 +2109,9 @@ fn node_nll_gradient(
     schedule: Option<&pk::event_driven::EventSchedule>,
     mult: Option<&[Vec<f64>]>,
     err_keys: &[usize],
+    obs_grad_recycle: &mut Vec<crate::sens::provider::ObsGrad>,
+    eta_work: &mut DVector<f64>,
+    prior_work: &mut DVector<f64>,
 ) -> Option<Vec<f64>> {
     if stack.is_iov() {
         let iov = params.omega_iov.as_ref()?;
@@ -2108,9 +2141,9 @@ fn node_nll_gradient(
             schedule,
             mult,
             err_keys,
-            &mut Vec::new(),
-            &mut nalgebra::DVector::zeros(model.n_eta),
-            &mut nalgebra::DVector::zeros(model.n_eta),
+            obs_grad_recycle,
+            eta_work,
+            prior_work,
         )
     }
 }
@@ -2779,6 +2812,9 @@ mod tests {
         .expect("base mode response");
         let mult = model.ruv_obs_mult(&subject, &params.theta);
         let err_keys = model.error_spec.obs_keys(&subject);
+        let mut obs_grad_recycle = Vec::new();
+        let mut eta_work = DVector::zeros(model.n_eta);
+        let mut prior_work = DVector::zeros(model.n_eta);
         let node_grads: Vec<Vec<f64>> = bs
             .iter()
             .map(|b| {
@@ -2791,6 +2827,9 @@ mod tests {
                     schedule.as_ref(),
                     mult.as_deref(),
                     err_keys.as_ref(),
+                    &mut obs_grad_recycle,
+                    &mut eta_work,
+                    &mut prior_work,
                 )
                 .expect("node gradient")
             })
@@ -3218,6 +3257,9 @@ mod tests {
                 .expect("mode response");
                 let mult = model.ruv_obs_mult(&subject, &params.theta);
                 let err_keys = model.error_spec.obs_keys(&subject);
+                let mut obs_grad_recycle = Vec::new();
+                let mut eta_work = DVector::zeros(model.n_eta);
+                let mut prior_work = DVector::zeros(model.n_eta);
                 let node_grads: Vec<Vec<f64>> = bs
                     .iter()
                     .map(|b| {
@@ -3230,6 +3272,9 @@ mod tests {
                             schedule.as_ref(),
                             mult.as_deref(),
                             err_keys.as_ref(),
+                            &mut obs_grad_recycle,
+                            &mut eta_work,
+                            &mut prior_work,
                         )
                         .expect("node gradient")
                     })

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -72,15 +72,18 @@
 //! which is the entire cost. Dimensionality is therefore bounded by [`MAX_AGQ_GRID`]
 //! instead, and a sparse (Smolyak) rule is the real answer for `d = 5..8` (issue #251).
 
-use nalgebra::DMatrix;
+use nalgebra::{DMatrix, DVector};
 use rayon::prelude::*;
 use std::f64::consts::PI;
+use std::sync::OnceLock;
 
 use crate::estimation::importance_sampling::build_proposal;
 use crate::estimation::inner_optimizer::cacheable_schedule;
 use crate::pk;
 use crate::sens::provider::SubjectSens;
-use crate::stats::likelihood::individual_nll_into_with_schedule;
+use crate::stats::likelihood::{
+    individual_nll_into_prepared_with_schedule, individual_nll_into_with_schedule,
+};
 use crate::stats::util::log_sum_exp as logsumexp;
 use crate::types::{CompiledModel, HessianAnchor, ModelParameters, Population, Subject};
 
@@ -88,6 +91,15 @@ use crate::types::{CompiledModel, HessianAnchor, ModelParameters, Population, Su
 /// the extreme nodes to round-off, and the marginal accuracy gain is nil for any realistic
 /// NLME integrand.
 pub const MAX_AGQ_NODES: usize = 21;
+
+static GAUSS_HERMITE_RULES: [OnceLock<(Vec<f64>, Vec<f64>)>; MAX_AGQ_NODES] =
+    [const { OnceLock::new() }; MAX_AGQ_NODES];
+
+fn cached_gauss_hermite(n: usize) -> (&'static [f64], &'static [f64]) {
+    assert!((1..=MAX_AGQ_NODES).contains(&n));
+    let (nodes, weights) = GAUSS_HERMITE_RULES[n - 1].get_or_init(|| gauss_hermite(n));
+    (nodes, weights)
+}
 
 /// Hard cap on the tensor-grid size `n_agq^n_eta`, enforced at model-check time by
 /// [`crate::api::check_model_options`]. The tensor rule costs one full likelihood
@@ -347,12 +359,12 @@ impl Stack {
     }
 
     /// Split `b` back into `(η, [κ₁ … κ_K])`.
-    fn split<'a>(&self, b: &'a [f64]) -> (&'a [f64], Vec<Vec<f64>>) {
+    fn split<'a>(&self, b: &'a [f64]) -> (&'a [f64], Vec<&'a [f64]>) {
         let eta = &b[..self.n_eta];
         let kappas = (0..self.n_occ)
             .map(|k| {
                 let s = self.n_eta + k * self.n_kappa;
-                b[s..s + self.n_kappa].to_vec()
+                &b[s..s + self.n_kappa]
             })
             .collect();
         (eta, kappas)
@@ -386,7 +398,7 @@ impl Stack {
             );
         }
         let (eta, kappas) = self.split(b);
-        crate::stats::likelihood::individual_nll_iov(
+        crate::stats::likelihood::individual_nll_iov_with_scratch(
             model,
             subject,
             &params.theta,
@@ -395,6 +407,7 @@ impl Stack {
             &params.omega,
             params.omega_iov.as_ref(),
             &params.sigma.values,
+            scratch,
         )
     }
 }
@@ -716,14 +729,13 @@ fn agq_subject_evaluate(
     }
 }
 
-/// Sweep the tensor grid once, returning each node's `η_j` and its log-term
-/// `t_j = Σ_k log w_{j,k} + ‖z_j‖² − nll(η_j)`.
+/// Sweep the tensor grid once, returning every log-term and, when `retain_nodes`
+/// is true, each node's `η_j`.
 ///
 /// The single place the grid is materialised. The objective ([`agq_subject_nll`]) reduces
 /// the terms with `logsumexp`; the gradient ([`agq_subject_packed_gradient`]) additionally
-/// needs the `η_j` themselves and turns the same terms into softmax weights. Sharing one
-/// sweep is what guarantees the gradient is differentiating the objective that was actually
-/// evaluated, rather than a grid that drifted from it.
+/// needs the `η_j` themselves and turns the same terms into softmax weights. Objective-only
+/// callers leave them unmaterialized, avoiding one heap allocation per quadrature point.
 #[allow(clippy::too_many_arguments)]
 fn agq_nodes_and_terms(
     model: &CompiledModel,
@@ -751,6 +763,11 @@ fn agq_nodes_and_terms(
     let mut z = vec![0.0f64; d];
     let mut step = vec![0.0f64; d];
     let mut b = vec![0.0f64; d];
+    let err_keys = (!stack.is_iov()).then(|| model.error_spec.obs_keys(subject));
+    let ruv_mult = (!stack.is_iov()).then(|| model.ruv_obs_mult(subject, &params.theta));
+    let mut pred_recycle = Vec::new();
+    let mut eta_work = DVector::zeros(stack.n_eta);
+    let mut prior_work = DVector::zeros(stack.n_eta);
 
     loop {
         let mut log_w = 0.0;
@@ -768,7 +785,45 @@ fn agq_nodes_and_terms(
             b[k] = b_hat[k] + step[k];
         }
 
-        let nll = stack.nll_at(model, subject, params, &b, scratch, schedule);
+        let nll = if stack.is_iov() {
+            let kappa_views: Vec<&[f64]> = (0..stack.n_occ)
+                .map(|occasion| {
+                    let start = stack.n_eta + occasion * stack.n_kappa;
+                    &b[start..start + stack.n_kappa]
+                })
+                .collect();
+            crate::stats::likelihood::individual_nll_iov_with_scratch(
+                model,
+                subject,
+                &params.theta,
+                &b[..stack.n_eta],
+                &kappa_views,
+                &params.omega,
+                params.omega_iov.as_ref(),
+                &params.sigma.values,
+                scratch,
+            )
+        } else {
+            individual_nll_into_prepared_with_schedule(
+                model,
+                subject,
+                &params.theta,
+                &b,
+                &params.omega,
+                &params.sigma.values,
+                &params.residual_correlations,
+                scratch,
+                schedule,
+                err_keys.as_ref().expect("non-IOV error keys").as_ref(),
+                ruv_mult
+                    .as_ref()
+                    .expect("non-IOV residual multiplier")
+                    .as_deref(),
+                &mut pred_recycle,
+                &mut eta_work,
+                &mut prior_work,
+            )
+        };
         // A diverged node returns `individual_nll`'s 1e20 sentinel, which lands here as a
         // ~−1e20 log-term — negligible under logsumexp unless *every* node diverged, in
         // which case the subject correctly reports the sentinel back.
@@ -916,7 +971,7 @@ pub fn agq_population_nll(
     n_nodes: usize,
     anchor: HessianAnchor,
 ) -> f64 {
-    let (nodes, weights) = gauss_hermite(n_nodes);
+    let (nodes, weights) = cached_gauss_hermite(n_nodes);
     let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
     let per_subject: Vec<f64> = population
         .subjects
@@ -932,7 +987,7 @@ pub fn agq_population_nll(
                 params,
                 &stack,
                 &b_hat,
-                &nodes,
+                nodes,
                 &log_weights,
                 anchor,
             )
@@ -2054,6 +2109,8 @@ fn node_nll_gradient(
             mult,
             err_keys,
             &mut Vec::new(),
+            &mut nalgebra::DVector::zeros(model.n_eta),
+            &mut nalgebra::DVector::zeros(model.n_eta),
         )
     }
 }
@@ -2351,7 +2408,7 @@ impl<'a> SubjectScoreContext<'a> {
         bounds: &'a crate::estimation::parameterization::PackedBounds,
         force_fd: bool,
     ) -> Self {
-        let (nodes, weights) = gauss_hermite(options.agq_nodes().expect("quadrature stage"));
+        let (nodes, weights) = cached_gauss_hermite(options.agq_nodes().expect("quadrature stage"));
         Self {
             model,
             template,
@@ -2359,7 +2416,7 @@ impl<'a> SubjectScoreContext<'a> {
             options,
             bounds,
             params: crate::estimation::parameterization::unpack_params(x, template),
-            nodes,
+            nodes: nodes.to_vec(),
             log_weights: weights.iter().map(|w| w.ln()).collect(),
             fixed: crate::estimation::parameterization::packed_fixed_mask(template),
             force_fd: force_fd || !analytic_gradient_available(model),
@@ -3782,6 +3839,17 @@ mod tests {
         for (got, want) in w.iter().zip([sp / 6.0, 2.0 * sp / 3.0, sp / 6.0]) {
             assert!((got - want).abs() < 1e-12, "weight {got} != {want}");
         }
+    }
+
+    #[test]
+    fn cached_gauss_hermite_reuses_the_exact_rule_storage() {
+        let (nodes_a, weights_a) = cached_gauss_hermite(3);
+        let (nodes_b, weights_b) = cached_gauss_hermite(3);
+        assert!(std::ptr::eq(nodes_a.as_ptr(), nodes_b.as_ptr()));
+        assert!(std::ptr::eq(weights_a.as_ptr(), weights_b.as_ptr()));
+        let (expected_nodes, expected_weights) = gauss_hermite(3);
+        assert_eq!(nodes_a, expected_nodes);
+        assert_eq!(weights_a, expected_weights);
     }
 
     /// Weights sum to `√π = ∫ e^{−x²} dx`, and the rule is exact for polynomials up to

--- a/src/estimation/agq_cov_hessian.rs
+++ b/src/estimation/agq_cov_hessian.rs
@@ -719,6 +719,8 @@ pub(crate) fn node_jet(
             core.mult.as_deref(),
             err_keys.as_ref(),
             &mut Vec::new(),
+            &mut DVector::zeros(model.n_eta),
+            &mut DVector::zeros(model.n_eta),
         )?
     };
     let parts = subject_cov_hessian_parts(model, subject, params, &sens, &prep, b);

--- a/src/estimation/agq_cov_hessian.rs
+++ b/src/estimation/agq_cov_hessian.rs
@@ -672,11 +672,15 @@ pub(crate) struct NodeJet {
 /// pins the mode case against #436 so a future mode-only assumption in `prepare` fails loudly.
 ///
 /// [`subject_cov_hessian_parts`]: super::sens_cov_hessian::subject_cov_hessian_parts
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn node_jet(
     model: &CompiledModel,
     subject: &Subject,
     params: &ModelParameters,
     b: &[f64],
+    obs_grad_recycle: &mut Vec<crate::sens::provider::ObsGrad>,
+    eta_work: &mut DVector<f64>,
+    prior_work: &mut DVector<f64>,
 ) -> Option<NodeJet> {
     use crate::estimation::inner_optimizer::analytic_eta_nll_gradient_with_schedule;
     use crate::estimation::sens_cov_hessian::{
@@ -718,9 +722,9 @@ pub(crate) fn node_jet(
             None,
             core.mult.as_deref(),
             err_keys.as_ref(),
-            &mut Vec::new(),
-            &mut DVector::zeros(model.n_eta),
-            &mut DVector::zeros(model.n_eta),
+            obs_grad_recycle,
+            eta_work,
+            prior_work,
         )?
     };
     let parts = subject_cov_hessian_parts(model, subject, params, &sens, &prep, b);
@@ -849,6 +853,11 @@ pub(crate) fn subject_agq_cov_hessian(
     let node_scale = anchor.node_scale();
     let mut u: Vec<Vec<f64>> = Vec::with_capacity(grid.len());
     let mut node_acc = DMatrix::<f64>::zeros(dim, dim);
+    // Reused across every grid node instead of allocated fresh per `node_jet` call — this
+    // loop runs once per quadrature node, same hoist as `agq::node_nll_gradient`.
+    let mut obs_grad_recycle = Vec::new();
+    let mut eta_work = DVector::zeros(n_eta);
+    let mut prior_work = DVector::zeros(n_eta);
 
     for (j, z) in grid.iter().enumerate() {
         if pi[j] == 0.0 {
@@ -861,7 +870,15 @@ pub(crate) fn subject_agq_cov_hessian(
             .iter()
             .copied()
             .collect();
-        let jet = node_jet(model, subject, params, &b_j)?;
+        let jet = node_jet(
+            model,
+            subject,
+            params,
+            &b_j,
+            &mut obs_grad_recycle,
+            &mut eta_work,
+            &mut prior_work,
+        )?;
 
         let beta: Vec<DVector<f64>> = (0..dim)
             .map(|zeta| node_displacement(&b_hat_d[zeta], &m_d[zeta], &zv))

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -1,9 +1,10 @@
 use crate::pk;
-#[cfg(test)]
-use crate::stats::likelihood::individual_nll_iov;
 use crate::stats::likelihood::{
-    individual_nll_into_with_schedule, individual_nll_iov_with_scratch, iov_occasion_groups,
+    individual_nll_into_prepared_with_schedule, individual_nll_iov_with_scratch,
+    iov_occasion_groups,
 };
+#[cfg(test)]
+use crate::stats::likelihood::{individual_nll_into_with_schedule, individual_nll_iov};
 use crate::types::*;
 use nalgebra::{DMatrix, DVector};
 use std::cell::RefCell;
@@ -872,11 +873,14 @@ pub fn find_ebe(
     // `df_deta` allocations in place instead of allocating one `Vec<f64>` per
     // observation on every call.
     let obs_grad_recycle = RefCell::new(Vec::<crate::sens::provider::ObsGrad>::new());
+    let pred_recycle = RefCell::new(Vec::<f64>::new());
+    let eta_work = RefCell::new(DVector::zeros(n_eta));
+    let prior_work = RefCell::new(DVector::zeros(n_eta));
 
     // Objective evaluated directly at eta_true (the optimiser variable).
     let obj = |e: &[f64]| -> f64 {
         let mut scratch = pk_scratch_cell.borrow_mut();
-        individual_nll_into_with_schedule(
+        individual_nll_into_prepared_with_schedule(
             model,
             subject,
             &params.theta,
@@ -890,6 +894,11 @@ pub fn find_ebe(
             &params.residual_correlations,
             &mut scratch,
             schedule.as_ref(),
+            err_keys.as_ref(),
+            mult.as_deref(),
+            &mut pred_recycle.borrow_mut(),
+            &mut eta_work.borrow_mut(),
+            &mut prior_work.borrow_mut(),
         )
     };
 
@@ -930,6 +939,8 @@ pub fn find_ebe(
             mult.as_deref(),
             err_keys.as_ref(),
             &mut obs_grad_recycle.borrow_mut(),
+            &mut eta_work.borrow_mut(),
+            &mut prior_work.borrow_mut(),
         ) {
             Some(g) => {
                 GRADIENT_TIMINGS.record_analytic(t0.elapsed().as_nanos() as u64);
@@ -2206,6 +2217,8 @@ pub(crate) fn analytic_eta_nll_gradient(
         mult.as_deref(),
         err_keys.as_ref(),
         &mut Vec::new(),
+        &mut DVector::zeros(model.n_eta),
+        &mut DVector::zeros(model.n_eta),
     )
 }
 
@@ -2246,6 +2259,8 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     mult: Option<&[Vec<f64>]>,
     err_keys: &[usize],
     obs_grad_recycle: &mut Vec<crate::sens::provider::ObsGrad>,
+    eta_work: &mut DVector<f64>,
+    prior_work: &mut DVector<f64>,
 ) -> Option<Vec<f64>> {
     // The inner NLL is `½(η'Ω⁻¹η + log|Ω| + data_gauss + 2·data_nonGaussian)`, so its
     // η-gradient is a plain **sum** of term gradients. Assemble the non-Gaussian block
@@ -2269,10 +2284,11 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
     // model for the provider to evaluate. The gradient is prior + non-Gaussian; return it
     // directly rather than asking a provider that has nothing to compute.
     if subject.obs_times.is_empty() {
-        let eta_v = nalgebra::DVector::from_column_slice(eta);
+        eta_work.as_mut_slice().copy_from_slice(eta);
+        prior_work.gemv(1.0, &omega.inv, eta_work, 0.0);
         // `mut` is only exercised by the markov CTMM fold below.
         #[cfg_attr(not(feature = "markov"), allow(unused_mut))]
-        let mut grad: Vec<f64> = (&omega.inv * &eta_v).as_slice().to_vec();
+        let mut grad: Vec<f64> = prior_work.as_slice().to_vec();
         #[cfg(feature = "markov")]
         if let Some(g) = &ctmm_grad {
             for (acc, gi) in grad.iter_mut().zip(g.iter()) {
@@ -2319,6 +2335,8 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
             &sens,
             mult,
             err_keys,
+            eta_work,
+            prior_work,
         )
         .map(add_nongaussian);
         *obs_grad_recycle = sens;
@@ -2385,10 +2403,10 @@ pub(crate) fn analytic_eta_nll_gradient_with_schedule(
         grad[r] += ruv_grad;
     }
     // Prior: ∂/∂η ½ η'Ω⁻¹η = Ω⁻¹η.
-    let eta_v = nalgebra::DVector::from_column_slice(eta);
-    let prior = &omega.inv * &eta_v;
+    eta_work.as_mut_slice().copy_from_slice(eta);
+    prior_work.gemv(1.0, &omega.inv, eta_work, 0.0);
     for (k, g) in grad.iter_mut().enumerate() {
-        *g += prior[k];
+        *g += prior_work[k];
     }
     let result = Some(add_nongaussian(grad));
     *obs_grad_recycle = sens;
@@ -2423,14 +2441,16 @@ fn dense_residual_inner_gradient(
     sens: &[crate::sens::provider::ObsGrad],
     mult: Option<&[Vec<f64>]>,
     err_keys: &[usize],
+    eta_work: &mut DVector<f64>,
+    prior_work: &mut DVector<f64>,
 ) -> Option<Vec<f64>> {
     use nalgebra::{DMatrix, DVector};
     let n_eta = model.n_eta;
-    let eta_v = DVector::from_column_slice(eta);
-    let prior = &omega.inv * &eta_v;
+    eta_work.as_mut_slice().copy_from_slice(eta);
+    prior_work.gemv(1.0, &omega.inv, eta_work, 0.0);
     let n_obs = sens.len();
     if n_obs == 0 {
-        return Some(prior.as_slice().to_vec());
+        return Some(prior_work.as_slice().to_vec());
     }
     let ipreds: Vec<f64> = sens.iter().map(|o| o.f).collect();
     let corr = residual_correlations;
@@ -2506,7 +2526,7 @@ fn dense_residual_inner_gradient(
         }
         // sᵀ ∂R/∂η_k s.
         let quad = s.dot(&(&dr_k * &s));
-        grad[k] = -term_a + 0.5 * (tr_mk - quad) + prior[k];
+        grad[k] = -term_a + 0.5 * (tr_mk - quad) + prior_work[k];
     }
     Some(grad)
 }

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -876,6 +876,11 @@ pub fn find_ebe(
     let pred_recycle = RefCell::new(Vec::<f64>::new());
     let eta_work = RefCell::new(DVector::zeros(n_eta));
     let prior_work = RefCell::new(DVector::zeros(n_eta));
+    // The analytic-gradient closure may fall back to finite differences, which
+    // re-enters `obj` while its own scratch borrows are live. Keep the two sets
+    // separate so that fallback remains re-entrant.
+    let grad_eta_work = RefCell::new(DVector::zeros(n_eta));
+    let grad_prior_work = RefCell::new(DVector::zeros(n_eta));
 
     // Objective evaluated directly at eta_true (the optimiser variable).
     let obj = |e: &[f64]| -> f64 {
@@ -897,8 +902,8 @@ pub fn find_ebe(
             err_keys.as_ref(),
             mult.as_deref(),
             &mut pred_recycle.borrow_mut(),
-            &mut eta_work.borrow_mut(),
-            &mut prior_work.borrow_mut(),
+            &mut grad_eta_work.borrow_mut(),
+            &mut grad_prior_work.borrow_mut(),
         )
     };
 

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -874,11 +874,16 @@ pub fn find_ebe(
     // observation on every call.
     let obs_grad_recycle = RefCell::new(Vec::<crate::sens::provider::ObsGrad>::new());
     let pred_recycle = RefCell::new(Vec::<f64>::new());
+    // `obj`'s own scratch.
     let eta_work = RefCell::new(DVector::zeros(n_eta));
     let prior_work = RefCell::new(DVector::zeros(n_eta));
-    // The analytic-gradient closure may fall back to finite differences, which
-    // re-enters `obj` while its own scratch borrows are live. Keep the two sets
-    // separate so that fallback remains re-entrant.
+    // `agrad`'s scratch for its analytic-gradient call, kept separate from `obj`'s above.
+    // The `match analytic_eta_nll_gradient_with_schedule(...) { ... }` below has its
+    // scrutinee's `&mut …borrow_mut()` temporaries live for the *whole* match — including
+    // the `None` arm, which calls `gradient_fd(&obj, ..)` and so re-enters `obj` while
+    // those borrows are still outstanding. Sharing one RefCell pair between `obj` and
+    // `agrad` would panic there with "already borrowed"; separate cells keep the fallback
+    // re-entrant.
     let grad_eta_work = RefCell::new(DVector::zeros(n_eta));
     let grad_prior_work = RefCell::new(DVector::zeros(n_eta));
 
@@ -902,8 +907,8 @@ pub fn find_ebe(
             err_keys.as_ref(),
             mult.as_deref(),
             &mut pred_recycle.borrow_mut(),
-            &mut grad_eta_work.borrow_mut(),
-            &mut grad_prior_work.borrow_mut(),
+            &mut eta_work.borrow_mut(),
+            &mut prior_work.borrow_mut(),
         )
     };
 
@@ -944,8 +949,8 @@ pub fn find_ebe(
             mult.as_deref(),
             err_keys.as_ref(),
             &mut obs_grad_recycle.borrow_mut(),
-            &mut eta_work.borrow_mut(),
-            &mut prior_work.borrow_mut(),
+            &mut grad_eta_work.borrow_mut(),
+            &mut grad_prior_work.borrow_mut(),
         ) {
             Some(g) => {
                 GRADIENT_TIMINGS.record_analytic(t0.elapsed().as_nanos() as u64);

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -158,6 +158,8 @@ mod ctmm_inner {
                 None,
                 err_keys.as_ref(),
                 &mut Vec::new(),
+                &mut nalgebra::DVector::zeros(model.n_eta),
+                &mut nalgebra::DVector::zeros(model.n_eta),
             )
             .expect("endpoint-only CTMM is in analytic scope");
 

--- a/src/estimation/sens_cov_hessian.rs
+++ b/src/estimation/sens_cov_hessian.rs
@@ -3684,7 +3684,16 @@ mod tests {
         let bad = DVector::from_column_slice(&eta)
             + std::f64::consts::SQRT_2 * anchor.node_scale() * DVector::from_column_slice(&tail);
         assert!(
-            node_jet(&model, &s, p, bad.as_slice()).is_none(),
+            node_jet(
+                &model,
+                &s,
+                p,
+                bad.as_slice(),
+                &mut Vec::new(),
+                &mut DVector::zeros(model.n_eta),
+                &mut DVector::zeros(model.n_eta),
+            )
+            .is_none(),
             "tail fixture must be outside the provider's scope"
         );
         // Include a zero-weight tail before AND after the live node to pin alignment.
@@ -3867,7 +3876,16 @@ mod tests {
             // identical plain fixture must remain supported.
             let supported = magnitude.is_none();
             assert_eq!(
-                node_jet(&model, &subject, params, &eta).is_some(),
+                node_jet(
+                    &model,
+                    &subject,
+                    params,
+                    &eta,
+                    &mut Vec::new(),
+                    &mut DVector::zeros(model.n_eta),
+                    &mut DVector::zeros(model.n_eta),
+                )
+                .is_some(),
                 supported
             );
             assert_eq!(
@@ -3962,7 +3980,16 @@ mod tests {
         params.theta = theta;
         let eta = precise_ebe(&model, &subject, &params);
 
-        let jet = node_jet(&model, &subject, &params, &eta).expect("warfarin is in scope");
+        let jet = node_jet(
+            &model,
+            &subject,
+            &params,
+            &eta,
+            &mut Vec::new(),
+            &mut DVector::zeros(model.n_eta),
+            &mut DVector::zeros(model.n_eta),
+        )
+        .expect("warfarin is in scope");
 
         // Stationarity: the mode's inner gradient vanishes, to the inner tolerance.
         for i in 0..model.n_eta {

--- a/src/pk/mod.rs
+++ b/src/pk/mod.rs
@@ -1246,12 +1246,12 @@ pub fn predict_iov(
 /// IOV predictions with caller-owned per-event parameter storage. Every event
 /// is still evaluated at its current theta, eta, kappa, covariates and time;
 /// only allocation capacity is reused, never numerical values.
-pub(crate) fn predict_iov_with_scratch(
+pub(crate) fn predict_iov_with_scratch<K: AsRef<[f64]>>(
     model: &CompiledModel,
     subject: &Subject,
     theta: &[f64],
     eta_bsv: &[f64],
-    kappas: &[Vec<f64>],
+    kappas: &[K],
     scratch: &mut EventPkParams,
 ) -> Vec<f64> {
     use std::collections::HashMap;
@@ -1294,7 +1294,7 @@ pub(crate) fn predict_iov_with_scratch(
         let mut c = Vec::with_capacity(eta_bsv.len() + n_kappa);
         c.extend_from_slice(eta_bsv);
         match occ_to_k.get(&occ_id) {
-            Some(&k) if k < kappas.len() => c.extend_from_slice(&kappas[k]),
+            Some(&k) if k < kappas.len() => c.extend_from_slice(kappas[k].as_ref()),
             _ => c.extend(std::iter::repeat(0.0).take(n_kappa)),
         }
         c
@@ -2349,6 +2349,19 @@ pub fn compute_predictions_with_states(
 /// Uses analytical equations for standard PK models, or delegates to ODE solver
 /// when an OdeSpec is provided.
 pub fn compute_predictions(pk_model: PkModel, subject: &Subject, pk_params: &PkParams) -> Vec<f64> {
+    compute_predictions_recycle(pk_model, subject, pk_params, Vec::new())
+}
+
+/// Allocation-reusing counterpart of [`compute_predictions`] for repeated
+/// evaluations of the same subject. The ordinary static superposition path
+/// overwrites `out` in place; event-driven fallbacks retain their established
+/// owned-vector implementation.
+fn compute_predictions_recycle(
+    pk_model: PkModel,
+    subject: &Subject,
+    pk_params: &PkParams,
+    mut out: Vec<f64>,
+) -> Vec<f64> {
     // Defensive guard (#324/#394): modeled-RATE doses (RATE=-2 -> D{cmt}) must be
     // resolved to a concrete (`Fixed`) rate/duration *before* reaching this closed
     // form. The analytical dispatch paths do exactly that (`api::model_preds` and
@@ -2398,11 +2411,14 @@ pub fn compute_predictions(pk_model: PkModel, subject: &Subject, pk_params: &PkP
             &pk_pk_only,
         );
     }
-    subject
-        .obs_times
-        .iter()
-        .map(|&t| predict_concentration(pk_model, &subject.doses, t, pk_params))
-        .collect()
+    out.clear();
+    out.extend(
+        subject
+            .obs_times
+            .iter()
+            .map(|&t| predict_concentration(pk_model, &subject.doses, t, pk_params)),
+    );
+    out
 }
 
 /// True when any dose targets a compartment the **dose-superposition** dispatch
@@ -2647,6 +2663,29 @@ pub fn compute_predictions_with_tv_into_with_schedule(
     scratch: &mut EventPkParams,
     schedule: Option<&event_driven::EventSchedule>,
 ) -> Vec<f64> {
+    compute_predictions_with_tv_recycle_with_schedule(
+        model,
+        subject,
+        theta,
+        eta,
+        scratch,
+        schedule,
+        Vec::new(),
+    )
+}
+
+/// Inner-loop counterpart of [`compute_predictions_with_tv_into_with_schedule`]
+/// that reuses the returned observation vector on allocation-sensitive repeated
+/// evaluations of one subject.
+pub(crate) fn compute_predictions_with_tv_recycle_with_schedule(
+    model: &crate::types::CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    scratch: &mut EventPkParams,
+    schedule: Option<&event_driven::EventSchedule>,
+    mut recycled: Vec<f64>,
+) -> Vec<f64> {
     // #905: on an analytical model, a subject with no Gaussian observation feeds the
     // PK predictor nothing — every hazard left here is closed-form and no
     // binary/CTMM linear predictor reads a concentration (see
@@ -2662,7 +2701,9 @@ pub fn compute_predictions_with_tv_into_with_schedule(
     // subject is gated — correctly, it feeds the predictor nothing like any other
     // no-Gaussian-obs subject.
     if model.ode_spec.is_none() && !subject_feeds_analytical_pk(model, subject) {
-        return vec![f64::NAN; subject.obs_times.len()];
+        recycled.clear();
+        recycled.resize(subject.obs_times.len(), f64::NAN);
+        return recycled;
     }
     // A `one_cpt_transit` subject that the closed form can't serve (TIME switch / TV
     // covariates) routes to the exact ODE `transit()` equivalent, which takes the ODE branch
@@ -2678,7 +2719,9 @@ pub fn compute_predictions_with_tv_into_with_schedule(
         // prediction. These zeros are never read: `apply_analytic_readout` builds
         // an empty `state[]` for such a model (no `central = conc × V` step) and
         // overwrites every entry with the readout's value.
-        vec![0.0; subject.obs_times.len()]
+        recycled.clear();
+        recycled.resize(subject.obs_times.len(), 0.0);
+        recycled
     } else if let Some(ref ode) = model.ode_spec {
         // ODE path. Resets (EVID=3/4) need the state-propagating event-driven
         // walker too, even without time-varying covariates — the plain
@@ -2775,7 +2818,7 @@ pub fn compute_predictions_with_tv_into_with_schedule(
         // Resolve any modeled-`RATE` doses (#394) before the closed-form math.
         let resolved =
             crate::dosing::resolve_subject_doses(subject, model.active_dose_attr_map(), &pk.values);
-        compute_predictions(model.pk_model, &resolved, &pk)
+        compute_predictions_recycle(model.pk_model, &resolved, &pk, recycled)
     };
 
     // Analytical initial-compartment amounts (issue #521): layer the closed-form

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -27,28 +27,6 @@ fn model_predictions(
     pk::compute_predictions_with_tv(model, subject, theta, eta)
 }
 
-/// Caller-owned-scratch variant of [`model_predictions`] that also
-/// accepts an optional pre-built
-/// [`pk::event_driven::EventSchedule`]. Used by FOCE inner-loop callers
-/// (BFGS line search, post-convergence eval) that build the schedule
-/// once per `find_ebe` call and reuse it across many `(theta, eta)`
-/// evaluations of the same subject. SAEM and other callers pass `None`
-/// — the no-TV fast path doesn't consume the schedule, and the
-/// dispatcher falls back to building one on demand on the TV path.
-#[inline]
-fn model_predictions_into_with_schedule(
-    model: &CompiledModel,
-    subject: &Subject,
-    theta: &[f64],
-    eta: &[f64],
-    scratch: &mut pk::EventPkParams,
-    schedule: Option<&pk::event_driven::EventSchedule>,
-) -> Vec<f64> {
-    pk::compute_predictions_with_tv_into_with_schedule(
-        model, subject, theta, eta, scratch, schedule,
-    )
-}
-
 #[inline]
 pub(crate) fn m3_logcdf(limit: f64, f: f64, sd: f64, cens: i8) -> f64 {
     let z = if cens < 0 {
@@ -513,6 +491,49 @@ pub fn individual_nll_into_with_schedule(
     scratch: &mut pk::EventPkParams,
     schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> f64 {
+    let err_keys = model.error_spec.obs_keys(subject);
+    let ruv_mult = model.ruv_obs_mult(subject, theta);
+    let mut pred_recycle = Vec::new();
+    let mut eta_work = DVector::zeros(eta.len());
+    let mut prior_work = DVector::zeros(eta.len());
+    individual_nll_into_prepared_with_schedule(
+        model,
+        subject,
+        theta,
+        eta,
+        omega,
+        sigma_values,
+        residual_correlations,
+        scratch,
+        schedule,
+        err_keys.as_ref(),
+        ruv_mult.as_deref(),
+        &mut pred_recycle,
+        &mut eta_work,
+        &mut prior_work,
+    )
+}
+
+/// Inner-loop form of [`individual_nll_into_with_schedule`] with subject-static
+/// residual dispatch and magnitude inputs prepared by the caller, plus a
+/// caller-owned prediction vector reused across objective evaluations.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn individual_nll_into_prepared_with_schedule(
+    model: &CompiledModel,
+    subject: &Subject,
+    theta: &[f64],
+    eta: &[f64],
+    omega: &OmegaMatrix,
+    sigma_values: &[f64],
+    residual_correlations: &[ResidualCorrelation],
+    scratch: &mut pk::EventPkParams,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+    err_keys: &[usize],
+    ruv_mult: Option<&[Vec<f64>]>,
+    pred_recycle: &mut Vec<f64>,
+    eta_work: &mut DVector<f64>,
+    prior_work: &mut DVector<f64>,
+) -> f64 {
     // Ω⁻¹ and log|Ω| are pre-computed in `OmegaMatrix::from_matrix_*`.
     // Hot-path users (FOCE inner BFGS, SAEM MH) call this 100s–1000s of
     // times per subject per outer iter — recomputing Cholesky+inverse
@@ -522,12 +543,10 @@ pub fn individual_nll_into_with_schedule(
     }
     let omega_inv = &omega.inv;
     let log_det_omega = omega.log_det;
-    // #658: per-observation residual endpoint keys (covariate selector or CMT).
-    let err_keys = model.error_spec.obs_keys(subject);
-
     // Eta prior: eta' * Omega_inv * eta
-    let eta_vec = DVector::from_column_slice(eta);
-    let eta_prior = eta_vec.dot(&(omega_inv * &eta_vec));
+    eta_work.as_mut_slice().copy_from_slice(eta);
+    prior_work.gemv(1.0, omega_inv, eta_work, 0.0);
+    let eta_prior = eta_work.dot(prior_work);
 
     // #570: a joint PK-TTE subject otherwise integrates the augmented PK+CHZ system
     // twice per eval (Gaussian preds, then `ode_cumhaz_hazard` for `H`/`h`). When the
@@ -541,11 +560,27 @@ pub fn individual_nll_into_with_schedule(
     // on the no-TV fast path).
     #[cfg(feature = "survival")]
     let preds = match &joint_share {
-        Some(s) => s.preds.clone(),
-        None => model_predictions_into_with_schedule(model, subject, theta, eta, scratch, schedule),
+        Some(s) => {
+            pred_recycle.clear();
+            pred_recycle.extend_from_slice(&s.preds);
+            pred_recycle
+        }
+        None => {
+            let hint = std::mem::take(pred_recycle);
+            *pred_recycle = pk::compute_predictions_with_tv_recycle_with_schedule(
+                model, subject, theta, eta, scratch, schedule, hint,
+            );
+            pred_recycle
+        }
     };
     #[cfg(not(feature = "survival"))]
-    let preds = model_predictions_into_with_schedule(model, subject, theta, eta, scratch, schedule);
+    let preds = {
+        let hint = std::mem::take(pred_recycle);
+        *pred_recycle = pk::compute_predictions_with_tv_recycle_with_schedule(
+            model, subject, theta, eta, scratch, schedule, hint,
+        );
+        pred_recycle
+    };
     // For SDE models, compute per-observation EKF process-noise variance and
     // add it to the residual variance to form V_total.
     let p_obs = if model.is_sde() {
@@ -558,10 +593,6 @@ pub fn individual_nll_into_with_schedule(
     // Does not touch FREM covariate pseudo-observations (handled below before
     // this factor is applied) or the EKF process noise `p_obs`.
     let ruv_scale = model.residual_var_scale(eta);
-    // Per-observation custom residual magnitude (#484), evaluated once here (it
-    // is η-independent) and shared with the diagonal and dense paths so the EBE
-    // objective matches the outer OFV's variance.
-    let ruv_mult = model.ruv_obs_mult(subject, theta);
     let mut data_ll = 0.0;
     let has_censored_m3 =
         matches!(model.bloq_method, BloqMethod::M3) && subject.has_censored_observation();
@@ -575,7 +606,7 @@ pub fn individual_nll_into_with_schedule(
             residual_correlations,
             ruv_scale,
             &p_obs,
-            ruv_mult.as_deref(),
+            ruv_mult,
         ) {
             Some(term) => data_ll += term,
             None => return 1e20,
@@ -617,7 +648,7 @@ pub fn individual_nll_into_with_schedule(
                 err_keys[j],
                 f_pred,
                 sigma_values,
-                ruv_mult.as_ref().map(|m| m[j].as_slice()),
+                ruv_mult.and_then(|m| m.get(j)).map(Vec::as_slice),
             ) * ruv_scale;
             let v = v_resid + p_obs.get(j).copied().unwrap_or(0.0);
             let cens = subject.cens.get(j).copied().unwrap_or(0);
@@ -915,11 +946,6 @@ fn ekf_p_obs(
         |f_pred| crate::stats::residual_error::residual_variance(error_model, f_pred, sigma_values),
     );
     p_obs
-}
-
-/// Log-determinant of Omega via Cholesky: log|Omega| = 2 * sum(log(L_ii))
-fn omega_log_det(omega: &OmegaMatrix) -> f64 {
-    chol_log_det(&omega.chol)
 }
 
 /// FOCE per-subject negative log-likelihood.
@@ -2516,12 +2542,12 @@ pub fn individual_nll_iov(
 /// Inner-loop sibling that retains per-event PK buffer capacity across trial
 /// eta/kappa values. The public convenience function keeps its original API.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn individual_nll_iov_with_scratch(
+pub(crate) fn individual_nll_iov_with_scratch<K: AsRef<[f64]>>(
     model: &CompiledModel,
     subject: &Subject,
     theta: &[f64],
     eta: &[f64],
-    kappas: &[Vec<f64>],
+    kappas: &[K],
     omega: &OmegaMatrix,
     omega_iov: Option<&OmegaMatrix>,
     sigma_values: &[f64],
@@ -2532,29 +2558,22 @@ pub(crate) fn individual_nll_iov_with_scratch(
     }
 
     // BSV eta prior
-    let omega_inv = match omega.matrix.clone().cholesky() {
-        Some(chol) => chol.inverse(),
-        None => return 1e20,
-    };
-    let log_det_omega = omega_log_det(omega);
+    let omega_inv = &omega.inv;
+    let log_det_omega = omega.log_det;
     let eta_vec = DVector::from_column_slice(eta);
-    let eta_prior = eta_vec.dot(&(&omega_inv * &eta_vec));
+    let eta_prior = eta_vec.dot(&(omega_inv * &eta_vec));
 
     // Kappa priors and IOV log-det
     let (iov_inv, log_det_iov) = if let Some(iov) = omega_iov {
-        let inv = match iov.matrix.clone().cholesky() {
-            Some(chol) => chol.inverse(),
-            None => return 1e20,
-        };
-        (inv, omega_log_det(iov))
+        (&iov.inv, iov.log_det)
     } else {
-        (DMatrix::identity(1, 1), 0.0) // unreachable when kappas non-empty
+        return 1e20;
     };
 
     let mut kappa_prior = 0.0;
     for kap in kappas {
-        let kap_vec = DVector::from_column_slice(kap);
-        kappa_prior += kap_vec.dot(&(&iov_inv * &kap_vec));
+        let kap_vec = DVector::from_column_slice(kap.as_ref());
+        kappa_prior += kap_vec.dot(&(iov_inv * &kap_vec));
     }
     let k_occasions = kappas.len();
 
@@ -2810,6 +2829,54 @@ mod tests {
         let nonmem_ofv = 0.691_015_142_109_431_8;
         let ferx_ofv = -4.0 * upper;
         assert!((ferx_ofv - nonmem_ofv).abs() < 1e-6);
+    }
+
+    #[test]
+    fn prepared_inner_nll_reuse_is_bit_identical() {
+        let model = make_model();
+        let subject = make_simple_subject();
+        let theta = [5.0, 50.0];
+        let eta = [0.17];
+        let omega = make_omega(0.09);
+        let sigma = [0.05];
+        let expected = individual_nll_into_with_schedule(
+            &model,
+            &subject,
+            &theta,
+            &eta,
+            &omega,
+            &sigma,
+            &[],
+            &mut pk::EventPkParams::default(),
+            None,
+        );
+
+        let err_keys = model.error_spec.obs_keys(&subject);
+        let mult = model.ruv_obs_mult(&subject, &theta);
+        let mut event_scratch = pk::EventPkParams::default();
+        let mut predictions = vec![-999.0; subject.obs_times.len()];
+        let mut eta_work = DVector::from_element(model.n_eta, -999.0);
+        let mut prior_work = DVector::from_element(model.n_eta, -999.0);
+        let reused = individual_nll_into_prepared_with_schedule(
+            &model,
+            &subject,
+            &theta,
+            &eta,
+            &omega,
+            &sigma,
+            &[],
+            &mut event_scratch,
+            None,
+            err_keys.as_ref(),
+            mult.as_deref(),
+            &mut predictions,
+            &mut eta_work,
+            &mut prior_work,
+        );
+
+        assert_eq!(expected.to_bits(), reused.to_bits());
+        assert_eq!(predictions.len(), subject.obs_times.len());
+        assert!(predictions.iter().all(|v| v.is_finite()));
     }
 
     #[test]
@@ -3071,6 +3138,19 @@ mod tests {
             Some(&omega_iov),
             &sigma,
         );
+        let borrowed: Vec<&[f64]> = kappas.iter().map(Vec::as_slice).collect();
+        let reused = individual_nll_iov_with_scratch(
+            &model,
+            &subj,
+            &theta,
+            &eta,
+            &borrowed,
+            &omega,
+            Some(&omega_iov),
+            &sigma,
+            &mut pk::EventPkParams::default(),
+        );
+        assert_eq!(iov.to_bits(), reused.to_bits());
         // Kappa prior is positive → IOV NLL should differ from base
         assert!(
             (iov - base).abs() > 1e-6,

--- a/src/stats/likelihood.rs
+++ b/src/stats/likelihood.rs
@@ -2567,6 +2567,14 @@ pub(crate) fn individual_nll_iov_with_scratch<K: AsRef<[f64]>>(
     let (iov_inv, log_det_iov) = if let Some(iov) = omega_iov {
         (&iov.inv, iov.log_det)
     } else {
+        // Guaranteed unreachable: the only caller path that admits `omega_iov: None` is
+        // `kappas.is_empty()`, which returns above before this point. `1e20` is a defensive
+        // sentinel, not a real score — loud in debug/test builds so a future caller that
+        // violates the invariant fails here rather than silently scoring a fabricated NLL.
+        debug_assert!(
+            false,
+            "individual_nll_iov_with_scratch: omega_iov is None with kappas non-empty"
+        );
         return 1e20;
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -592,7 +592,6 @@ impl DoseAttr {
     /// ODE-only) and on the compartment existing. `alag` and `lagtime` both map
     /// to [`DoseAttr::Lag`], matching the existing bare `alag`/`lagtime` aliases.
     pub fn from_indexed_name(name: &str) -> Option<(DoseAttr, usize)> {
-        let lower = name.to_ascii_lowercase();
         // The prefixes are mutually exclusive — no name starts with two of them,
         // and none is a prefix of another (`lagtime`/`alag`/`f`/`d`/`r` all differ
         // in their first byte except the two lag aliases, which are disjoint) — so
@@ -604,7 +603,11 @@ impl DoseAttr {
             ("d", DoseAttr::Duration),
             ("r", DoseAttr::Rate),
         ] {
-            if let Some(suffix) = lower.strip_prefix(prefix) {
+            let Some(head) = name.get(..prefix.len()) else {
+                continue;
+            };
+            if head.eq_ignore_ascii_case(prefix) {
+                let suffix = &name[prefix.len()..];
                 // The suffix must be a pure positive integer; `f_bio`, `cl`, etc.
                 // (non-numeric or empty suffixes) are not attributes.
                 if !suffix.is_empty() && suffix.bytes().all(|b| b.is_ascii_digit()) {
@@ -4784,8 +4787,7 @@ impl CompiledModel {
             return true;
         }
         self.indiv_param_names.iter().any(|n| {
-            let u = n.to_uppercase();
-            u == "F"
+            n.eq_ignore_ascii_case("F")
                 || (self.ode_spec.is_some()
                     && matches!(DoseAttr::from_indexed_name(n), Some((DoseAttr::F, _))))
         })


### PR DESCRIPTION
## Why
FOCE-family inner objectives and AGQ grids repeatedly allocate subject-sized prediction/prior buffers and rebuild invariant metadata. IOV AGQ additionally copied every occasion vector and recomputed cached covariance inverses at every node.

## What changed
- Reuse prediction and prior-matrix scratch across EBE objective/gradient evaluations.
- Reuse static analytical prediction output capacity.
- Reuse AGQ node NLL scratch and cache invariant Gauss-Hermite rules.
- Borrow IOV kappa slices and use cached Omega inverses/log-determinants.
- Remove allocation from indexed dose-attribute and bioavailability name checks.

## Alternatives considered
A broader dense-BFGS rewrite was benchmarked and discarded because it was neutral-to-negative. Current main independently contains the validated optimizer scratch implementation; this PR is additive to it.

## Cross-repo dependency
| Repo | PR | Status | Must merge |
|------|----|--------|------------|
| ferx (R) | — | not needed | — |

## Breaking changes
- [x] None

## Numerical validation
- [x] Compared against current `main` with the same `ci-fast` profile and one Rayon thread.
- [x] All 40 runs per arm reproduced the same displayed OFV and outer iteration count: FOCE −280.3640 / 67; FOCEI −234.2689 / 94; Laplace −285.9702 / 37; AGQ −285.9739 / 37.
- [x] A full Warfarin FOCE output comparison was identical for parameters and sdtab; only timing fields differed.

## Performance
40 interleaved A/B pairs per estimator, `ci-fast`, `RAYON_NUM_THREADS=1`, current `main` versus PR head. Speedup is `(main − PR) / main`. Bootstrap intervals are 95% intervals for the mean of the paired percentage speedups (10,000 resamples).

| Estimator | main median | PR median | median speedup | paired mean speedup (95% CI) |
|---|---:|---:|---:|---:|
| FOCE | 0.490180 s | 0.481353 s | 1.80% | 5.31% (1.19%, 9.44%) |
| FOCEI | 0.382070 s | 0.375719 s | 1.66% | 1.01% (−5.79%, 6.96%) |
| Laplace | 0.376595 s | 0.362636 s | 3.71% | 0.58% (−2.93%, 3.89%) |
| AGQ | 0.402073 s | 0.395743 s | 1.57% | 5.33% (1.04%, 8.95%) |

FOCE and AGQ have positive paired intervals. FOCEI and Laplace have positive medians but their wall-time intervals cross zero on this small fixture, so this PR does not claim a statistically resolved timing win for those two.

Deterministic allocation instrumentation used the same current-`main` and PR builds. The analytical fixture exercises the shared FOCE/FOCEI/Laplace/AGQ inner path; the IOV fixture additionally exercises borrowed kappa storage and cached covariance data.

| Fixture | main allocation calls | PR allocation calls | reduction | main requested bytes | PR requested bytes | reduction |
|---|---:|---:|---:|---:|---:|---:|
| Analytical | 363,983 | 206,468 | 43.28% | 20,842,937 | 14,736,092 | 29.30% |
| IOV | 3,709,126 | 3,275,283 | 11.70% | 631,641,248 | 562,017,713 | 11.02% |

## Tests
- [x] Unit regression coverage added for reused NLL storage, borrowed IOV slices, and cached Hermite storage.
- [x] Compile, format, clippy, rustdoc, public-API, release-semantics, and TTE/CTMM coverage checks pass.
- [ ] Post-fix core coverage rerun is still in progress.

## Example (user-facing features only)
- [x] Not applicable (internal performance work; no API or behavior change)

## Docs
- [x] `CHANGELOG.md` performance entry added.
- [x] No user-visible behavior or documentation surface changed.

## Checklist
- [ ] Required CI/preflight-equivalent checks pending core coverage completion.
- [x] Dual2 formulas are unchanged; only f64 prediction/likelihood storage changed.
- [x] Cargo.toml version bump not needed

## Docs & examples
- [x] No DSL, fit-option, example, or data changes.
- [x] No example execution step needed beyond numerical regression runs.

## Reviewer hints
The subtle points are re-entrant buffer ownership across optimizer closures, bit-identical prior multiplication, and IOV borrowed-slice lifetimes.

## Open questions
None.
