### PR TITLE
perf(estimation): cache per-subject EventSchedule across outer-loop evaluations [closes #1345]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,19 @@ section of the SDLC for the versioning policy).
 
 ### Performance
 
+- **FOCEI, Laplace, and `focei` with `n_agq > 1` now build each subject's `EventSchedule`
+  once per outer-loop evaluation instead of once per subject per AGQ node/gradient call.**
+  `cacheable_schedule` gates this on time-varying covariates or `EVID=3/4` resets (its
+  guard is otherwise unchanged), so a fit with only baseline covariates and no resets never
+  allocated a cacheable schedule in the first place and sees no change. Verified bit-identical
+  OFVs against `main` across every configuration tested. Measured on `ci-fast`, single Rayon
+  thread: no resolvable difference on the 24-subject/2-occasion-per-subject Schnider propofol
+  fixture (`tests/schnider_propofol_nonmem.rs`), where schedule construction is a small share
+  of per-eval cost; a synthetic 40-subject/15-occasion-per-subject stress fixture (built to
+  amplify per-subject schedule-construction cost) showed a modest, directionally consistent
+  ~3–6% wall-clock reduction across FOCEI, Laplace, and `focei`+AGQ(n=3). No claim is made
+  beyond that stress scenario (#1345).
+
 - **FOCE, FOCEI, Laplace, and AGQ now reuse prediction and prior-matrix storage across
   repeated conditional-likelihood evaluations.** AGQ also caches invariant Hermite rules;
   IOV quadrature borrows occasion effects and uses the covariance inverses already cached in

--- a/src/estimation/agq.rs
+++ b/src/estimation/agq.rs
@@ -653,6 +653,7 @@ fn anchor_hessian(
 /// re-optimise it, it only lays the grid around it. `nodes`/`log_weights` are the 1-D
 /// Gauss–Hermite rule, hoisted by the caller so the eigenproblem is solved once per
 /// population rather than once per subject.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn agq_subject_nll(
     model: &CompiledModel,
     subject: &Subject,
@@ -662,6 +663,7 @@ pub(crate) fn agq_subject_nll(
     nodes: &[f64],
     log_weights: &[f64],
     anchor: HessianAnchor,
+    schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> f64 {
     agq_subject_evaluate(
         model,
@@ -673,10 +675,17 @@ pub(crate) fn agq_subject_nll(
         log_weights,
         anchor,
         false,
+        schedule,
     )
     .0
 }
 
+/// Same as the body [`agq_subject_nll`] delegates to, but `schedule` is now a caller-supplied
+/// parameter instead of a fresh [`cacheable_schedule`] rebuild on every call — see
+/// [`crate::estimation::inner_optimizer::build_schedule_cache`]. It depends only on
+/// `model` + `subject`, so the two population-level callers ([`agq_population_nll`],
+/// [`agq_population_evaluate`]) build the cache once per outer-loop evaluation and hand each
+/// subject its entry, rather than every subject re-walking its own dose/event timeline.
 #[allow(clippy::too_many_arguments)]
 fn agq_subject_evaluate(
     model: &CompiledModel,
@@ -688,23 +697,16 @@ fn agq_subject_evaluate(
     log_weights: &[f64],
     anchor: HessianAnchor,
     retain_gradient_work: bool,
+    schedule: Option<&pk::event_driven::EventSchedule>,
 ) -> (f64, Option<PreparedGrid>) {
     let d = stack.d();
     let mut scratch = pk::EventPkParams::with_capacity_for(subject);
-    let schedule = cacheable_schedule(model, subject);
 
     // No random effects: the "integral" is a point mass and AGQ degenerates to the
     // conditional likelihood itself. (The formula below would agree — an empty tensor
     // product is the single empty node — but there is no Σ to factor, so short-circuit.)
     if d == 0 {
-        let nll = stack.nll_at(
-            model,
-            subject,
-            params,
-            b_hat,
-            &mut scratch,
-            schedule.as_ref(),
-        );
+        let nll = stack.nll_at(model, subject, params, b_hat, &mut scratch, schedule);
         return (nll, None);
     }
 
@@ -717,7 +719,7 @@ fn agq_subject_evaluate(
             stack,
             b_hat,
             &mut scratch,
-            schedule.as_ref(),
+            schedule,
         )
     } else {
         anchor_hessian(
@@ -728,7 +730,7 @@ fn agq_subject_evaluate(
             stack,
             b_hat,
             &mut scratch,
-            schedule.as_ref(),
+            schedule,
         )
         .map(|h| (h, None))
     };
@@ -756,7 +758,7 @@ fn agq_subject_evaluate(
         log_weights,
         &proposal,
         &mut scratch,
-        schedule.as_ref(),
+        schedule,
         retain_gradient_work,
     );
 
@@ -903,6 +905,7 @@ pub(crate) fn agq_subject_objective(
         &nodes,
         &log_weights,
         HessianAnchor::GaussNewton,
+        None,
     )
 }
 
@@ -993,6 +996,50 @@ pub fn agq_population_nll(
     n_nodes: usize,
     anchor: HessianAnchor,
 ) -> f64 {
+    agq_population_nll_impl(
+        model, population, params, eta_hats, kappas, n_nodes, anchor, None,
+    )
+}
+
+/// Same objective as [`agq_population_nll`], but with a caller-hoisted
+/// [`crate::estimation::inner_optimizer::build_schedule_cache`] so every subject's
+/// per-eval schedule rebuild is skipped in favor of the one built for the whole fit.
+/// Used only by the FOCEI/Laplace/AGQ outer hot loop (`outer_optimizer.rs`); every other
+/// caller goes through [`agq_population_nll`] and pays the per-call rebuild.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn agq_population_nll_with_schedules(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
+    n_nodes: usize,
+    anchor: HessianAnchor,
+    schedules: &[Option<pk::event_driven::EventSchedule>],
+) -> f64 {
+    agq_population_nll_impl(
+        model,
+        population,
+        params,
+        eta_hats,
+        kappas,
+        n_nodes,
+        anchor,
+        Some(schedules),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agq_population_nll_impl(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
+    n_nodes: usize,
+    anchor: HessianAnchor,
+    schedules: Option<&[Option<pk::event_driven::EventSchedule>]>,
+) -> f64 {
     let (nodes, weights) = cached_gauss_hermite(n_nodes);
     let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
     let per_subject: Vec<f64> = population
@@ -1003,6 +1050,7 @@ pub fn agq_population_nll(
             let subj_kappas = kappas.get(i).map(Vec::as_slice).unwrap_or(&[]);
             let stack = Stack::new(model, params, subj_kappas.len());
             let b_hat = stack_mode(eta_hats[i].as_slice(), subj_kappas);
+            let schedule = schedules.and_then(|s| s[i].as_ref());
             agq_subject_nll(
                 model,
                 subject,
@@ -1012,6 +1060,7 @@ pub fn agq_population_nll(
                 nodes,
                 &log_weights,
                 anchor,
+                schedule,
             )
         })
         .collect();
@@ -1035,6 +1084,61 @@ pub(crate) fn agq_population_evaluate(
     n_nodes: usize,
     anchor: HessianAnchor,
 ) -> PopulationEvaluation {
+    agq_population_evaluate_impl(
+        model, population, params, template, x, eta_hats, kappas, bounds, options, n_nodes, anchor,
+        None,
+    )
+}
+
+/// Same evaluation as [`agq_population_evaluate`], but with a caller-hoisted
+/// [`crate::estimation::inner_optimizer::build_schedule_cache`] — see
+/// [`agq_population_nll_with_schedules`]. Used only by the FOCEI/Laplace/AGQ outer hot loop.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn agq_population_evaluate_with_schedules(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
+    bounds: &crate::estimation::parameterization::PackedBounds,
+    options: &crate::types::FitOptions,
+    n_nodes: usize,
+    anchor: HessianAnchor,
+    schedules: &[Option<pk::event_driven::EventSchedule>],
+) -> PopulationEvaluation {
+    agq_population_evaluate_impl(
+        model,
+        population,
+        params,
+        template,
+        x,
+        eta_hats,
+        kappas,
+        bounds,
+        options,
+        n_nodes,
+        anchor,
+        Some(schedules),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn agq_population_evaluate_impl(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    template: &ModelParameters,
+    x: &[f64],
+    eta_hats: &[nalgebra::DVector<f64>],
+    kappas: &[Vec<nalgebra::DVector<f64>>],
+    bounds: &crate::estimation::parameterization::PackedBounds,
+    options: &crate::types::FitOptions,
+    n_nodes: usize,
+    anchor: HessianAnchor,
+    schedules: Option<&[Option<pk::event_driven::EventSchedule>]>,
+) -> PopulationEvaluation {
     let (nodes, weights) = gauss_hermite(n_nodes);
     let log_weights: Vec<f64> = weights.iter().map(|w| w.ln()).collect();
     let context = SubjectScoreContext::new(model, template, x, options, bounds, false);
@@ -1047,6 +1151,7 @@ pub(crate) fn agq_population_evaluate(
             let subj_kappas = kappas.get(i).map(Vec::as_slice).unwrap_or(&[]);
             let stack = Stack::new(model, params, subj_kappas.len());
             let b_hat = stack_mode(eta_hats[i].as_slice(), subj_kappas);
+            let schedule = schedules.and_then(|s| s[i].as_ref());
             let (nll, grid) = agq_subject_evaluate(
                 model,
                 subject,
@@ -1057,10 +1162,16 @@ pub(crate) fn agq_population_evaluate(
                 &log_weights,
                 anchor,
                 true,
+                schedule,
             );
             let prepared = grid.map(|grid| PreparedSubject::Grid { stack, b_hat, grid });
-            let score =
-                context.score_with_prepared(subject, eta_hats[i].as_slice(), subj_kappas, prepared);
+            let score = context.score_with_prepared(
+                subject,
+                eta_hats[i].as_slice(),
+                subj_kappas,
+                prepared,
+                schedule,
+            );
             (nll, score)
         })
         .collect();
@@ -2464,7 +2575,7 @@ impl<'a> SubjectScoreContext<'a> {
         eta: &[f64],
         kappas: &[nalgebra::DVector<f64>],
     ) -> Option<Vec<f64>> {
-        self.score_with_prepared(subject, eta, kappas, None)
+        self.score_with_prepared(subject, eta, kappas, None, None)
     }
 
     fn score_with_prepared(
@@ -2473,6 +2584,7 @@ impl<'a> SubjectScoreContext<'a> {
         eta: &[f64],
         kappas: &[nalgebra::DVector<f64>],
         prepared: Option<PreparedSubject>,
+        schedule: Option<&pk::event_driven::EventSchedule>,
     ) -> Option<Vec<f64>> {
         if crate::cancel::is_cancelled(&self.options.cancel) {
             return None;
@@ -2480,7 +2592,7 @@ impl<'a> SubjectScoreContext<'a> {
         if !self.force_fd {
             let mut g = vec![0.0; self.x.len()];
             let analytic = if let Some(prepared) = prepared {
-                self.prepared_score(subject, prepared, &mut g)
+                self.prepared_score(subject, prepared, schedule, &mut g)
             } else {
                 let stack = Stack::new(self.model, &self.params, kappas.len());
                 let b = stack_mode(eta, kappas);
@@ -2515,12 +2627,12 @@ impl<'a> SubjectScoreContext<'a> {
         &self,
         subject: &Subject,
         prepared: PreparedSubject,
+        schedule: Option<&pk::event_driven::EventSchedule>,
         out: &mut [f64],
     ) -> Option<()> {
         match prepared {
             PreparedSubject::Grid { stack, b_hat, grid } => {
                 let mut scratch = pk::EventPkParams::with_capacity_for(subject);
-                let schedule = cacheable_schedule(self.model, subject);
                 finish_agq_subject_gradient(
                     self.model,
                     subject,
@@ -2536,7 +2648,7 @@ impl<'a> SubjectScoreContext<'a> {
                     &grid.bs,
                     &grid.softmax,
                     &mut scratch,
-                    schedule.as_ref(),
+                    schedule,
                     grid.base_jet,
                     out,
                 )
@@ -2575,6 +2687,7 @@ impl<'a> SubjectScoreContext<'a> {
             &self.nodes,
             &self.log_weights,
             self.options.hessian_anchor(),
+            None,
         );
         (nll.is_finite() && nll < NLL_SENTINEL).then_some(nll)
     }
@@ -2633,6 +2746,7 @@ pub(crate) fn population_gradient_mixed(
                 subject,
                 eta_hats[i].as_slice(),
                 kappas.get(i).map(Vec::as_slice).unwrap_or(&[]),
+                None,
                 None,
             )
         })
@@ -2757,6 +2871,7 @@ mod tests {
             &nodes,
             &lw,
             HessianAnchor::GaussNewton,
+            None,
         );
         assert!(
             base.is_finite() && base < NLL_SENTINEL,
@@ -4083,6 +4198,7 @@ mod tests {
             &nodes,
             &log_weights,
             HessianAnchor::GaussNewton,
+            None,
         );
 
         let d = stack.d();
@@ -4147,5 +4263,129 @@ mod tests {
         // 21^50 overflows u64/usize many times over; must saturate, not wrap to something
         // small that would sneak past the MAX_AGQ_GRID check.
         assert_eq!(grid_size(21, 50), usize::MAX);
+    }
+
+    /// `agq_population_nll_with_schedules` / `agq_population_evaluate_with_schedules` must be
+    /// bit-identical to the uncached `agq_population_nll` / `agq_population_evaluate` they
+    /// wrap. Mixes a subject with an `EVID 3/4` reset (`cacheable_schedule` returns `Some`)
+    /// and one with neither a reset nor a time-varying covariate (`None`) in the same
+    /// population, since that mix is what would expose the cache's per-subject index ever
+    /// drifting out of alignment with `population.subjects`.
+    #[test]
+    fn cached_schedule_agq_population_matches_uncached() {
+        use crate::estimation::inner_optimizer::{build_schedule_cache, find_ebe};
+        use crate::estimation::parameterization::{compute_bounds, pack_params};
+        use crate::types::{DoseEvent, EstimationMethod, FitOptions, Population};
+
+        let model = parse_model_string(M3_MODEL).unwrap();
+        let template = &model.default_params;
+        let x = pack_params(template);
+        let params = crate::estimation::parameterization::unpack_params(&x, template);
+
+        let no_reset = score_subject(&model, &params.theta, &[0.5, 1.0, 2.0, 4.0, 8.0]);
+        assert!(!no_reset.has_resets());
+
+        let mut reset_subject = score_subject(&model, &params.theta, &[0.5, 1.0, 2.0, 4.0, 8.0]);
+        reset_subject
+            .doses
+            .push(DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0));
+        reset_subject.reset_times = vec![12.0];
+        let preds = crate::pk::compute_predictions_with_tv(
+            &model,
+            &reset_subject,
+            &params.theta,
+            &[0.12, -0.08, 0.2],
+        );
+        reset_subject.observations = preds.iter().map(|p| p * 0.85).collect();
+        assert!(reset_subject.has_resets());
+
+        let population = Population {
+            subjects: vec![no_reset, reset_subject],
+            covariate_names: Vec::new(),
+            dv_column: "DV".into(),
+            input_columns: Vec::new(),
+            exclusions: None,
+            warnings: Vec::new(),
+        };
+        let schedules = build_schedule_cache(&model, &population);
+        assert!(schedules[0].is_none());
+        assert!(schedules[1].is_some());
+
+        let eta_hats: Vec<_> = population
+            .subjects
+            .iter()
+            .map(|s| find_ebe(&model, s, &params, 200, 1e-11, None, None, 0).eta)
+            .collect();
+        let kappas = vec![Vec::new(); population.subjects.len()];
+        let bounds = compute_bounds(template);
+
+        for (method, anchor) in [
+            (EstimationMethod::FoceI, HessianAnchor::GaussNewton),
+            (EstimationMethod::Laplace, HessianAnchor::Exact),
+        ] {
+            let options = FitOptions {
+                method,
+                n_agq: 3,
+                ..FitOptions::default()
+            };
+            let uncached_nll =
+                agq_population_nll(&model, &population, &params, &eta_hats, &kappas, 3, anchor);
+            let cached_nll = agq_population_nll_with_schedules(
+                &model,
+                &population,
+                &params,
+                &eta_hats,
+                &kappas,
+                3,
+                anchor,
+                &schedules,
+            );
+            assert_eq!(
+                uncached_nll.to_bits(),
+                cached_nll.to_bits(),
+                "{anchor:?}: cached population NLL diverged from the uncached rebuild"
+            );
+
+            let uncached_eval = agq_population_evaluate(
+                &model,
+                &population,
+                &params,
+                template,
+                &x,
+                &eta_hats,
+                &kappas,
+                &bounds,
+                &options,
+                3,
+                anchor,
+            );
+            let cached_eval = agq_population_evaluate_with_schedules(
+                &model,
+                &population,
+                &params,
+                template,
+                &x,
+                &eta_hats,
+                &kappas,
+                &bounds,
+                &options,
+                3,
+                anchor,
+                &schedules,
+            );
+            assert_eq!(uncached_eval.nll.to_bits(), cached_eval.nll.to_bits());
+            let (uncached_grad, cached_grad) = (
+                uncached_eval.gradient.expect("uncached gradient"),
+                cached_eval.gradient.expect("cached gradient"),
+            );
+            assert_eq!(uncached_grad.len(), cached_grad.len());
+            for (i, (u, c)) in uncached_grad.iter().zip(&cached_grad).enumerate() {
+                assert_eq!(
+                    u.to_bits(),
+                    c.to_bits(),
+                    "{anchor:?} gradient coordinate {i}: uncached={u:e}, cached={c:e}"
+                );
+            }
+        }
     }
 }

--- a/src/estimation/focei_pipeline_tests.rs
+++ b/src/estimation/focei_pipeline_tests.rs
@@ -107,8 +107,15 @@ fn fused_inner_and_marginal_match_separate_passes() {
                                 interaction,
                             )
                         };
-                        let fused =
-                            run_inner_loop_and_nll(&model, &pop, params, &opts, warm, Some(&mu));
+                        let fused = run_inner_loop_and_nll(
+                            &model,
+                            &pop,
+                            params,
+                            &opts,
+                            warm,
+                            Some(&mu),
+                            None,
+                        );
                         assert_eq!(expected_nll.to_bits(), fused.4.to_bits());
                         for (a, b) in separate.0.iter().zip(&fused.0) {
                             assert_eq!(bits(a.as_slice()), bits(b.as_slice()));
@@ -158,7 +165,7 @@ fn fused_dispatch_keeps_laplace_and_agq_objectives() {
             &separate.3,
             &opts,
         );
-        let fused = run_inner_loop_and_nll(&model, &pop, params, &opts, None, None);
+        let fused = run_inner_loop_and_nll(&model, &pop, params, &opts, None, None, None);
         assert_eq!(expected.to_bits(), fused.4.to_bits());
     }
 }

--- a/src/estimation/inner_optimizer.rs
+++ b/src/estimation/inner_optimizer.rs
@@ -762,6 +762,72 @@ pub fn find_ebe(
     mu_k: Option<&[f64]>,
     restarts: usize,
 ) -> EbeResult {
+    let schedule = cacheable_schedule(model, subject);
+    find_ebe_impl(
+        model,
+        subject,
+        params,
+        max_iter,
+        tol,
+        eta_init,
+        mu_k,
+        restarts,
+        schedule.as_ref(),
+    )
+}
+
+/// Same as [`find_ebe`], but takes an already-resolved [`EventSchedule`](pk::event_driven::EventSchedule)
+/// instead of rebuilding one via [`cacheable_schedule`] on every call.
+///
+/// `cacheable_schedule`'s result depends only on `model` + `subject` — never on `params`/`eta`
+/// — so it is identical on every outer-loop evaluation of the same subject, not just across the
+/// BFGS steps of one `find_ebe` call. A caller that re-solves the same subject many times over a
+/// fit (the FOCEI/AGQ/Laplace outer hot loop) builds a `Vec<Option<EventSchedule>>` once via
+/// [`build_schedule_cache`] and passes each subject's entry here instead of paying the merged
+/// dose/event-timeline rebuild on every one of those calls.
+pub(crate) fn find_ebe_cached(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    max_iter: usize,
+    tol: f64,
+    eta_init: Option<&[f64]>,
+    mu_k: Option<&[f64]>,
+    restarts: usize,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> EbeResult {
+    find_ebe_impl(
+        model, subject, params, max_iter, tol, eta_init, mu_k, restarts, schedule,
+    )
+}
+
+/// Build the per-subject [`EventSchedule`](pk::event_driven::EventSchedule) cache once per
+/// fit, for reuse across every outer-loop evaluation via [`find_ebe_cached`]. Mirrors the
+/// once-per-population `schedules` cache `bayes.rs`'s chain loop already builds — the schedule
+/// is fit-invariant (see [`cacheable_schedule`]'s own doc for the staleness analysis), so
+/// building it once here instead of once per `find_ebe` call is always sound.
+pub(crate) fn build_schedule_cache(
+    model: &CompiledModel,
+    population: &Population,
+) -> Vec<Option<pk::event_driven::EventSchedule>> {
+    population
+        .subjects
+        .iter()
+        .map(|subject| cacheable_schedule(model, subject))
+        .collect()
+}
+
+fn find_ebe_impl(
+    model: &CompiledModel,
+    subject: &Subject,
+    params: &ModelParameters,
+    max_iter: usize,
+    tol: f64,
+    eta_init: Option<&[f64]>,
+    mu_k: Option<&[f64]>,
+    restarts: usize,
+    schedule: Option<&pk::event_driven::EventSchedule>,
+) -> EbeResult {
     let n_eta = model.n_eta;
 
     if inner_profile_enabled() {
@@ -854,9 +920,10 @@ pub fn find_ebe(
     //
     // Event parameter storage is allocated lazily by per-event prediction paths.
     // The schedule is built only when cacheable_schedule permits reuse; a static
-    // fast path needs neither event storage nor a merged schedule.
+    // fast path needs neither event storage nor a merged schedule. It is now a
+    // parameter (see `find_ebe_cached`/`build_schedule_cache`) rather than being
+    // rebuilt here on every call.
     let pk_scratch_cell = RefCell::new(pk::EventPkParams::default());
-    let schedule = cacheable_schedule(model, subject);
     // Custom / time-varying residual-magnitude (#484/#576): η-independent, so
     // computed once per subject here — not inside `agrad`, which BFGS calls on
     // every inner step (and every line-search trial) — instead of re-walking
@@ -903,7 +970,7 @@ pub fn find_ebe(
             // search at the declared correlation while the outer loop moved it.
             &params.residual_correlations,
             &mut scratch,
-            schedule.as_ref(),
+            schedule,
             err_keys.as_ref(),
             mult.as_deref(),
             &mut pred_recycle.borrow_mut(),
@@ -945,7 +1012,7 @@ pub fn find_ebe(
             // Live ρ (#847) — the same value `obj` above scores, so the BFGS
             // gradient and objective can never disagree about the residual R.
             &params.residual_correlations,
-            schedule.as_ref(),
+            schedule,
             mult.as_deref(),
             err_keys.as_ref(),
             &mut obs_grad_recycle.borrow_mut(),
@@ -1202,7 +1269,7 @@ pub fn find_ebe(
                 &params.theta,
                 &eta_true,
                 &mut scratch,
-                schedule.as_ref(),
+                schedule,
             );
             GRADIENT_TIMINGS.record_jac_fd(t0.elapsed().as_nanos() as u64);
             j
@@ -3514,6 +3581,43 @@ pub fn run_inner_loop_warm(
     (etas, h_matrices, stats, kappas)
 }
 
+/// Same as [`run_inner_loop_warm`], but reuses a [`build_schedule_cache`] built once per
+/// fit instead of paying a fresh [`cacheable_schedule`] rebuild for every subject on every
+/// outer-loop evaluation. See [`find_ebe_cached`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn run_inner_loop_warm_cached(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    max_iter: usize,
+    tol: f64,
+    prev_etas: Option<&[DVector<f64>]>,
+    mu_k: Option<&[f64]>,
+    min_obs: usize,
+    restarts: usize,
+    schedules: &[Option<pk::event_driven::EventSchedule>],
+) -> (
+    Vec<DVector<f64>>,
+    Vec<DMatrix<f64>>,
+    InnerLoopStats,
+    Vec<Vec<DVector<f64>>>,
+) {
+    let (etas, h_matrices, stats, kappas, _) = run_inner_loop_warm_map_cached(
+        model,
+        population,
+        params,
+        max_iter,
+        tol,
+        prev_etas,
+        mu_k,
+        min_obs,
+        restarts,
+        schedules,
+        |_, _| (),
+    );
+    (etas, h_matrices, stats, kappas)
+}
+
 /// Finish subject-local work on the same worker immediately after its EBE solve,
 /// before the population barrier. The FOCE outer loop uses this to score the
 /// marginal without launching another subject pass. Results retain subject order.
@@ -3536,6 +3640,79 @@ pub(crate) fn run_inner_loop_warm_map<T: Send>(
     Vec<Vec<DVector<f64>>>,
     Vec<T>,
 ) {
+    run_inner_loop_warm_map_impl(
+        model,
+        population,
+        params,
+        max_iter,
+        tol,
+        prev_etas,
+        mu_k,
+        min_obs,
+        restarts,
+        None,
+        finish_subject,
+    )
+}
+
+/// Same as [`run_inner_loop_warm_map`], but reuses a [`build_schedule_cache`] built once per
+/// fit instead of paying a fresh [`cacheable_schedule`] rebuild for every subject on every
+/// outer-loop evaluation. See [`find_ebe_cached`].
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+pub(crate) fn run_inner_loop_warm_map_cached<T: Send>(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    max_iter: usize,
+    tol: f64,
+    prev_etas: Option<&[DVector<f64>]>,
+    mu_k: Option<&[f64]>,
+    min_obs: usize,
+    restarts: usize,
+    schedules: &[Option<pk::event_driven::EventSchedule>],
+    finish_subject: impl Fn(&Subject, &EbeResult) -> T + Sync,
+) -> (
+    Vec<DVector<f64>>,
+    Vec<DMatrix<f64>>,
+    InnerLoopStats,
+    Vec<Vec<DVector<f64>>>,
+    Vec<T>,
+) {
+    run_inner_loop_warm_map_impl(
+        model,
+        population,
+        params,
+        max_iter,
+        tol,
+        prev_etas,
+        mu_k,
+        min_obs,
+        restarts,
+        Some(schedules),
+        finish_subject,
+    )
+}
+
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn run_inner_loop_warm_map_impl<T: Send>(
+    model: &CompiledModel,
+    population: &Population,
+    params: &ModelParameters,
+    max_iter: usize,
+    tol: f64,
+    prev_etas: Option<&[DVector<f64>]>,
+    mu_k: Option<&[f64]>,
+    min_obs: usize,
+    restarts: usize,
+    schedules: Option<&[Option<pk::event_driven::EventSchedule>]>,
+    finish_subject: impl Fn(&Subject, &EbeResult) -> T + Sync,
+) -> (
+    Vec<DVector<f64>>,
+    Vec<DMatrix<f64>>,
+    InnerLoopStats,
+    Vec<Vec<DVector<f64>>>,
+    Vec<T>,
+) {
     use rayon::prelude::*;
 
     let results: Vec<(EbeResult, T)> = population
@@ -3544,7 +3721,20 @@ pub(crate) fn run_inner_loop_warm_map<T: Send>(
         .enumerate()
         .map(|(i, subject)| {
             let init = prev_etas.map(|pe| pe[i].as_slice());
-            let ebe = find_ebe(model, subject, params, max_iter, tol, init, mu_k, restarts);
+            let ebe = match schedules {
+                Some(cache) => find_ebe_cached(
+                    model,
+                    subject,
+                    params,
+                    max_iter,
+                    tol,
+                    init,
+                    mu_k,
+                    restarts,
+                    cache[i].as_ref(),
+                ),
+                None => find_ebe(model, subject, params, max_iter, tol, init, mu_k, restarts),
+            };
             let extra = finish_subject(subject, &ebe);
             (ebe, extra)
         })

--- a/src/estimation/inner_optimizer_tests.rs
+++ b/src/estimation/inner_optimizer_tests.rs
@@ -1915,3 +1915,120 @@ fn fd_inner_ebe_runaway_on_floored_row_is_recovered() {
         );
     }
 }
+
+/// A subject with an `EVID 3/4` reset makes `cacheable_schedule` return `Some`; a plain
+/// subject with neither a reset nor a time-varying covariate makes it return `None` (see
+/// `cacheable_schedule`'s guard). `run_inner_loop_warm_cached` must produce results
+/// bit-identical to the uncached `run_inner_loop_warm` in both cases — including when
+/// `build_schedule_cache`'s per-subject `Some`/`None` entries are mixed in the same
+/// population, which is the scenario that would expose an index misalignment between the
+/// cache and `population.subjects`.
+#[test]
+fn cached_schedule_inner_loop_matches_uncached() {
+    let model = crate::parser::model_parser::parse_model_string(
+        "[parameters]\n  theta TVCL(0.2, 0.001, 10.0)\n  theta TVV(10.0, 0.1, 500.0)\n  omega ETA_CL ~ 0.09\n  omega ETA_V ~ 0.04\n  sigma PROP_ERR ~ 0.04\n[individual_parameters]\n  CL = TVCL * exp(ETA_CL)\n  V = TVV * exp(ETA_V)\n[structural_model]\n  pk one_cpt_iv(cl=CL, v=V)\n[error_model]\n  DV ~ proportional(PROP_ERR)\n",
+    )
+    .expect("parse one_cpt_iv model");
+    let params = &model.default_params;
+
+    let obs_times = vec![1.0, 4.0, 8.0, 24.0];
+    let n = obs_times.len();
+    let no_reset_subject = Subject {
+        id: "no-reset".into(),
+        doses: vec![DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0)],
+        obs_times: obs_times.clone(),
+        obs_raw_times: Vec::new(),
+        observations: vec![8.0, 5.0, 3.0, 1.0],
+        obs_cmts: vec![1; n],
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: Vec::new(),
+        reset_covariates: Vec::new(),
+        cens: vec![0; n],
+        occasions: vec![1; n],
+        obs_l2: Vec::new(),
+        dose_occasions: Vec::new(),
+        reset_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        obs_records: vec![],
+    };
+    let reset_subject = Subject {
+        id: "reset".into(),
+        doses: vec![
+            DoseEvent::new(0.0, 100.0, 1, 0.0, false, 0.0),
+            DoseEvent::new(12.0, 100.0, 1, 0.0, false, 0.0),
+        ],
+        obs_times: vec![1.0, 4.0, 8.0, 13.0, 16.0, 20.0],
+        obs_raw_times: Vec::new(),
+        observations: vec![8.0, 5.0, 3.0, 8.0, 5.0, 3.0],
+        obs_cmts: vec![1; 6],
+        covariates: HashMap::new(),
+        dose_covariates: Vec::new(),
+        obs_covariates: Vec::new(),
+        pk_only_times: Vec::new(),
+        pk_only_covariates: Vec::new(),
+        reset_times: vec![12.0],
+        reset_covariates: Vec::new(),
+        cens: vec![0; 6],
+        occasions: vec![1; 6],
+        obs_l2: Vec::new(),
+        dose_occasions: Vec::new(),
+        reset_occasions: Vec::new(),
+        fremtype: Vec::new(),
+        obs_records: vec![],
+    };
+    assert!(!no_reset_subject.has_resets());
+    assert!(reset_subject.has_resets());
+
+    let population = Population {
+        subjects: vec![
+            no_reset_subject.clone(),
+            reset_subject.clone(),
+            no_reset_subject,
+            reset_subject,
+        ],
+        covariate_names: Vec::new(),
+        dv_column: "DV".to_string(),
+        input_columns: vec![],
+        exclusions: None,
+        warnings: vec![],
+    };
+    let schedules = build_schedule_cache(&model, &population);
+    assert!(schedules[0].is_none());
+    assert!(schedules[1].is_some());
+    assert!(schedules[2].is_none());
+    assert!(schedules[3].is_some());
+
+    let uncached = run_inner_loop_warm(&model, &population, params, 50, 1e-8, None, None, 0, 0);
+    let cached = run_inner_loop_warm_cached(
+        &model,
+        &population,
+        params,
+        50,
+        1e-8,
+        None,
+        None,
+        0,
+        0,
+        &schedules,
+    );
+
+    for i in 0..population.subjects.len() {
+        assert_eq!(
+            uncached.0[i].as_slice(),
+            cached.0[i].as_slice(),
+            "subject {i}: η̂ diverged between the cached and uncached inner loop"
+        );
+        assert_eq!(
+            uncached.1[i].as_slice(),
+            cached.1[i].as_slice(),
+            "subject {i}: Jacobian diverged between the cached and uncached inner loop"
+        );
+    }
+    assert_eq!(uncached.2.n_unconverged, cached.2.n_unconverged);
+    assert_eq!(uncached.2.n_fallback, cached.2.n_fallback);
+    assert_eq!(uncached.2.n_start_rejected, cached.2.n_start_rejected);
+}

--- a/src/estimation/outer_optimizer.rs
+++ b/src/estimation/outer_optimizer.rs
@@ -842,6 +842,7 @@ fn run_inner_loop_and_nll(
     options: &FitOptions,
     prev_etas: Option<&[DVector<f64>]>,
     mu_k: Option<&[f64]>,
+    schedules: Option<&[Option<crate::pk::event_driven::EventSchedule>]>,
 ) -> (
     Vec<DVector<f64>>,
     Vec<DMatrix<f64>>,
@@ -849,11 +850,17 @@ fn run_inner_loop_and_nll(
     Vec<Vec<DVector<f64>>>,
     f64,
 ) {
-    let (etas, h_matrices, stats, kappas, nll, _) =
-        run_inner_loop_and_nll_prepared(model, population, params, options, prev_etas, mu_k, None);
+    let (etas, h_matrices, stats, kappas, nll, _) = run_inner_loop_and_nll_prepared(
+        model, population, params, options, prev_etas, mu_k, None, schedules,
+    );
     (etas, h_matrices, stats, kappas, nll)
 }
 
+/// Same dispatch as [`run_inner_loop_and_nll`], plus the AGQ gradient-fusion path,
+/// and an optional caller-hoisted schedule cache (see
+/// [`crate::estimation::inner_optimizer::build_schedule_cache`]). `optimize_nlopt_once` and
+/// `run_global_presearch` build the cache once per fit and pass it through here on every
+/// outer eval; `optimize_bfgs`'s legacy fallback passes `None` and pays the per-eval rebuild.
 #[allow(clippy::type_complexity)]
 fn run_inner_loop_and_nll_prepared(
     model: &CompiledModel,
@@ -863,6 +870,7 @@ fn run_inner_loop_and_nll_prepared(
     prev_etas: Option<&[DVector<f64>]>,
     mu_k: Option<&[f64]>,
     agq_gradient_inputs: Option<(&ModelParameters, &[f64], &PackedBounds)>,
+    schedules: Option<&[Option<crate::pk::event_driven::EventSchedule>]>,
 ) -> (
     Vec<DVector<f64>>,
     Vec<DMatrix<f64>>,
@@ -872,20 +880,34 @@ fn run_inner_loop_and_nll_prepared(
     Option<crate::estimation::agq::PopulationEvaluation>,
 ) {
     if options.agq_nodes().is_some() {
-        let (etas, h_matrices, stats, kappas) = run_inner_loop_warm(
-            model,
-            population,
-            params,
-            options.inner_maxiter,
-            options.inner_tol,
-            prev_etas,
-            mu_k,
-            options.min_obs_for_convergence_check as usize,
-            options.inner_restarts,
-        );
+        let (etas, h_matrices, stats, kappas) = match schedules {
+            Some(cache) => crate::estimation::inner_optimizer::run_inner_loop_warm_cached(
+                model,
+                population,
+                params,
+                options.inner_maxiter,
+                options.inner_tol,
+                prev_etas,
+                mu_k,
+                options.min_obs_for_convergence_check as usize,
+                options.inner_restarts,
+                cache,
+            ),
+            None => run_inner_loop_warm(
+                model,
+                population,
+                params,
+                options.inner_maxiter,
+                options.inner_tol,
+                prev_etas,
+                mu_k,
+                options.min_obs_for_convergence_check as usize,
+                options.inner_restarts,
+            ),
+        };
         let n_nodes = options.agq_nodes().expect("AGQ branch");
-        let evaluation = agq_gradient_inputs.map(|(template, x, bounds)| {
-            crate::estimation::agq::agq_population_evaluate(
+        let evaluation = agq_gradient_inputs.map(|(template, x, bounds)| match schedules {
+            Some(cache) => crate::estimation::agq::agq_population_evaluate_with_schedules(
                 model,
                 population,
                 params,
@@ -897,11 +919,25 @@ fn run_inner_loop_and_nll_prepared(
                 options,
                 n_nodes,
                 options.hessian_anchor(),
-            )
+                cache,
+            ),
+            None => crate::estimation::agq::agq_population_evaluate(
+                model,
+                population,
+                params,
+                template,
+                x,
+                &etas,
+                &kappas,
+                bounds,
+                options,
+                n_nodes,
+                options.hessian_anchor(),
+            ),
         });
         let nll = evaluation.as_ref().map_or_else(
-            || {
-                crate::estimation::agq::agq_population_nll(
+            || match schedules {
+                Some(cache) => crate::estimation::agq::agq_population_nll_with_schedules(
                     model,
                     population,
                     params,
@@ -909,23 +945,24 @@ fn run_inner_loop_and_nll_prepared(
                     &kappas,
                     n_nodes,
                     options.hessian_anchor(),
-                )
+                    cache,
+                ),
+                None => crate::estimation::agq::agq_population_nll(
+                    model,
+                    population,
+                    params,
+                    &etas,
+                    &kappas,
+                    n_nodes,
+                    options.hessian_anchor(),
+                ),
             },
             |evaluation| evaluation.nll,
         );
         return (etas, h_matrices, stats, kappas, nll, evaluation);
     }
-    let (etas, h_matrices, stats, kappas, contributions) = run_inner_loop_warm_map(
-        model,
-        population,
-        params,
-        options.inner_maxiter,
-        options.inner_tol,
-        prev_etas,
-        mu_k,
-        options.min_obs_for_convergence_check as usize,
-        options.inner_restarts,
-        |subject, ebe| {
+    let finish_subject =
+        |subject: &Subject, ebe: &crate::estimation::inner_optimizer::EbeResult| {
             subject_nll(
                 model,
                 subject,
@@ -935,8 +972,35 @@ fn run_inner_loop_and_nll_prepared(
                 &ebe.kappas,
                 options.interaction,
             )
-        },
-    );
+        };
+    let (etas, h_matrices, stats, kappas, contributions) = if let Some(cache) = schedules {
+        crate::estimation::inner_optimizer::run_inner_loop_warm_map_cached(
+            model,
+            population,
+            params,
+            options.inner_maxiter,
+            options.inner_tol,
+            prev_etas,
+            mu_k,
+            options.min_obs_for_convergence_check as usize,
+            options.inner_restarts,
+            cache,
+            finish_subject,
+        )
+    } else {
+        run_inner_loop_warm_map(
+            model,
+            population,
+            params,
+            options.inner_maxiter,
+            options.inner_tol,
+            prev_etas,
+            mu_k,
+            options.min_obs_for_convergence_check as usize,
+            options.inner_restarts,
+            finish_subject,
+        )
+    };
     let nll = contributions.iter().sum();
     (etas, h_matrices, stats, kappas, nll, None)
 }
@@ -1124,6 +1188,12 @@ fn run_global_presearch(
     let n_subj = population.subjects.len();
     let n_eta = model.n_eta;
 
+    // Built once for the whole pre-search: every probe below re-solves the same
+    // subjects' schedules, which depend only on `model` + `population` (never on the
+    // trial `params`) — see `run_inner_loop_and_nll_prepared`.
+    let schedule_cache =
+        crate::estimation::inner_optimizer::build_schedule_cache(model, population);
+
     // Probe CRS2-LM availability — some NLopt builds (notably the
     // minimal one in the homebrew nlopt-rs crate) ship without it.
     // Catch the panic so we surface a useful warning instead of
@@ -1173,6 +1243,7 @@ fn run_global_presearch(
             options,
             Some(&cached_zero),
             Some(&mu_k),
+            Some(&schedule_cache),
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
         let raw = 2.0 * nll + nn_reg.penalty_value(&params.theta) + priors.penalty(&x);
@@ -1210,6 +1281,7 @@ fn run_global_presearch(
             options,
             Some(&state.cached_etas),
             Some(&mu_k),
+            Some(&schedule_cache),
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
         let raw_ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta) + priors.penalty(&x);
@@ -1743,6 +1815,11 @@ fn optimize_nlopt_once(
     // optimizer minimises the penalized objective, everything user-facing keeps
     // the clean −2LL, and `FitResult` reports the two halves separately.
     let priors = build_prior_set(model, init_params);
+    // Built once for the whole outer optimization: every eval below re-solves the same
+    // subjects' schedules, which depend only on `model` + `population` (never on the
+    // trial `params`) — see `run_inner_loop_and_nll_prepared`.
+    let schedule_cache =
+        crate::estimation::inner_optimizer::build_schedule_cache(model, population);
 
     // Per-element scale factors: present O(1) coordinates to NLopt.
     //
@@ -2013,6 +2090,7 @@ fn optimize_nlopt_once(
                 Some(&state.cached_etas),
                 Some(&mu_k),
                 fuse_agq_gradient.then_some((init_params, x.as_slice(), &bounds)),
+                Some(&schedule_cache),
             );
             (ehs, hms, ebe_stats, kappas, 2.0 * nll, prepared)
         };
@@ -2750,6 +2828,7 @@ fn optimize_bfgs(
             options,
             Some(prev_etas),
             Some(&mu_k),
+            None,
         );
         // Penalized objective fed to the optimizer (unregularized fits unchanged).
         let ofv = 2.0 * nll + nn_reg.penalty_value(&params.theta) + priors.penalty(x);
@@ -2773,6 +2852,7 @@ fn optimize_bfgs(
             options,
             Some(prev_etas),
             Some(&mu_k),
+            None,
         );
         let ofv = 2.0 * nll;
         // d(OFV)/d(x) = 2 · Σᵢ d(NLL_i)/d(x).


### PR DESCRIPTION
## Why

#1345 (section E1) identified that `cacheable_schedule`-gated `EventSchedule` construction is
rebuilt from scratch on every AGQ node / gradient call within a single outer NLL evaluation,
even though the schedule depends only on the model and the subject's data — never on the
trial parameter vector. For FOCEI, Laplace, and `focei` with `n_agq > 1`, that means the same
subject's schedule is rebuilt many times per outer iteration.

## What changed

- `estimation/inner_optimizer.rs`: `find_ebe` now delegates to a new private `find_ebe_impl`
  that accepts an optional pre-built `EventSchedule`. A new `pub(crate) build_schedule_cache`
  maps `cacheable_schedule` once over every subject in a `Population`, and new
  `find_ebe_cached` / `run_inner_loop_warm_cached` / `run_inner_loop_warm_map_cached` reuse
  that cache instead of recomputing it.
- `estimation/agq.rs`: new `agq_population_nll_with_schedules` /
  `agq_population_evaluate_with_schedules` thread the same cache through the AGQ population
  loop.
- `estimation/outer_optimizer.rs`: `run_inner_loop_and_nll` / `run_inner_loop_and_nll_prepared`
  and `run_global_presearch` build the schedule cache once per outer-loop entry point and
  dispatch to the cached or uncached path depending on whether it's available.

Both the cached and uncached paths funnel into the same `find_ebe_impl` /
`run_inner_loop_warm_map_impl`, so correctness only depends on the cache's per-subject index
staying aligned with `population.subjects` — the risk two new regression tests target directly
(see Tests below). `cacheable_schedule`'s existing guard (time-varying covariates or `EVID=3/4`
resets; declines on lagtime, bioavailability-with-rate, algebraic, and compartment-free models)
is unchanged.

Two other findings from the same research pass are **not** in this PR:
- `omega_joint_inv`/`Stack` caching — evaluated and deprioritized (low expected value relative
  to implementation/review cost for this pass).
- `packed_fixed_mask` caching in `SubjectScoreContext::new` — already shipped in #1374 before
  this branch existed; nothing left to do here.

## Alternatives considered

Caching at the `Population` level (a `HashMap<subject id, EventSchedule>`) was considered and
rejected in favor of a plain `Vec<Option<EventSchedule>>` indexed by subject position, since
every caller already iterates subjects by index and a `Vec` avoids a hash lookup per subject
per AGQ node.

## Cross-repo dependency

Not needed — `pub(crate)` only, no `ferx-r` impact.

## Breaking changes

- [x] None

## Numerical validation

- [x] Compared against: prior ferx commit `caec0477` (branch base, verified bit-identical to
      `origin/main` at the time this branch was cut)
- [x] Reference values: bit-identical OFVs (`.to_bits()` equality) between the cached and
      uncached paths across FOCEI, Laplace, and `focei`+AGQ(n=3), verified both in the new
      unit tests and via the full `cargo test --lib` suite (4509 passed, 0 failed, 23 ignored —
      no regressions vs. the pre-PR baseline of 4507/0/23).

## Performance

- [x] Faster — benchmark: see the `CHANGELOG.md` entry under `### Performance`. Measured on
      `ci-fast`, single Rayon thread (`RAYON_NUM_THREADS=1`): no resolvable difference on the
      24-subject/2-occasion Schnider propofol fixture (schedule construction is a small share
      of per-eval cost there); a synthetic 40-subject/15-occasion-per-subject stress fixture
      (built specifically to amplify per-subject schedule-construction cost) showed a modest,
      directionally consistent ~3–6% wall-clock reduction across FOCEI, Laplace, and
      `focei`+AGQ(n=3). No claim is made beyond that stress scenario.

## Tests

- [x] Unit test(s) added in module (`cargo test --lib` passes)
- [x] Regression test added — fails without fix

Two new tests close a coverage gap: the existing `focei_pipeline_tests.rs` updates only ever
pass `None` for the new `schedules` parameter, so no prior test exercised the `Some(schedule)`
cached path.

- `estimation::inner_optimizer::tests::cached_schedule_inner_loop_matches_uncached` — mixes a
  subject with an `EVID 3/4` reset (`cacheable_schedule` → `Some`) and one with neither a reset
  nor a time-varying covariate (`None`) in the same population, and asserts
  `run_inner_loop_warm_cached` is bit-identical to `run_inner_loop_warm`.
- `estimation::agq::tests::cached_schedule_agq_population_matches_uncached` — same mixed-population
  construction, asserting `agq_population_nll_with_schedules` /
  `agq_population_evaluate_with_schedules` (NLL and gradient) are bit-identical to their
  uncached counterparts for both FOCEI and Laplace.

Both were specifically designed to catch a cache-index/`population.subjects` misalignment,
which a population where every subject takes the same `Some`/`None` branch could not expose.

## Example (user-facing features only)

- [x] Not applicable (internal / refactor / fix with no new API surface)

## Docs

- [x] `CHANGELOG.md` `[Unreleased]` entry added (under `### Performance`)
- [x] No user-visible change beyond the changelog entry (no new fit option, DSL syntax, or
      output field)

## Checklist

- [x] `tools/preflight.sh` green — fmt, all 5 `cargo check` feature sets, clippy
      (`--all-targets`, both invocations), rustdoc (both invocations), `docs-lint`
      (test + clippy), and the public-API baseline check all ran individually to completion
      with exit code 0 (run gate-by-gate rather than via the single `preflight.sh` invocation,
      due to heavy external memory contention on the build box from concurrent sessions —
      each gate's cargo invocation matches exactly what `tools/preflight.sh --list` prints).
- [x] No `sens/`/`pk/` `*_g<T: PkNum>` gradient-reachable code touched — the new functions
      wrap the existing inner-loop/AGQ dispatch, they don't change any analytic sensitivity.
- [x] `Cargo.toml` version not bumped (no breaking change).

## Docs & examples

- [x] Not applicable — no new DSL syntax, fit option, example file, or estimator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)